### PR TITLE
DeclareFontEncoding: always set a default substitution

### DIFF
--- a/base/ltfssbas.dtx
+++ b/base/ltfssbas.dtx
@@ -495,6 +495,11 @@
 %   support cyrillic integration (pr/2988)}
 %    \begin{macrocode}
   \xdef\LastDeclaredEncoding{#1}%
+  \expandafter\edef\csname D@#1\endcsname{%
+       \def\noexpand\default@family{\default@family}%
+       \def\noexpand\default@series{\default@series}%
+       \def\noexpand\default@shape {\default@shape}%
+       }%
   }
 \@onlypreamble\DeclareFontEncoding@
 %    \end{macrocode}


### PR DESCRIPTION
If a font encoding 'Foo' is declared but `\DeclareFontSubstitution` is
never set up on this encoding, then switching to this font encoding will
never update the substitution defaults.

For instance the default substitution shape may be 'n' if 'OT1' was the
encoding used before, or 'it' if 'OML' was the encoding used before.

Fix this by setting `\D@Foo` in `\DeclareFontEncoding{Foo}{}{}` too. This
uses the current values of the global `\default@family` and so on, which
at this point have been set by the last `\DeclareErrorFont` command.

In `fonttext.ltx` all encodings specified before `\DeclareErrorFont`
have a `\DeclareFontSubstitution`, so it does not matter that the global
`\default@family` was not yet specified.

# Internal housekeeping

## Status of pull request

- Feedback wanted 