### PR TITLE
Make sbox robust and scantokens of its content

### DIFF
--- a/base/ltboxes.dtx
+++ b/base/ltboxes.dtx
@@ -481,10 +481,12 @@
 %         {Use \cs{color@setgroup}}
 % \changes{v1.0j}{1994/10/18}
 %         {\cs{long} added}
+% \changes{????}{2017/11/17}
+%         {Make robust, scantokens of second argument}
 % Save |#1| in a box register.
 %    \begin{macrocode}
-\long\def\sbox#1#2{\setbox#1\hbox{%
-  \color@setgroup#2\color@endgroup}}
+\DeclareRobustCommand\sbox[2]{\setbox#1\hbox{%
+  \color@setgroup\scantokens{#2}\color@endgroup}}
 %    \end{macrocode}
 % \end{macro}
 %


### PR DESCRIPTION
The `\sbox` macro is flawed in two ways.

1. It performs an assignment but is not protected.

2. It scans the box content as an argument which fixes catcodes and makes it impossible to box, e.g. tabular material.  Compare with this question on TeX.SX: [How can a matrix of nodes be saved into a box?](https://tex.stackexchange.com/questions/366709)

This PR attempts to fix this behaviour while maintaining backwards compatibility (i.e. every code which relied on the old, faulty implementation was probably not behaving correctly anyway).