### PR TITLE
cosmetics: format Unicode codepoints properly

### DIFF
--- a/base/testfiles/tlb-inputenc-001.tlg
+++ b/base/testfiles/tlb-inputenc-001.tlg
@@ -24,7 +24,7 @@ l. ...thorn U+00fe [^^c3^^be
 Your command was ignored.
 Type  I <command> <return>  to replace it with another command,
 or  <return>  to continue without it.
-! Package inputenc Error: Unicode character ^^cc^^81 (U+301)
+! Package inputenc Error: Unicode character ^^cc^^81 (U+0301)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -33,7 +33,7 @@ l. ...comb acute U+0301 [^^cc^^81
                                 ]
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^f0^^9d^^94^^84 (U+1D504)
+! Package inputenc Error: Unicode character ^^f0^^9d^^94^^84 (U-0001D504)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -43,4 +43,4 @@ l. ...fraktur A [^^f0^^9d^^94^^84
 You may provide a definition with
 \DeclareUnicodeCharacter 
 a\IeC {\nobreakspace }nbsp
-Fraktur A [\GenericError {(inputenc)                }{Package inputenc Error: Unicode character ^^f0^^9d^^94^^84 (U+1D504)\MessageBreak not set up for use with LaTeX}{See the inputenc package documentation for explanation.}{You may provide a definition with\MessageBreak \DeclareUnicodeCharacter }]
+Fraktur A [\GenericError {(inputenc)                }{Package inputenc Error: Unicode character ^^f0^^9d^^94^^84 (U-0001D504)\MessageBreak not set up for use with LaTeX}{See the inputenc package documentation for explanation.}{You may provide a definition with\MessageBreak \DeclareUnicodeCharacter }]

--- a/base/testfiles/tlb-utf8-c0.tlg
+++ b/base/testfiles/tlb-utf8-c0.tlg
@@ -16,7 +16,7 @@ l. ...\showthe\catcode4
 l. ...\showthe\catcode11
 > 13.
 l. ...\showthe\catcode150
-! Package inputenc Error: Unicode character ^^G (U+7)
+! Package inputenc Error: Unicode character ^^G (U+0007)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.

--- a/base/testfiles/tlb-utf8-undec-cp1252.tlg
+++ b/base/testfiles/tlb-utf8-undec-cp1252.tlg
@@ -1,6 +1,6 @@
 This is a generated file for the LaTeX2e validation system.
 Don't change this file in any respect.
-! Package inputenc Error: Unicode character ^^d6^^93 (U+593)
+! Package inputenc Error: Unicode character ^^d6^^93 (U+0593)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.

--- a/base/testfiles/tltx001.tlg
+++ b/base/testfiles/tltx001.tlg
@@ -1520,7 +1520,7 @@ Type  H <return>  for immediate help.
 l. ...\mbox{\verb=zyx=}
 Try typing  <return>  to proceed.
 If that doesn't work, type  X <return>  to quit.
-! Package inputenc Error: Unicode character ^^A (U+1)
+! Package inputenc Error: Unicode character ^^A (U+0001)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1529,7 +1529,7 @@ l. ...^^A
          ^^B^^C^^D^^E^^F^^G^^H^^I^^J^^K
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^B (U+2)
+! Package inputenc Error: Unicode character ^^B (U+0002)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1538,7 +1538,7 @@ l. ...^^A^^B
             ^^C^^D^^E^^F^^G^^H^^I^^J^^K
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^C (U+3)
+! Package inputenc Error: Unicode character ^^C (U+0003)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1547,7 +1547,7 @@ l. ...^^A^^B^^C
                ^^D^^E^^F^^G^^H^^I^^J^^K
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^D (U+4)
+! Package inputenc Error: Unicode character ^^D (U+0004)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1556,7 +1556,7 @@ l. ...^^A^^B^^C^^D
                   ^^E^^F^^G^^H^^I^^J^^K
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^E (U+5)
+! Package inputenc Error: Unicode character ^^E (U+0005)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1565,7 +1565,7 @@ l. ...^^A^^B^^C^^D^^E
                      ^^F^^G^^H^^I^^J^^K
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^F (U+6)
+! Package inputenc Error: Unicode character ^^F (U+0006)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1574,7 +1574,7 @@ l. ...^^A^^B^^C^^D^^E^^F
                         ^^G^^H^^I^^J^^K
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^G (U+7)
+! Package inputenc Error: Unicode character ^^G (U+0007)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1583,7 +1583,7 @@ l. ...^^A^^B^^C^^D^^E^^F^^G
                            ^^H^^I^^J^^K
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^H (U+8)
+! Package inputenc Error: Unicode character ^^H (U+0008)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1592,7 +1592,7 @@ l. ...^^A^^B^^C^^D^^E^^F^^G^^H
                               ^^I^^J^^K
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^K (U+B)
+! Package inputenc Error: Unicode character ^^K (U+000B)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1600,7 +1600,7 @@ Type  H <return>  for immediate help.
 l. ...^^A^^B^^C^^D^^E^^F^^G^^H^^I^^J^^K
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^N (U+E)
+! Package inputenc Error: Unicode character ^^N (U+000E)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1609,7 +1609,7 @@ l. ...^^N
          ^^O^^P^^Q^^R^^S^^T^^U^^V^^W^^X^^Y^^Z
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^O (U+F)
+! Package inputenc Error: Unicode character ^^O (U+000F)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1618,7 +1618,7 @@ l. ...^^N^^O
             ^^P^^Q^^R^^S^^T^^U^^V^^W^^X^^Y^^Z
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^P (U+10)
+! Package inputenc Error: Unicode character ^^P (U+0010)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1627,7 +1627,7 @@ l. ...^^N^^O^^P
                ^^Q^^R^^S^^T^^U^^V^^W^^X^^Y^^Z
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^Q (U+11)
+! Package inputenc Error: Unicode character ^^Q (U+0011)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1636,7 +1636,7 @@ l. ...^^N^^O^^P^^Q
                   ^^R^^S^^T^^U^^V^^W^^X^^Y^^Z
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^R (U+12)
+! Package inputenc Error: Unicode character ^^R (U+0012)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1645,7 +1645,7 @@ l. ...^^N^^O^^P^^Q^^R
                      ^^S^^T^^U^^V^^W^^X^^Y^^Z
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^S (U+13)
+! Package inputenc Error: Unicode character ^^S (U+0013)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1654,7 +1654,7 @@ l. ...^^N^^O^^P^^Q^^R^^S
                         ^^T^^U^^V^^W^^X^^Y^^Z
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^T (U+14)
+! Package inputenc Error: Unicode character ^^T (U+0014)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1663,7 +1663,7 @@ l. ...^^N^^O^^P^^Q^^R^^S^^T
                            ^^U^^V^^W^^X^^Y^^Z
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^U (U+15)
+! Package inputenc Error: Unicode character ^^U (U+0015)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1672,7 +1672,7 @@ l. ...^^N^^O^^P^^Q^^R^^S^^T^^U
                               ^^V^^W^^X^^Y^^Z
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^V (U+16)
+! Package inputenc Error: Unicode character ^^V (U+0016)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1681,7 +1681,7 @@ l. ...^^N^^O^^P^^Q^^R^^S^^T^^U^^V
                                  ^^W^^X^^Y^^Z
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^W (U+17)
+! Package inputenc Error: Unicode character ^^W (U+0017)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1690,7 +1690,7 @@ l. ...^^N^^O^^P^^Q^^R^^S^^T^^U^^V^^W
                                     ^^X^^Y^^Z
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^X (U+18)
+! Package inputenc Error: Unicode character ^^X (U+0018)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1699,7 +1699,7 @@ l. ...^^N^^O^^P^^Q^^R^^S^^T^^U^^V^^W^^X
                                        ^^Y^^Z
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^Y (U+19)
+! Package inputenc Error: Unicode character ^^Y (U+0019)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1708,7 +1708,7 @@ l. ...^^N^^O^^P^^Q^^R^^S^^T^^U^^V^^W^^X^^Y
                                           ^^Z
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^Z (U+1A)
+! Package inputenc Error: Unicode character ^^Z (U+001A)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1716,7 +1716,7 @@ Type  H <return>  for immediate help.
 l. ...^^N^^O^^P^^Q^^R^^S^^T^^U^^V^^W^^X^^Y^^Z
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^[ (U+1B)
+! Package inputenc Error: Unicode character ^^[ (U+001B)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1725,7 +1725,7 @@ l. ...^^[
          ^^\^^]^^^^^_
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^\ (U+1C)
+! Package inputenc Error: Unicode character ^^\ (U+001C)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1734,7 +1734,7 @@ l. ...^^[^^\
             ^^]^^^^^_
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^] (U+1D)
+! Package inputenc Error: Unicode character ^^] (U+001D)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1743,7 +1743,7 @@ l. ...^^[^^\^^]
                ^^^^^_
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^^ (U+1E)
+! Package inputenc Error: Unicode character ^^^ (U+001E)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
@@ -1752,7 +1752,7 @@ l. ...^^[^^\^^]^^^
                   ^^_
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Unicode character ^^_ (U+1F)
+! Package inputenc Error: Unicode character ^^_ (U+001F)
 (inputenc)                not set up for use with LaTeX.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.

--- a/base/utf8ienc.dtx
+++ b/base/utf8ienc.dtx
@@ -794,14 +794,10 @@
 % \begin{macro}{\UTFviii@splitcsname}
 % \changes{v1.1o}{2015/08/28}{Macro added}
 % \begin{macro}{\UTFviii@hexcodepoint}
-% \changes{v1.2e}{2018/08/05}{Format codepoint properly}
+% \changes{v1.2e}{2018/08/05}{Format codepoint properly; assume numexpr}
 %    Split a csname representing a unicode character and return
-%    the character and (if |\numexpr| is defined) the unicode number in hex.
+%    the character and the unicode number in hex.
 %    \begin{macrocode}
-\ifx\numexpr\@undefined
-\gdef\UTFviii@hexcodepoint#1{#1}%
-\gdef\UTFviii@splitcsname#1:#2\relax{#2}}
-\else
 \gdef\UTFviii@hexcodepoint#1{%
  \ifnum#1<16 U+000%
  \else\ifnum#1<256 U+00%
@@ -820,7 +816,6 @@
 #2 (\expandafter\UTFviii@hexcodepoint\expandafter{%
                      \the\numexpr\decode@UTFviii#2\relax})%
 }
-\fi
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}

