### PR TITLE
normalise \IncludeInRelease to the nominal date

### DIFF
--- a/base/latexrelease.ins
+++ b/base/latexrelease.ins
@@ -87,22 +87,39 @@ extension .ins) which are part of the distribution.
   \from{latexrelease.dtx}{latexrelease}%
   \from{ltdirchk.dtx}    {latexrelease}%
   \from{ltdefns.dtx}     {latexrelease}%
+  \from{ltalloc.dtx}     {latexrelease}% empty
+  \from{ltcntrl.dtx}     {latexrelease}% empty
+  \from{lterror.dtx}     {latexrelease}% empty
+  \from{ltpar.dtx}       {latexrelease}% empty
+  \from{ltlists.dtx}     {latexrelease}% empty
   \from{ltboxes.dtx}     {latexrelease}%
+  \from{lttab.dtx}       {latexrelease}% empty
   \from{ltmath.dtx}      {latexrelease}%
   \from{ltpictur.dtx}    {latexrelease}%
+  \from{ltthm.dtx}       {latexrelease}% empty
+  \from{ltsect.dtx}      {latexrelease}% empty
   \from{ltfiles.dtx}     {latexrelease}%
   \from{ltoutenc.dtx}    {latexrelease}%
   \from{ltcounts.dtx}    {latexrelease}%
   \from{ltlength.dtx}    {latexrelease}%
   \from{ltfloat.dtx}     {latexrelease}%
+  \from{ltidxglo.dtx}    {latexrelease}% empty
+  \from{ltbibl.dtx}      {latexrelease}% empty
+  \from{ltpage.dtx}      {latexrelease}% empty
   \from{ltoutput.dtx}    {latexrelease}%
   \from{ltclass.dtx}     {latexrelease,tracerollback}%
   \from{ltspace.dtx}     {latexrelease}%
+  \from{ltlogos.dtx}     {latexrelease}% empty
   \from{ltplain.dtx}     {latexrelease}%
   \from{ltfssdcl.dtx}    {latexrelease}%
   \from{ltfssini.dtx}    {latexrelease}%
+  \from{ltfntcmd.dtx}    {latexrelease}% empty
   \from{ltfssbas.dtx}    {latexrelease}%
+  \from{ltfsstrc.dtx}    {latexrelease}% empty
   \from{ltfsscmp.dtx}    {latexrelease}%
+  \from{ltpageno.dtx}    {latexrelease}% empty
+  \from{ltxref.dtx}      {latexrelease}% empty
+  \from{ltmiscen.dtx}    {latexrelease}%
   \from{ltluatex.dtx}    {latexrelease}%
   \from{ltfinal.dtx}     {latexrelease}%
 }

--- a/base/ltfiles.dtx
+++ b/base/ltfiles.dtx
@@ -234,7 +234,7 @@
 % \changes{v0.9e}{1993/12/09}{Hook added}
 %    \begin{macrocode}
 %</2ekernel>
-%<latexrelease>\IncludeInRelease{2017/03/10}%
+%<latexrelease>\IncludeInRelease{2017/04/15}%
 %<latexrelease>  {\document}{Save language for hyphenation}%
 %<*2ekernel|latexrelease>
 %    \end{macrocode}

--- a/base/ltmiscen.dtx
+++ b/base/ltmiscen.dtx
@@ -685,6 +685,7 @@
 %<latexrelease>  \hyphenchar\font\m@ne
 %<latexrelease>  \everypar \expandafter{\the\everypar \unpenalty}%
 %<latexrelease>}
+%<latexrelease>\EndIncludeInRelease
 %<*2ekernel>
 %    \end{macrocode}
 %  \end{macro}
@@ -769,7 +770,6 @@
 %    \begin{macrocode}
 %</2ekernel>
 %<*2ekernel|latexrelease>
-%<latexrelease>\EndIncludeInRelease
 %<latexrelease>\IncludeInRelease{2017-04-15}{\verb}%
 %<latexrelease>                 {Disable hyphenation in verb}%
 \def\verb{\relax\ifmmode\hbox\else\leavevmode\null\fi
@@ -791,6 +791,7 @@
 %<latexrelease>    \verb@eol@error \let\do\@makeother \dospecials
 %<latexrelease>    \verbatim@font\@noligs
 %<latexrelease>    \@ifstar\@sverb\@verb}
+%<latexrelease>\EndIncludeInRelease
 %<*2ekernel>
 %    \end{macrocode}
 %  \end{macro}

--- a/base/ltoutput.dtx
+++ b/base/ltoutput.dtx
@@ -2038,7 +2038,7 @@
 %    internal commands as hooks.
 %    \begin{macrocode}
 %</2ekernel>
-%<latexrelease>\IncludeInRelease{2017/03/10}%
+%<latexrelease>\IncludeInRelease{2017/04/15}%
 %<latexrelease>  {\@outputpage}{Reset language for hyphenation}%
 %<*2ekernel|latexrelease>
 \def\@outputpage{%

--- a/base/ltpar.dtx
+++ b/base/ltpar.dtx
@@ -164,7 +164,6 @@
 %    itself to the primitive |\@@par| after one iteration.
 %    \begin{macrocode}
 \def\@par{\let\par\@@par\par}
-%</2ekernel>
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}
@@ -173,6 +172,7 @@
 %    Restore from a short-term change to |\par|.
 %    \begin{macrocode}
 \def\@restorepar{\def\par{\@par}}
+%</2ekernel>
 %    \end{macrocode}
 % \end{macro}
 %

--- a/base/ltplain.dtx
+++ b/base/ltplain.dtx
@@ -1459,7 +1459,7 @@
 % \changes{v2.0d}{2015/02/20}{Spell commands correctly :-)}
 % \changes{v2.0g}{2015/03/10}{Reorganise to be less noisy}
 %    \begin{macrocode}
-%<latexrelease>\IncludeInRelease{2015/01/20}{\loggingall}{etex tracing}%
+%<latexrelease>\IncludeInRelease{2015/01/01}{\loggingall}{etex tracing}%
 %<*2ekernel|latexrelease>
 \ifx\tracingscantokens\@undefined
 \gdef\loggingall{%
@@ -1511,7 +1511,7 @@
 % \begin{macro}{\hideoutput}
 % \changes{v2.0g}{2015/03/10}{macro added}
 %    \begin{macrocode}
-%<latexrelease>\IncludeInRelease{2015/01/20}{\tracingnone}%
+%<latexrelease>\IncludeInRelease{2015/01/01}{\tracingnone}%
 %<latexrelease>                             {turn off etex tracing}%
 %<*2ekernel|latexrelease>
 \ifx\tracingscantokens\@undefined


### PR DESCRIPTION
Based on David's comment on #25

> all new \includeRelease dates at a new ctan release should be normalised to the nominal date of that release.