### PR TITLE
cosmetic: show invalid byte in hex, not decimal

### DIFF
--- a/base/utf8ienc.dtx
+++ b/base/utf8ienc.dtx
@@ -323,9 +323,10 @@
 % \begin{macro}{\UTFviii@invalid@err}
 % \begin{macro}{\UTFviii@invalid@help}
 % \changes{v1.2a}{2018/03/24}{Macro added}%
+% \changes{v1.2e}{2018/08/05}{Show invalid byte in hex}%
 %    \begin{macrocode}
 \def\UTFviii@invalid@err#1{%
- \PackageError{inputenc}{Invalid UTF-8 byte \number`#1}%
+ \PackageError{inputenc}{Invalid UTF-8 byte "\UTFviii@hexbyte{`#1}}%
                         \UTFviii@invalid@help}
 %    \end{macrocode}
 %


### PR DESCRIPTION
Bytes and byte sequences are customarily given hexadecimal; this also eases debugging in most editors