--- a/base/utf8ienc.dtx
+++ b/base/utf8ienc.dtx
@@ -793,22 +793,36 @@
 %
 % \begin{macro}{\UTFviii@splitcsname}
 % \changes{v1.1o}{2015/08/28}{Macro added}
+% \begin{macro}{\UTFviii@hexcodepoint}
+% \changes{v1.2e}{2018/08/05}{Format codepoint properly}
 %    Split a csname representing a unicode character and return
 %    the character and (if |\numexpr| is defined) the unicode number in hex.
 %    \begin{macrocode}
 \ifx\numexpr\@undefined
+\gdef\UTFviii@hexcodepoint#1{#1}%
 \gdef\UTFviii@splitcsname#1:#2\relax{#2}}
 \else
+\gdef\UTFviii@hexcodepoint#1{%
+ \ifnum#1<16 U+000%
+ \else\ifnum#1<256 U+00%
+ \else\ifnum#1<4096 U+0%
+ \else\ifnum#1<65536 U+%
+ \else\ifnum#1<1048576 U-000%
+ \else U-00%
+ \fi\fi\fi\fi\fi%
+ \UTFviii@hexnumber{#1}%
+}%
 \gdef\UTFviii@splitcsname#1:#2\relax{%
 %    \end{macrocode}
 % \changes{v1.2b}{2018/03/26}{add percent as \cs{endlinechar} not -1 in the format}%
 % Need to pre-expand the argument to ensure cleanup in case of mal-formed UTF-8.
 %    \begin{macrocode}
-#2 (U+\expandafter\UTFviii@hexnumber\expandafter{%
+#2 (\expandafter\UTFviii@hexcodepoint\expandafter{%
                      \the\numexpr\decode@UTFviii#2\relax})%
 }
 \fi
 %    \end{macrocode}
+% \end{macro}
 % \end{macro}
 %
 %    \begin{macrocode}


### PR DESCRIPTION
Instead of just writing `U+` and the codepoint in hex, format them as `U+XXXX` for BMP codepoints and `U-XXXXXXXX` for astral planes.