### PR TITLE
correct unicode value of \=y

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -1,9 +1,9 @@
-2020-04-22 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
+2020-04-22  Ulrike Fischer <Ulrike.Fischer@latex-project.org>
 
 	* ltoutenc.dtx (tuenc.def):
 	corrected unicode value of \=y from "0232 to "0233
 
-2020-04-21 Frank Mittelbach <Frank.Mittelbach@latex-project.org>
+2020-04-21  Frank Mittelbach <Frank.Mittelbach@latex-project.org>
 
 	* ltspace.dtx (subsection{Horizontal space (and breaks)}):
 	Support calc syntax with \hspace (gh/152)

--- a/base/changes.txt
+++ b/base/changes.txt
@@ -1,4 +1,9 @@
-2020-04-21  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
+2020-04-22 Ulrike Fischer<Ulrike.Fischer@latex-project.org>
+
+	* ltoutenc.dtx (tuenc.def):
+	corrected unicode value of \=y from "0232 to "0233
+
+2020-04-21 Frank Mittelbach <Frank.Mittelbach@latex-project.org>
 
 	* ltspace.dtx (subsection{Horizontal space (and breaks)}):
 	Support calc syntax with \hspace (gh/152)

--- a/base/changes.txt
+++ b/base/changes.txt
@@ -1,4 +1,4 @@
-2020-04-22 Ulrike Fischer<Ulrike.Fischer@latex-project.org>
+2020-04-22 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
 
 	* ltoutenc.dtx (tuenc.def):
 	corrected unicode value of \=y from "0232 to "0233

--- a/base/ltoutenc.dtx
+++ b/base/ltoutenc.dtx
@@ -37,14 +37,14 @@
 %<TS1>\ProvidesFile{ts1enc.def}[2001/06/05 v3.0e (jk/car/fm)
 %<TU>\ProvidesFile{tuenc.def}
 %<package>\ProvidesPackage{fontenc}
-%<OT1|T1|OMS|OML|OT4|TU|package> [2020/02/11 v2.0o
+%<OT1|T1|OMS|OML|OT4|TU|package> [2020/04/22 v2.0p
 %<OT1|T1|OMS|OML|OT4|TS1|TU>      Standard LaTeX file]
 %<package>                        Standard LaTeX package]
 %
 %<*driver>
 % \fi
 \ProvidesFile{ltoutenc.dtx}
-             [2020/02/11 v2.0o LaTeX Kernel (font encodings)]
+             [2020/04/22 v2.0p LaTeX Kernel (font encodings)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltoutenc.dtx}
@@ -188,6 +188,8 @@
 %   like.}
 % \changes{v1.99m}{2015/02/21}
 %         {Removed autoload code}
+% \changes{v2.0p}{2020/04/22}
+%         {corrected \=y unicode value in tuenc.def}
 %
 %
 % \section{Font encodings}
@@ -3370,7 +3372,7 @@
 \DeclareUnicodeComposite{\textcommabelow}{T}{"021A}
 \DeclareUnicodeComposite{\textcommabelow}{t}{"021B}
 \DeclareUnicodeComposite{\=}             {Y}{"0232}
-\DeclareUnicodeComposite{\=}             {y}{"0232}
+\DeclareUnicodeComposite{\=}             {y}{"0233}
 \DeclareUnicodeComposite{\.}             {B}{"1E02}
 \DeclareUnicodeComposite{\.}             {b}{"1E03}
 \DeclareUnicodeComposite{\d}             {B}{"1E04}
@@ -3601,7 +3603,7 @@
 \xdef\@fontenc@load@list{\@fontenc@load@list
   \@elt{\csname opt@fontenc.sty\endcsname}}
 %    \end{macrocode}
-%    
+%
 %    \begin{macrocode}
 \global\expandafter\let\csname ver@fontenc.sty\endcsname\relax
 \global\expandafter\let\csname opt@fontenc.sty\endcsname\relax


### PR DESCRIPTION
there was a small typo, \=Y and \=y pointed to the same value. 

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ x] Version and date string updated in changed source files
- [ x] Relevant `\changes` entries in source included
- [ x] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` updated
