### PR TITLE
Fix using UTF-8 sequences that start with "F4

### DIFF
--- a/base/utf8ienc.dtx
+++ b/base/utf8ienc.dtx
@@ -417,6 +417,7 @@
 %
 % Handle the single byte control characters.
 % \changes{v1.2a}{2018/03/24}{Loop over C0 controls added}%
+% \changes{v1.2e}{2018/08/05}{Fix "F4 lead byte}%
 % C0 controls are valid UTF-8 but defined to give the ``Character not defined error''
 % They may be defined with |\DeclareUnicodeCharacter|.
 %    \begin{macrocode}
@@ -465,7 +466,7 @@
 %    Setting up 4-byte UTF-8:
 %    \begin{macrocode}
     \count@"F0
-    \@tempcnta"F4
+    \@tempcnta"F5
     \def\UTFviii@tmp{\xdef~{\noexpand\UTFviii@four@octets\string~}}
 \UTFviii@loop
 %    \end{macrocode}
@@ -473,7 +474,7 @@
 % Bytes above F4 are not valid UTF-8 starting bytes as they would encode numbers beyond
 % the Unicode range
 %    \begin{macrocode}
-    \count@"F4
+    \count@"F5
     \@tempcnta"100
     \def\UTFviii@tmp{\xdef~{\noexpand\UTFviii@invalid@err\string~}}
 \UTFviii@loop
@@ -620,6 +621,7 @@
 %    |\parse@XML@charref| work without arguments.
 % \changes{v1.1g}{2005/09/27}{Real spaces do not show up so use \cs{space}}
 % \changes{v1.2a}{2018/03/24}{Allow control characters if active}
+% \changes{v1.2e}{2018/08/05}{Check upper bounds}%
 % In the case single byte UTF-8 sequences, only allw definition if
 % the character os already active.  The definition of |\UTFviii@tmp|
 % looks slightly strange but is designed for the sequence of |\expandafter|
@@ -649,14 +651,16 @@
      \parse@UTFviii@a;%
      \parse@UTFviii@a,%
      \parse@UTFviii@b E\UTFviii@three@octets.{,;}%
-   \else
+  \else\ifnum\count@<"110000\relax
      \parse@UTFviii@a;%
      \parse@UTFviii@a,%
      \parse@UTFviii@a!%
      \parse@UTFviii@b F\UTFviii@four@octets.{!,;}%
-    \fi
-    \fi
-  \fi
+  \else%
+     \PackageError{inputenc}%
+                  {\UTFviii@hexnumber\count@\space too large for Unicode}%
+                  {Values between 0 and 10FFFF are permitted}%
+  \fi\fi\fi\fi
 %  \endgroup
 }
 %    \end{macrocode}


### PR DESCRIPTION
There’s an off-by-one error in setting up \UTFviii@four@octets
for the codepoints. However, due to the too permissible nature
of the definition checks, \parse@XML@charref must additionally
be changed to reject too large values upon definition attempt.

Taken from https://github.com/mirabilos/tex-unicodedomino