### PR TITLE
Don't call callback.register(..., nil) for user-defined callbacks

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -4,6 +4,11 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 =======================================================================
 
+2020-03-07  Marcel Krüger    <Marcel.Krueger@latex-project.org>
+
+  * ltluatex.dtx: Fix remove_from_callback for mlist_to_hlist
+  and other engine callbacks hidden by user-defined ones
+
 #########################
 # 2020-02-02 PL 1 Release
 #########################

--- a/base/ltluatex.dtx
+++ b/base/ltluatex.dtx
@@ -28,7 +28,7 @@
 \ProvidesFile{ltluatex.dtx}
 %</driver>
 %<*tex>
-[2020/02/02 v1.1l
+[2020/03/07 v1.1m
 %</tex>
 %<plain>  LuaTeX support for plain TeX (core)
 %<*tex>
@@ -1716,6 +1716,7 @@ luatexbase.add_to_callback = add_to_callback
 % \changes{v1.0a}{2015/09/24}{Function added}
 % \changes{v1.0k}{2015/12/02}{adjust initialisation of cb local (PHG)}
 % \changes{v1.0k}{2015/12/02}{Give more specific error messages (PHG)}
+% \changes{v1.1m}{2020/03/07}{Do not call callback.register for user-defined callbacks}
 %   Remove a function from a callback. First check arguments.
 %    \begin{macrocode}
 local function remove_from_callback(name, description)

--- a/base/ltluatex.dtx
+++ b/base/ltluatex.dtx
@@ -1761,7 +1761,9 @@ local function remove_from_callback(name, description)
   )
   if #l == 0 then
     callbacklist[name] = nil
-    callback_register(name, nil)
+    if user_callbacks_defaults[name] == nil then
+      callback_register(name, nil)
+    end
   end
   return cb.func,cb.description
 end

--- a/base/testfiles/tlb-mathcallbacks.luatex.tlg
+++ b/base/testfiles/tlb-mathcallbacks.luatex.tlg
@@ -1,0 +1,13 @@
+This is a generated file for the LaTeX2e validation system.
+Don't change this file in any respect.
+Inserting `test' at position 1 in `pre_mlist_to_hlist_filter'.
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <7> on input line ....
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <5> on input line ....
+pre_mlist_to_hlist_filter called
+Inserting `test' at position 1 in `mlist_to_hlist'.
+pre_mlist_to_hlist_filter called
+mlist_to_hlist called
+Removing  `test' from `mlist_to_hlist'.
+Inserting `test' at position 1 in `mlist_to_hlist'.

--- a/base/testfiles/tlb-mathcallbacks.luatex.tlg
+++ b/base/testfiles/tlb-mathcallbacks.luatex.tlg
@@ -10,4 +10,7 @@ Inserting `test' at position 1 in `mlist_to_hlist'.
 pre_mlist_to_hlist_filter called
 mlist_to_hlist called
 Removing  `test' from `mlist_to_hlist'.
+pre_mlist_to_hlist_filter called
 Inserting `test' at position 1 in `mlist_to_hlist'.
+pre_mlist_to_hlist_filter called
+new mlist_to_hlist called

--- a/base/testfiles/tlb-mathcallbacks.lvt
+++ b/base/testfiles/tlb-mathcallbacks.lvt
@@ -1,0 +1,31 @@
+\input{test2e}
+\begin{document}
+\START
+\ifx\directlua\undefined\END\expandafter\stop\fi
+\directlua{
+  luatexbase.add_to_callback('pre_mlist_to_hlist_filter', function(mlist)
+    texio.write_nl'pre_mlist_to_hlist_filter called'
+    return mlist
+  end, 'test')
+}
+\[ 1 \]
+\directlua{
+  luatexbase.add_to_callback('mlist_to_hlist', function(...)
+    texio.write_nl'mlist_to_hlist called'
+    return node.mlist_to_hlist(...)
+  end, 'test')
+}%
+\[ 1 \]%
+\directlua{
+  luatexbase.remove_from_callback('mlist_to_hlist', 'test')
+}
+\[ 1 \]
+\directlua{
+  luatexbase.add_to_callback('mlist_to_hlist', function(...)
+    texio.write_nl'new mlist_to_hlist called'
+    return node.mlist_to_hlist(...)
+  end, 'test')
+}%
+\[ 1 \]
+\END
+\end{document}

--- a/base/testfiles/tlb-mathcallbacks.tlg
+++ b/base/testfiles/tlb-mathcallbacks.tlg
@@ -1,0 +1,2 @@
+This is a generated file for the LaTeX2e validation system.
+Don't change this file in any respect.


### PR DESCRIPTION
Fixes #302 and therefore fixes `remove_from_callback` for `mlist_to_hlist`.

# Internal housekeeping

## Status of pull request

- (Hopefully) Ready to merge

## Checklist of required changes before merge will be approved
- [X] Test file(s) added
- [X] Version and date string updated in changed source files
- [X] Relevant `\changes` entries in source included
- [X] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` updated
  The change isn't really "newsworthy" in my opinion: It's a bugfix which only affects a quite rare case.
