### PR TITLE
Document \DeclareFontFamilySubstitution

### DIFF
--- a/base/doc/fntguide.tex
+++ b/base/doc/fntguide.tex
@@ -1924,7 +1924,7 @@ This declaration takes three arguments:
   overall default.
 \item[Meta series interface:] Can be |md| or |bf|.
 \item[Series value:] This is the value that is going to be used when the
-  combination of \oarg{meta family} and \arg{meta series} is requested.
+  combination of \m{meta family} and \m{meta series} is requested.
 \end{description}
 For example,
 \begin{verbatim}
@@ -1953,6 +1953,25 @@ small capitals for the third level.  If there are more nesting levels
 than provided, declarations stored in |\emreset| (by default
 |\ulcshape\upshape|) are used for the next level and then the list
 restarts.
+
+\subsection{Providing font family substitutions}
+
+\begin{decl}
+  |\DeclareFontFamilySubstitution| \arg{encoding}
+                                   \arg{family}
+                                   \arg{new-family}
+\end{decl}
+
+\NEWfeature{2020/02/02}
+This declaration selects the font family \m{new-family} as replacement
+for \m{family} in the font encoding \m{encoding}.  For example,
+\begin{verbatim}
+   \DeclareFontFamilySubstitution{LGR}
+           {Montserrat-LF}{IBMPlexSans-TLF}
+\end{verbatim}
+tells \LaTeX{} to substitute the sans serif font |Montserrat-LF| in the
+Greek encoding |LGR| with |IBMPlexSans-TLF| once requested in a
+document.
 
 \section{If you need to know more \ldots}
 


### PR DESCRIPTION
Dear all,

this is the next PR adding description for `\DeclareFontFamilySubstitution` to `fntguide.tex`.  Any comments welcome.