### PR TITLE
Make U+00AD active for Unicode engines

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -11,6 +11,11 @@ are not part of the distribution.
 	* ltxref.dtx:
 	added \@currentcounter to \refstepcounter (gh/300)
 
+2020-05-06  Marcel Krüger    <Marcel.Krueger@latex-project.org>
+
+  * ltspace.dtx:
+  Make Unicode softhyphen U+00AD active and defined as \-.
+
 2020-05-02  Johannes Braams  <texniek at braams.xs4all.nl>
 
 	* ltexpl.dtx: Created aliases for two expl3 macros in order to use

--- a/base/doc/ltnews32.tex
+++ b/base/doc/ltnews32.tex
@@ -517,6 +517,17 @@ documentation~\cite{32:babel}.
 
 
 
+\subsection{Add support for Unicode soft hyphens}
+
+For a long time, the UTF-8 option for \pkg{inputenc} made the Unicode
+soft hyphen character (U+00AD) an alias for the \LaTeX\ soft hyphen
+|\-|. The Unicode engines \XeTeX{} and \LuaTeX{} behaved
+different though: They either ignored U+00AD or interpreted it as an
+unconditional hyphen. This inconsistency is fixed now and \LaTeX{}
+always treats \texttt{U+00AD} as |\-|.
+
+
+
 \begin{thebibliography}{9}
 
 \fontsize{9.3}{11.3}\selectfont

--- a/base/ltspace.dtx
+++ b/base/ltspace.dtx
@@ -32,7 +32,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltspace.dtx}
-             [2020/04/21 v1.3m LaTeX Kernel (spacing)]
+             [2020/05/06 v1.3n LaTeX Kernel (spacing)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltspace.dtx}
@@ -1361,6 +1361,18 @@
 % \end{macro}
 % \end{macro}
 % \end{macro}
+%
+% \changes{v1.3n}{2020/05/06}{Made softhyphen active in TU engines}
+%
+%   For Unicode engines, make the Unicode soft hyphen an active
+%   character defined as \cs{-}.
+%
+%    \begin{macrocode}
+\ifx\Umathcode\@undefined\else
+  \catcode "AD=13
+  \def^^ad{\-}
+\fi
+%    \end{macrocode}
 %
 % \begin{macro}{\obeycr}
 % \begin{macro}{\restorecr}


### PR DESCRIPTION
Make U+00AD an active alias for `\-` on LuaTeX and XeTeX. This gives U+AD the proper behavior and also improves compatibility with non-Unicode engines.

(The PR by itself doesn't actually has any visible effect right now because the babel hyphenation code globally resets the catcode, but I think that should be changed in babel directly.)
 
# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
<!--- - Under development -->
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [X] Version and date string updated in changed source files
- [X] Relevant `\changes` entries in source included
- [X] Relevant `changes.txt` updated
- [X] `ltnewsX.tex` updated
