### PR TITLE
utf8ienc.dtx: Declare ⟨ (U+27E8), ⟩ (U+27E9)

### DIFF
--- a/base/testfiles/sx237381.tlg
+++ b/base/testfiles/sx237381.tlg
@@ -77,6 +77,8 @@ File: ts1enc.dfu ....-..-.. v... UTF-8 support for inputenc
    defining Unicode char U+25E6 (decimal 9702)
    defining Unicode char U+25EF (decimal 9711)
    defining Unicode char U+266A (decimal 9834)
+   defining Unicode char U+27E8 (decimal 10216)
+   defining Unicode char U+27E9 (decimal 10217)
    defining Unicode char U+FEFF (decimal 65279)
 )) (t1enc.def
 File: t1enc.def ....-..-.. v... Standard LaTeX file

--- a/base/utf8ienc.dtx
+++ b/base/utf8ienc.dtx
@@ -1628,6 +1628,8 @@
 %<all,ts1>\DeclareUnicodeCharacter{25E6}{\textopenbullet}
 %<all,ts1>\DeclareUnicodeCharacter{25EF}{\textbigcircle}
 %<all,ts1>\DeclareUnicodeCharacter{266A}{\textmusicalnote}
+%<all,x2,ts1,t2c,t2b,t2a>\DeclareUnicodeCharacter{27E8}{\textlangle}
+%<all,x2,ts1,t2c,t2b,t2a>\DeclareUnicodeCharacter{27E9}{\textrangle}
 %<all,t1>\DeclareUnicodeCharacter{1E20}{\@tabacckludge=G}
 %<all,t1>\DeclareUnicodeCharacter{1E21}{\@tabacckludge=g}
 %    \end{macrocode}


### PR DESCRIPTION
Although ⟨ (U+27E8, `\textlangle`) and ⟩ (U+27E9, `\textrangle`) are 'mathematical angle brackets', Unicode recommends them for text use in place of U+2329 and U+232A. These characters are deprecated and canonically decompose to U+3008 and U+300B, in the CJK Symbols and Punctuation block. See <https://unicode.org/consortium/utc-minutes/UTC-088-200108.html>.