### PR TITLE
LuaTeX callback adjustments

### DIFF
--- a/base/ltluatex.dtx
+++ b/base/ltluatex.dtx
@@ -28,7 +28,7 @@
 \ProvidesFile{ltluatex.dtx}
 %</driver>
 %<*tex>
-[2019/10/22 v1.1j
+[2020/02/02 v1.1l
 %</tex>
 %<plain>  LuaTeX support for plain TeX (core)
 %<*tex>
@@ -1453,6 +1453,12 @@ local function data_handler(name)
   end
 end
 %    \end{macrocode}
+% Default for user-defined |data| callbacks without explicit default.
+%    \begin{macrocode}
+local function data_handler_default(value)
+  return value
+end
+%    \end{macrocode}
 % Handler for |exclusive| callbacks. We can assume |callbacklist[name]| is not
 % empty: otherwise, the function wouldn't be registered in the callback any
 % more.
@@ -1488,6 +1494,12 @@ local function list_handler(name)
   end
 end
 %    \end{macrocode}
+% Default for user-defined |list| callbacks without explicit default.
+%    \begin{macrocode}
+local function list_handler_default()
+  return true
+end
+%    \end{macrocode}
 % Handler for |simple| callbacks.
 %    \begin{macrocode}
 local function simple_handler(name)
@@ -1498,14 +1510,25 @@ local function simple_handler(name)
   end
 end
 %    \end{macrocode}
+% Default for user-defined |simple| callbacks without explicit default.
+%    \begin{macrocode}
+local function simple_handler_default()
+end
+%    \end{macrocode}
 %
-% Keep a handlers table for indexed access.
+% Keep a handlers table for indexed access and a table with the corresponding default functions.
 %    \begin{macrocode}
 local handlers = {
   [data]      = data_handler,
   [exclusive] = exclusive_handler,
   [list]      = list_handler,
   [simple]    = simple_handler,
+}
+local defaults = {
+  [data]      = data_handler_default,
+  [exclusive] = nil,
+  [list]      = list_handler_default,
+  [simple]    = simple_handler_default,
 }
 %    \end{macrocode}
 %
@@ -1523,11 +1546,13 @@ local user_callbacks_defaults = { }
 % \changes{v1.0a}{2015/09/24}{Function added}
 % \changes{v1.0i}{2015/11/29}{Check name is not nil in error message (PHG)}
 % \changes{v1.0k}{2015/12/02}{Give more specific error messages (PHG)}
+% \changes{v1.1l}{2020/02/02}{Provide proper fallbacks for user-defined callbacks without user-provided default handler}
 %   The allocator itself.
 %    \begin{macrocode}
 local function create_callback(name, ctype, default)
+  local ctype_id = types[ctype]
   if not name  or name  == ""
-  or not ctype or ctype == ""
+  or not ctype_id
   then
     luatexbase_error("Unable to create callback:\n" ..
                      "valid callback name and type required")
@@ -1536,12 +1561,17 @@ local function create_callback(name, ctype, default)
     luatexbase_error("Unable to create callback `" .. name ..
                      "':\ncallback is already defined")
   end
-  if default ~= false and type (default) ~= "function" then
+  default = default or defaults[ctype_id]
+  if not default then
     luatexbase_error("Unable to create callback `" .. name ..
-                     ":\ndefault is not a function")
-   end
+                     "':\ndefault is required for `" .. ctype ..
+                     "' callbacks")
+  elseif type (default) ~= "function" then
+    luatexbase_error("Unable to create callback `" .. name ..
+                     "':\ndefault is not a function")
+  end
   user_callbacks_defaults[name] = default
-  callbacktypes[name] = types[ctype]
+  callbacktypes[name] = ctype_id
 end
 luatexbase.create_callback = create_callback
 %    \end{macrocode}
@@ -1566,9 +1596,6 @@ local function call_callback(name,...)
   local f
   if not l then
     f = user_callbacks_defaults[name]
-    if l == false then
-	   return nil
-	 end
   else
     f = handlers[callbacktypes[name]](name)
   end

--- a/base/ltluatex.dtx
+++ b/base/ltluatex.dtx
@@ -1338,7 +1338,9 @@ local callbacktypes = callbacktypes or {
   ligaturing             = simple,
   kerning                = simple,
   insert_local_par       = simple,
+  pre_mlist_to_hlist_filter = list,
   mlist_to_hlist         = exclusive,
+  post_mlist_to_hlist_filter = reverselist,
   new_graf               = simple,
 %    \end{macrocode}
 % Section 8.5: information reporting callbacks.
@@ -1575,7 +1577,11 @@ local defaults = {
 % If a default function is not required, it may be declared as |false|.
 % First we need a list of user callbacks.
 %    \begin{macrocode}
-local user_callbacks_defaults = { }
+local user_callbacks_defaults = {
+  pre_mlist_to_hlist_filter = list_handler_default,
+  mlist_to_hlist = node.mlist_to_hlist,
+  post_mlist_to_hlist_filter = list_handler_default,
+}
 %    \end{macrocode}
 %
 % \begin{macro}{create_callback}
@@ -1842,6 +1848,31 @@ local function uninstall()
   luatexbase = nil
 end
 luatexbase.uninstall = uninstall
+%    \end{macrocode}
+% \end{macro}
+% \begin{macro}{mlist_to_hlist}
+% \changes{v1.1l}{2020/02/02}{|pre/post_mlist_to_hlist| added}
+%   To emulate these callbacks, the ``real'' |mlist_to_hlist| is replaced by a
+%   wrapper calling the wrappers before and after.
+%    \begin{macrocode}
+callback_register("mlist_to_hlist", function(head, display_type, need_penalties)
+  local current = call_callback("pre_mlist_to_hlist_filter", head, display_type, need_penalties)
+  if current == false then
+    flush_list(head)
+    return nil
+  elseif current == true then
+    current = head
+  end
+  current = call_callback("mlist_to_hlist", current, display_type, need_penalties)
+  local post = call_callback("post_mlist_to_hlist_filter", current, display_type, need_penalties)
+  if post == true then
+    return current
+  elseif post == false then
+    flush_list(current)
+    return nil
+  end
+  return post
+end)
 %    \end{macrocode}
 % \end{macro}
 % \endgroup

--- a/base/ltluatex.dtx
+++ b/base/ltluatex.dtx
@@ -1239,12 +1239,13 @@ local callbacklist = callbacklist or { }
 % Numerical codes for callback types, and name-to-value association (the
 % table keys are strings, the values are numbers).
 %    \begin{macrocode}
-local list, data, exclusive, simple = 1, 2, 3, 4
-local types = {
-  list      = list,
-  data      = data,
-  exclusive = exclusive,
-  simple    = simple,
+local list, data, exclusive, simple, reverselist = 1, 2, 3, 4, 5
+local types   = {
+  list        = list,
+  data        = data,
+  exclusive   = exclusive,
+  simple      = simple,
+  reverselist = reverselist,
 }
 %    \end{macrocode}
 %
@@ -1441,6 +1442,8 @@ end
 %     |true|, then the same head is passed to the next function. If all
 %     functions return |true|, then |true| is returned, otherwise the return
 %     value of the last function not returning |true| is used.
+%   \item[reverselist] is a specialized variant of \emph{list} which executes
+%     functions in inverse order.
 %   \item[exclusive] is for functions with more complex signatures; functions in
 %     this type of callback are \emph{not} combined: An error is raised if
 %     a second callback is registered..
@@ -1498,10 +1501,37 @@ local function list_handler(name)
   end
 end
 %    \end{macrocode}
-% Default for user-defined |list| callbacks without explicit default.
+% Default for user-defined |list| and |reverselist| callbacks without explicit default.
 %    \begin{macrocode}
 local function list_handler_default()
   return true
+end
+%    \end{macrocode}
+% Handler for |reverselist| callbacks.
+% \changes{v1.1l}{2020/02/02}{Add reverselist callback type}
+%    \begin{macrocode}
+local function reverselist_handler(name)
+  return function(head, ...)
+    local ret
+    local alltrue = true
+    local callbacks = callbacklist[name]
+    for i = #callbacks, 1, -1 do
+      local cb = callbacks[i]
+      ret = cb.func(head, ...)
+      if ret == false then
+        luatexbase_warning(
+          "Function `" .. cb.description .. "' returned false\n"
+            .. "in callback `" .. name .."'"
+         )
+         break
+      end
+      if ret ~= true then
+        alltrue = false
+        head = ret
+      end
+    end
+    return alltrue and true or head
+  end
 end
 %    \end{macrocode}
 % Handler for |simple| callbacks.
@@ -1522,17 +1552,19 @@ end
 %
 % Keep a handlers table for indexed access and a table with the corresponding default functions.
 %    \begin{macrocode}
-local handlers = {
-  [data]      = data_handler,
-  [exclusive] = exclusive_handler,
-  [list]      = list_handler,
-  [simple]    = simple_handler,
+local handlers  = {
+  [data]        = data_handler,
+  [exclusive]   = exclusive_handler,
+  [list]        = list_handler,
+  [reverselist] = reverselist_handler,
+  [simple]      = simple_handler,
 }
 local defaults = {
-  [data]      = data_handler_default,
-  [exclusive] = nil,
-  [list]      = list_handler_default,
-  [simple]    = simple_handler_default,
+  [data]        = data_handler_default,
+  [exclusive]   = nil,
+  [list]        = list_handler_default,
+  [reverselist] = list_handler_default,
+  [simple]      = simple_handler_default,
 }
 %    \end{macrocode}
 %

--- a/base/ltluatex.dtx
+++ b/base/ltluatex.dtx
@@ -1366,10 +1366,12 @@ local callbacktypes = callbacktypes or {
 % \changes{v1.1j}{2019/06/18}{page\_objnum\_provider added}
 % \changes{v1.1j}{2019/06/18}{process\_pdf\_image\_content added}
 % \changes{v1.1j}{2019/10/22}{page\_objnum\_provider and process\_pdf\_image\_content classified data}
+% \changes{v1.1l}{2020/02/02}{page\_order\_index added}
 %    \begin{macrocode}
   finish_pdffile            = data,
   finish_pdfpage            = data,
   page_objnum_provider      = data,
+  page_order_index          = data,
   process_pdf_image_content = data,
 %    \end{macrocode}
 % Section 8.7: font-related callbacks.
@@ -1377,9 +1379,11 @@ local callbacktypes = callbacktypes or {
 % \changes{v1.1g}{2018/05/02}{glyph\_not\_found added}
 % \changes{v1.1j}{2019/06/18}{make\_extensible added}
 % \changes{v1.1j}{2019/06/18}{font\_descriptor\_objnum\_provider added}
+% \changes{v1.1l}{2020/02/02}{glyph\_info added}
 %    \begin{macrocode}
   define_font                     = exclusive,
-  glyph_not_found                 = exclusive, 
+  glyph_info                      = exclusive,
+  glyph_not_found                 = exclusive,
   glyph_stream_provider           = exclusive,
   make_extensible                 = exclusive,
   font_descriptor_objnum_provider = exclusive,

--- a/base/ltluatex.dtx
+++ b/base/ltluatex.dtx
@@ -1320,6 +1320,7 @@ local callbacktypes = callbacktypes or {
 % \changes{v1.1k}{2019/10/02}{linebreak\_filter is \texttt{exclusive}}
 % \changes{v1.1k}{2019/10/02}{process\_rule is \texttt{exclusive}}
 % \changes{v1.1k}{2019/10/02}{mlist\_to\_hlist is \texttt{exclusive}}
+% \changes{v1.1l}{2020/02/02}{post\_linebreak\_filter is \texttt{reverselist}}
 %    \begin{macrocode}
   contribute_filter      = simple,
   buildpage_filter       = simple,
@@ -1327,7 +1328,7 @@ local callbacktypes = callbacktypes or {
   pre_linebreak_filter   = list,
   linebreak_filter       = exclusive,
   append_to_vlist_filter = exclusive,
-  post_linebreak_filter  = list,
+  post_linebreak_filter  = reverselist,
   hpack_filter           = list,
   vpack_filter           = list,
   hpack_quality          = list,

--- a/base/testfiles/tlb-callbacks-001.luatex.tlg
+++ b/base/testfiles/tlb-callbacks-001.luatex.tlg
@@ -1,3 +1,5 @@
 This is a generated file for the LaTeX2e validation system.
 Don't change this file in any respect.
  LuaTeX Callback test
++ page_order_index
++ glyph_info

--- a/base/testfiles/tlb-callbacks-001.luatex.tlg
+++ b/base/testfiles/tlb-callbacks-001.luatex.tlg
@@ -1,5 +1,5 @@
 This is a generated file for the LaTeX2e validation system.
 Don't change this file in any respect.
  LuaTeX Callback test
-+ page_order_index
 + glyph_info
++ page_order_index

--- a/base/testfiles/tlb-callbacks-001.lvt
+++ b/base/testfiles/tlb-callbacks-001.lvt
@@ -20,16 +20,23 @@
  expected_user_callbacks['luaotfload.resolve_font']=1
  expected_user_callbacks['luaotfload.patch_font']=1
 %
+  local missing = {}
   for i,_ in pairs(callback.list()) do
     if  i \string~= 'char_exists' and luatexbase.callbacktypes[i] == nil then
-      texio.write_nl("- " .. i)
+      missing[\csstring\#missing + 1] = "- " .. i
+      missing[\csstring\#missing + 1] = "- " .. i
     end
   end
+  table.sort(missing)
+  texio.write_nl(table.concat(missing, '\string\n'))
+  local additional = {}
   for i,_ in pairs(luatexbase.callbacktypes) do
     if callback.list()[i] == nil and expected_user_callbacks[i] ==nil then
-      texio.write_nl("+ " .. i)
+      additional[\csstring\#additional + 1] = "+ " .. i
     end
   end
+  table.sort(additional)
+  texio.write_nl(table.concat(additional, '\string\n'))
 }
 
 \END

--- a/base/testfiles/tlb-callbacks-001.lvt
+++ b/base/testfiles/tlb-callbacks-001.lvt
@@ -12,6 +12,9 @@
 %
  local expected_user_callbacks={}
 %
+% current ltluatex user-callbacks
+ expected_user_callbacks['pre_mlist_to_hlist_filter']=1
+ expected_user_callbacks['post_mlist_to_hlist_filter']=1
 % curent luaotfload user-callbacks
  expected_user_callbacks['luaotfload.patch_font_unsafe']=1
  expected_user_callbacks['luaotfload.resolve_font']=1

--- a/base/testfiles/tlb-callbacks-001.tlg
+++ b/base/testfiles/tlb-callbacks-001.tlg
@@ -1,3 +1,5 @@
 This is a generated file for the LaTeX2e validation system.
 Don't change this file in any respect.
- LuaTeX Callback test
+LuaTeX Callback test
++ glyph_info
++ page_order_index

--- a/base/testfiles/tlb-ltluatex-001.luatex.tlg
+++ b/base/testfiles/tlb-ltluatex-001.luatex.tlg
@@ -7,7 +7,7 @@ stack traceback:
 ^^I[C]: in function 'error'
 ^^I./ltluatex.lua:109: in upvalue 'module_error'
 ^^I./ltluatex.lua:116: in upvalue 'luatexbase_error'
-^^I./ltluatex.lua:423: in field 'create_callback'
+^^I./ltluatex.lua:429: in field 'create_callback'
 ^^I[\directlua]:1: in main chunk.
 l. ...}
 The lua interpreter ran into a problem, so the

--- a/base/testfiles/tlb-ltluatex-001.luatex.tlg
+++ b/base/testfiles/tlb-ltluatex-001.luatex.tlg
@@ -7,7 +7,7 @@ stack traceback:
 ^^I[C]: in function 'error'
 ^^I./ltluatex.lua:109: in upvalue 'module_error'
 ^^I./ltluatex.lua:116: in upvalue 'luatexbase_error'
-^^I./ltluatex.lua:380: in field 'create_callback'
+^^I./ltluatex.lua:395: in field 'create_callback'
 ^^I[\directlua]:1: in main chunk.
 l. ...}
 The lua interpreter ran into a problem, so the

--- a/base/testfiles/tlb-ltluatex-001.luatex.tlg
+++ b/base/testfiles/tlb-ltluatex-001.luatex.tlg
@@ -7,7 +7,7 @@ stack traceback:
 ^^I[C]: in function 'error'
 ^^I./ltluatex.lua:109: in upvalue 'module_error'
 ^^I./ltluatex.lua:116: in upvalue 'luatexbase_error'
-^^I./ltluatex.lua:395: in field 'create_callback'
+^^I./ltluatex.lua:397: in field 'create_callback'
 ^^I[\directlua]:1: in main chunk.
 l. ...}
 The lua interpreter ran into a problem, so the

--- a/base/testfiles/tlb-ltluatex-001.luatex.tlg
+++ b/base/testfiles/tlb-ltluatex-001.luatex.tlg
@@ -7,7 +7,7 @@ stack traceback:
 ^^I[C]: in function 'error'
 ^^I./ltluatex.lua:109: in upvalue 'module_error'
 ^^I./ltluatex.lua:116: in upvalue 'luatexbase_error'
-^^I./ltluatex.lua:397: in field 'create_callback'
+^^I./ltluatex.lua:423: in field 'create_callback'
 ^^I[\directlua]:1: in main chunk.
 l. ...}
 The lua interpreter ran into a problem, so the


### PR DESCRIPTION
Implementing the IMO must urgent changes with LuaTeX callbacks. Especially this does not allow user-defined callback types yet because they would need some restructuring and more time for testing.

- Provide useful defaults if no default is provided for user-defined callbacks. This will not change any existing code because not providing a default handler here was broken already.
- Add a `reverselist` type, similar to `list` but calling  everything in reverse. I made a separate commit for actually using `reverselist` for `post_linebreak_filter` such that we can decide to merge that separatly because it is much more likely to lead to problems with existing code than the other changes.
- Add `pre/post_list_to_list_filter`. They are basically implemented using user-defined callbacks and the implementation also changes `mlist_to_hlist` to be effectively a "user-defined callback" (the "real" callback is fixed to combine all three callbacks) This mostly means that these could be called using `call_callback`, but especially for `mlist_to_hlist` this might even be useful.
There might be a small performance regression because we always set a `mlist_to_hlist` callback, but that doesn't seem to be significant.