### PR TITLE
Add luatexbase.new_luafunction()

### DIFF
--- a/base/ltluatex.dtx
+++ b/base/ltluatex.dtx
@@ -24,7 +24,7 @@
 \ProvidesFile{ltluatex.dtx}
 %</driver>
 %<*tex>
-[2018/08/18 v1.1h
+[2018/10/21 v1.1i
 %</tex>
 %<plain>  LuaTeX support for plain TeX (core)
 %<*tex>
@@ -199,6 +199,14 @@
 % |\directlua| and |\latelua|, indexed from~$1$.
 % The number is returned and also \meta{name} argument is added to the
 % |lua.name| array at that index.
+%
+% \noindent
+% \DescribeMacro{new_luafunction}
+% |luatexbase.new_luafunction(|\meta{functionname}|)|\\
+% Returns an allocation number for a lua function for use
+% with |\luafunction|, |\lateluafunction|, and |\luadef|,
+% indexed from~$1$. The optional \meta{functionname} argument
+% is just used for logging.
 %
 % These functions all require access to a named \TeX{} count register
 % to manage their allocations. The standard names are those defined
@@ -1181,6 +1189,29 @@ local function new_chunkname(name)
   return chunkname_count
 end
 luatexbase.new_chunkname = new_chunkname
+%    \end{macrocode}
+% \end{macro}
+%
+% \subsection{Lua function allocation}
+%
+% \begin{macro}{new_luafunction}
+% \changes{v1.1i}{2018/10/21}{Function added}
+% Much the same as for attribute allocation in Lua.
+% The optional \meta{name} argument is used in the log if given.
+%    \begin{macrocode}
+local luafunction_count_name =
+                         luafunction_count_name or "e@alloc@luafunction@count"
+local function new_luafunction(name)
+  tex_setcount("global", luafunction_count_name,
+                         tex_count[luafunction_count_name] + 1)
+  if tex_count[luafunction_count_name] > 65534 then
+    luatexbase_error("No room for a new luafunction register")
+  end
+  luatexbase_log("Lua function " .. (name or "") .. " = " ..
+                 tex_count[luafunction_count_name])
+  return tex_count[luafunction_count_name]
+end
+luatexbase.new_luafunction = new_luafunction
 %    \end{macrocode}
 % \end{macro}
 %


### PR DESCRIPTION
Is there any reason why `new_luafunction` does not exists?
Allocating Lua functions from Lua seems much more obvious than doing so from the TeX side.