### PR TITLE
Document relocation of textcomp macros into kernel

### DIFF
--- a/base/doc/fntguide.tex
+++ b/base/doc/fntguide.tex
@@ -1973,6 +1973,191 @@ tells \LaTeX{} to substitute the sans serif font |Montserrat-LF| in the
 Greek encoding |LGR| with |IBMPlexSans-TLF| once requested in a
 document.
 
+\section{Additional text symbols -- \textsf{textcomp}}
+
+\NEWfeature{2020/02/02}
+For a long time the interface to additional text symbols and the text
+companion encoding |TS1| in general was the \textsf{textcomp} package.
+All the symbols provided by the \textsf{textcomp} package are now
+available in \LaTeX{} kernel.  Furthermore, an intelligent substitution
+mechanism has been implemented so that glyphs missing in some fonts are
+automatically substituted with default glyphs that are sans serif if you
+typeset in |\textsf| and monospaced if you typeset using |\texttt|.  In
+the past they were always taken from Computer Modern Roman if
+substitution was necessary.
+
+{\sffamily This is most noticeable with |\oldstylenums| which are now
+  taken from |TS1| so that you no longer get \legacyoldstylenums{1234}
+  but \oldstylenums{1234} when typesetting in sans serif fonts \ttfamily
+  and \oldstylenums{1234} when using typewriter fonts.}
+
+\begin{decl}
+  |\legacyoldstylenums| \arg{nums}\\
+  |\UseLegacyTextSymbols|
+\end{decl}
+If there ever is a need to use the original (inferior) definition, then
+that remains available as |\legacyoldstylenums|; and to fully revert to
+the old behavior there is also |\UseLegacyTextSymbols|.  The latter
+declaration reverts |\oldstylenums| and also changes the footnote
+symbols, such as |\textdagger|, |\textparagraph|, etc., to pick up their
+glyphs from the math fonts instead of the current text font (this means
+they always keep the same shape and do not nicely blend in with the text
+font).
+
+The following tables show the macros available.  The next commands are
+`constructed' accents and are built via \TeX{} macros:
+\begin{center}
+  \begin{tabular}[t]{@{}ll}
+    \verb*|\capitalcedilla A| & \capitalcedilla A \\
+    \verb*|\capitalogonek A|  & \capitalogonek A  \\
+    \verb*|\textcircled a|    & \textcircled a
+  \end{tabular}
+\end{center}
+
+These accents are available via font encoding.  The numbers in third row
+show the slot number:
+\begin{center}
+  \begin{tabular}[t]{@{}p{0.32\linewidth}p{1em}p{2em}@{}}
+    \verb|\capitalgrave|        & \capitalgrave{}        & 0 \\
+    \verb|\capitalacute|        & \capitalacute{}        & 1 \\
+    \verb|\capitalcircumflex|   & \capitalcircumflex{}   & 2 \\
+    \verb|\capitaltilde|        & \capitaltilde{}        & 3 \\
+    \verb|\capitaldieresis|     & \capitaldieresis{}     & 4 \\
+    \verb|\capitalhungarumlaut| & \capitalhungarumlaut{} & 5 \\
+    \verb|\capitalring|         & \capitalring{}         & 6 \\
+    \verb|\capitalcaron|        & \capitalcaron{}        & 7
+  \end{tabular}
+  \quad
+  \begin{tabular}[t]{@{}p{0.32\linewidth}p{1em}p{2em}@{}}
+    \verb|\capitalbreve|        & \capitalbreve{}        & 8  \\
+    \verb|\capitalmacron|       & \capitalmacron{}       & 9  \\
+    \verb|\capitaldotaccent|    & \capitaldotaccent{}    & 10 \\
+    \verb|\t|                   & \t{}                   & 26 \\
+    \verb|\capitaltie|          & \capitaltie{}          & 27 \\
+    \verb|\newtie|              & \newtie{}              & 28 \\
+    \verb|\capitalnewtie|       & \capitalnewtie{}       & 29
+  \end{tabular}
+\end{center}
+
+Next table contains macros to access text symbols.  Again, the numbers
+are the slots in the encoding:
+
+\begin{center}\footnotesize
+  \begin{tabular}[t]{@{}lp{1.5em}l@{}}
+    \verb|\textcapitalcompwordmark|  & \textcapitalcompwordmark  & 23 \\
+    \verb|\textascendercompwordmark| & \textascendercompwordmark & 31 \\
+    \verb|\textquotestraightbase|    & \textquotestraightbase    & 13 \\
+    \verb|\textquotestraightdblbase| & \textquotestraightdblbase & 18 \\
+    \verb|\texttwelveudash|          & \texttwelveudash          & 21 \\
+    \verb|\textthreequartersemdash|  & \textthreequartersemdash  & 22 \\
+    \verb|\textleftarrow|            & \textleftarrow            & 24 \\
+    \verb|\textrightarrow|           & \textrightarrow           & 25 \\
+    \verb|\textblank|                & \textblank                & 32 \\
+    \verb|\textdollar|               & \textdollar               & 36 \\
+    \verb|\textquotesingle|          & \textquotesingle          & 39 \\
+    \verb|\textasteriskcentered|     & \textasteriskcentered     & 42 \\
+    \verb|\textdblhyphen|            & \textdblhyphen            & 45 \\
+    \verb|\textfractionsolidus|      & \textfractionsolidus      & 47 \\
+    \verb|\textzerooldstyle|         & \textzerooldstyle         & 48 \\
+    \verb|\textoneoldstyle|          & \textoneoldstyle          & 49 \\
+    \verb|\texttwooldstyle|          & \texttwooldstyle          & 50 \\
+    \verb|\textthreeoldstyle|        & \textthreeoldstyle        & 51 \\
+    \verb|\textfouroldstyle|         & \textfouroldstyle         & 52 \\
+    \verb|\textfiveoldstyle|         & \textfiveoldstyle         & 53 \\
+    \verb|\textsixoldstyle|          & \textsixoldstyle          & 54 \\
+    \verb|\textsevenoldstyle|        & \textsevenoldstyle        & 55 \\
+    \verb|\texteightoldstyle|        & \texteightoldstyle        & 56 \\
+    \verb|\textnineoldstyle|         & \textnineoldstyle         & 57 \\
+    \verb|\textlangle|               & \textlangle               & 60 \\
+    \verb|\textminus|                & \textminus                & 61 \\
+    \verb|\textrangle|               & \textrangle               & 62 \\
+    \verb|\textmho|                  & \textmho                  & 77 \\
+    \verb|\textbigcircle|            & \textbigcircle            & 79 \\
+    \verb|\textohm|                  & \textohm                  & 87 \\
+    \verb|\textlbrackdbl|            & \textlbrackdbl            & 91 \\
+    \verb|\textrbrackdbl|            & \textrbrackdbl            & 93 \\
+    \verb|\textuparrow|              & \textuparrow              & 94 \\
+    \verb|\textdownarrow|            & \textdownarrow            & 95 \\
+    \verb|\textasciigrave|           & \textasciigrave           & 96 \\
+    \verb|\textborn|                 & \textborn                 & 98 \\
+    \verb|\textdivorced|             & \textdivorced             & 99 \\
+    \verb|\textdied|                 & \textdied                 & 100 \\
+    \verb|\textleaf|                 & \textleaf                 & 108 \\
+    \verb|\textmarried|              & \textmarried              & 109 \\
+    \verb|\textmusicalnote|          & \textmusicalnote          & 110 \\
+    \verb|\texttildelow|             & \texttildelow             & 126 \\
+    \verb|\textdblhyphenchar|        & \textdblhyphenchar        & 127 \\
+    \verb|\textasciibreve|           & \textasciibreve           & 128 \\
+    \verb|\textasciicaron|           & \textasciicaron           & 129 \\
+    \verb|\textacutedbl|             & \textacutedbl             & 130 \\
+    \verb|\textgravedbl|             & \textgravedbl             & 131 \\
+    \verb|\textdagger|               & \textdagger               & 132 \\
+    \verb|\textdaggerdbl|            & \textdaggerdbl            & 133 \\
+    \verb|\textbardbl|               & \textbardbl               & 134 \\
+    \verb|\textperthousand|          & \textperthousand          & 135 \\
+    \verb|\textbullet|               & \textbullet               & 136 \\
+    \verb|\textcelsius|              & \textcelsius              & 137 \\
+    \verb|\textdollaroldstyle|       & \textdollaroldstyle       & 138 \\
+    \verb|\textcentoldstyle|         & \textcentoldstyle         & 139
+  \end{tabular}\qquad
+  \begin{tabular}[t]{lp{1.5em}l}
+    \verb|\textflorin|               & \textflorin               & 140 \\
+    \verb|\textcolonmonetary|        & \textcolonmonetary        & 141 \\
+    \verb|\textwon|                  & \textwon                  & 142 \\
+    \verb|\textnaira|                & \textnaira                & 143 \\
+    \verb|\textguarani|              & \textguarani              & 144 \\
+    \verb|\textpeso|                 & \textpeso                 & 145 \\
+    \verb|\textlira|                 & \textlira                 & 146 \\
+    \verb|\textrecipe|               & \textrecipe               & 147 \\
+    \verb|\textinterrobang|          & \textinterrobang          & 148 \\
+    \verb|\textinterrobangdown|      & \textinterrobangdown      & 149 \\
+    \verb|\textdong|                 & \textdong                 & 150 \\
+    \verb|\texttrademark|            & \texttrademark            & 151 \\
+    \verb|\textpertenthousand|       & \textpertenthousand       & 152 \\
+    \verb|\textpilcrow|              & \textpilcrow              & 153 \\
+    \verb|\textbaht|                 & \textbaht                 & 154 \\
+    \verb|\textnumero|               & \textnumero               & 155 \\
+    \verb|\textdiscount|             & \textdiscount             & 156 \\
+    \verb|\textestimated|            & \textestimated            & 157 \\
+    \verb|\textopenbullet|           & \textopenbullet           & 158 \\
+    \verb|\textservicemark|          & \textservicemark          & 159 \\
+    \verb|\textlquill|               & \textlquill               & 160 \\
+    \verb|\textrquill|               & \textrquill               & 161 \\
+    \verb|\textcent|                 & \textcent                 & 162 \\
+    \verb|\textsterling|             & \textsterling             & 163 \\
+    \verb|\textcurrency|             & \textcurrency             & 164 \\
+    \verb|\textyen|                  & \textyen                  & 165 \\
+    \verb|\textbrokenbar|            & \textbrokenbar            & 166 \\
+    \verb|\textsection|              & \textsection              & 167 \\
+    \verb|\textasciidieresis|        & \textasciidieresis        & 168 \\
+    \verb|\textcopyright|            & \textcopyright            & 169 \\
+    \verb|\textordfeminine|          & \textordfeminine          & 170 \\
+    \verb|\textcopyleft|             & \textcopyleft             & 171 \\
+    \verb|\textlnot|                 & \textlnot                 & 172 \\
+    \verb|\textcircledP|             & \textcircledP             & 173 \\
+    \verb|\textregistered|           & \textregistered           & 174 \\
+    \verb|\textasciimacron|          & \textasciimacron          & 175 \\
+    \verb|\textdegree|               & \textdegree               & 176 \\
+    \verb|\textpm|                   & \textpm                   & 177 \\
+    \verb|\texttwosuperior|          & \texttwosuperior          & 178 \\
+    \verb|\textthreesuperior|        & \textthreesuperior        & 179 \\
+    \verb|\textasciiacute|           & \textasciiacute           & 180 \\
+    \verb|\textmu|                   & \textmu                   & 181 \\
+    \verb|\textparagraph|            & \textparagraph            & 182 \\
+    \verb|\textperiodcentered|       & \textperiodcentered       & 183 \\
+    \verb|\textreferencemark|        & \textreferencemark        & 184 \\
+    \verb|\textonesuperior|          & \textonesuperior          & 185 \\
+    \verb|\textordmasculine|         & \textordmasculine         & 186 \\
+    \verb|\textsurd|                 & \textsurd                 & 187 \\
+    \verb|\textonequarter|           & \textonequarter           & 188 \\
+    \verb|\textonehalf|              & \textonehalf              & 189 \\
+    \verb|\textthreequarters|        & \textthreequarters        & 190 \\
+    \verb|\texteuro|                 & \texteuro                 & 191 \\
+    \verb|\texttimes|                & \texttimes                & 214 \\
+    \verb|\textdiv|                  & \textdiv                  & 246
+  \end{tabular}
+\end{center}
+
 \section{If you need to know more \ldots}
 
 \NEWdescription{1996/06/01}


### PR DESCRIPTION
Dear all,

this should be the final PR for `textcomp` macros now being part of the kernel.  I also added the available macros as I'm not aware of them being described in any other free manual.  Again, any comments welcome and thanks for your patience.