### PR TITLE
ltclass.dtx: unique \IncludeInRelease identifier

### DIFF
--- a/base/ltclass.dtx
+++ b/base/ltclass.dtx
@@ -1050,7 +1050,7 @@
 %    \begin{macrocode}
 %</2ekernel>
 %<latexrelease>\IncludeInRelease{2017/01/01}%
-%<latexrelease>                 {\@if@pti@ns}{Spaces in \ExecuteOptions}%
+%<latexrelease>                 {\ExecuteOptions}{Spaces in \ExecuteOptions}%
 %<*2ekernel|latexrelease>
 \def\ExecuteOptions#1{%
 %    \end{macrocode}
@@ -1068,7 +1068,7 @@
 %</2ekernel|latexrelease>
 %<latexrelease>\EndIncludeInRelease
 %<latexrelease>\IncludeInRelease{0000/00/00}%
-%<latexrelease>                 {\@if@pti@ns}{Spaces in \ExecuteOptions}%
+%<latexrelease>                 {\ExecuteOptions}{Spaces in \ExecuteOptions}%
 %<latexrelease>\def\ExecuteOptions#1{%
 %<latexrelease>  \def\reserved@a##1\@nil{%
 %<latexrelease>    \@for\CurrentOption:=#1\do


### PR DESCRIPTION
```` tex
\RequirePackage[0000/00/00]{latexrelease}
\stop
````

Logically, the log for above MWE should *never* contain "Already applied:”, but currently

````
Already applied: [2017/01/01] Spaces in \ExecuteOptions  on input line 2167.
Already applied: [0000/00/00] Spaces in \ExecuteOptions  on input line 2177.
````

appears.

The second argument of \IncludeInRelease should be a unique identifier, but ltclass.dtx contains `\@if@pti@ns` twice. This PR changes the latter to `\ExecuteOptions`.