### PR TITLE
ltoutput.dtx: missing latexrelease guard

### DIFF
--- a/base/ltoutput.dtx
+++ b/base/ltoutput.dtx
@@ -3303,7 +3303,7 @@
 %    \begin{macrocode}
 %<latexrelease|fltrace>\IncludeInRelease{2015/01/01}
 %<latexrelease|fltrace>  {\@addtonextcol}{float order in 2-column}%
-%<*2ekernel|fltrace>
+%<*2ekernel|latexrelease|fltrace>
 \def\@addtonextcol{%
   \begingroup
 %<*trace>
@@ -3387,7 +3387,7 @@
  \fl@trace{col: \the\@colnum. top: \the \@topnum. bot: \the \@botnum.}%
 %</trace>
 }%
-%</2ekernel|fltrace>
+%</2ekernel|latexrelease|fltrace>
 %<latexrelease|fltrace>\EndIncludeInRelease
 %<latexrelease|fltrace>\IncludeInRelease{0000/00/00}%
 %<latexrelease|fltrace>  {\@addtonextcol}{float order in 2-column}%


### PR DESCRIPTION
I found an empty `\@addtonextcol` block inside latexrelease.sty;

~~~~ tex
\IncludeInRelease{2015/01/01}
  {\@addtonextcol}{float order in 2-column}%
\EndIncludeInRelease
~~~~

If this block is unintended, my docstrip guard fix will add one.