### PR TITLE
cosmetics: show invalid bytes in hex, not decimal

### DIFF
--- a/base/testfiles/tlb-utf8-undec-cp1252.tlg
+++ b/base/testfiles/tlb-utf8-undec-cp1252.tlg
@@ -9,7 +9,7 @@ l. ...a^^d6 ^^93
                x^^94 ^^df
 You may provide a definition with
 \DeclareUnicodeCharacter 
-! Package inputenc Error: Invalid UTF-8 byte 148.
+! Package inputenc Error: Invalid UTF-8 byte "94.
 See the inputenc package documentation for explanation.
 Type  H <return>  for immediate help.
  ...                                              

--- a/base/utf8ienc.dtx
+++ b/base/utf8ienc.dtx
@@ -323,9 +323,10 @@
 % \begin{macro}{\UTFviii@invalid@err}
 % \begin{macro}{\UTFviii@invalid@help}
 % \changes{v1.2a}{2018/03/24}{Macro added}%
+% \changes{v1.2f}{2018/08/05}{Show invalid byte in hex}%
 %    \begin{macrocode}
 \def\UTFviii@invalid@err#1{%
- \PackageError{inputenc}{Invalid UTF-8 byte \number`#1}%
+ \PackageError{inputenc}{Invalid UTF-8 byte "\UTFviii@hexbyte{`#1}}%
                         \UTFviii@invalid@help}
 %    \end{macrocode}
 %
@@ -803,6 +804,18 @@
 %
 %    \begin{macrocode}
 \fi
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\UTFviii@hexbyte}
+% \changes{v1.2f}{2018/08/05}{Macro added}%
+%    Display a two-digit hex number.
+%
+%    \begin{macrocode}
+\gdef\UTFviii@hexbyte#1{%
+ \ifnum#1<16 0\fi%
+ \UTFviii@hexnumber{#1}%
+}%
 %    \end{macrocode}
 % \end{macro}
 %


### PR DESCRIPTION
This was originally part of https://github.com/latex3/latex2e/pull/62 which was rejected (for now, and with reason), but independent of the rejected part, and so still should be merged.