### PR TITLE
make a number of commands short again that got \long by mistake

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -1,3 +1,4 @@
+
 ================================================================================
 This file lists changes to the LaTeX2e files in reverse chronological order of
 publication (therefore the dates might be out of sequence if there are hotfixes).
@@ -5,6 +6,24 @@ It is provided for convenience only.  It therefore makes no claims to
 completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 ================================================================================
+
+2020-07-27  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
+
+	* ltpage.dtx (section| command.):
+	\markboth and \markright should not be \long (gh/354)}
+
+	* ltsect.dtx (subsection{The Title}):
+	\author and \date should not be \long (gh/354)}
+	\title and \thanks kept as \long.
+
+	* ltoutenc.dtx (subsubsection{Declaration commands}):
+	\UseTextAccent and \UseTextSymbol should not be \long (gh/354)}
+
+	* ltmath.dtx (subsubsection{The UNSORTED Rest}):
+	\cases, \matrix and \pmatrix should not be \long (gh/354)}
+
+	* ltpictur.dtx (section{Picture Mode}):
+	\linethickness should not be \long (gh/354)}
 
 2020-07-16  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 

--- a/base/ltmath.dtx
+++ b/base/ltmath.dtx
@@ -38,7 +38,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltmath.dtx}
-              [2020/04/21 v1.2f LaTeX Kernel (Math Setup)]
+              [2020/07/27 v1.2g LaTeX Kernel (Math Setup)]
 % \iffalse
 %</driver>
 %
@@ -407,15 +407,17 @@
 % \begin{macro}{\cases}
 % \changes{LaTeX2.09}{1991/08/14}
 %         {(RmS) inserted extra braces around entry for NFSS}
+% \changes{v1.2g}{2020/07/27}{Don't make the command \cs{long} (gh/354)}
 %    \begin{macrocode}
-\DeclareRobustCommand\cases[1]{\left\{\,\vcenter{\normalbaselines\m@th
+\DeclareRobustCommand*\cases[1]{\left\{\,\vcenter{\normalbaselines\m@th
     \ialign{$##\hfil$&\quad{##}\hfil\crcr#1\crcr}}\right.}
 %    \end{macrocode}
 % \end{macro}
 %
 % \begin{macro}{\matrix}
+% \changes{v1.2g}{2020/07/27}{Don't make the command \cs{long} (gh/354)}
 %    \begin{macrocode}
-\DeclareRobustCommand\matrix[1]{\null\,\vcenter{\normalbaselines\m@th
+\DeclareRobustCommand*\matrix[1]{\null\,\vcenter{\normalbaselines\m@th
     \ialign{\hfil$##$\hfil&&\quad\hfil$##$\hfil\crcr
       \mathstrut\crcr\noalign{\kern-\baselineskip}
       #1\crcr\mathstrut\crcr\noalign{\kern-\baselineskip}}}\,}
@@ -423,8 +425,9 @@
 % \end{macro}
 %
 % \begin{macro}{\pmatrix}
+% \changes{v1.2g}{2020/07/27}{Don't make the command \cs{long} (gh/354)}
 %    \begin{macrocode}
-\DeclareRobustCommand\pmatrix[1]{\left(\matrix{#1}\right)}
+\DeclareRobustCommand*\pmatrix[1]{\left(\matrix{#1}\right)}
 %    \end{macrocode}
 % \end{macro}
 %

--- a/base/ltoutenc.dtx
+++ b/base/ltoutenc.dtx
@@ -44,7 +44,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltoutenc.dtx}
-             [2021/07/04 v2.0q LaTeX Kernel (font encodings)]
+             [2020/07/21 v2.0r LaTeX Kernel (font encodings)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltoutenc.dtx}
@@ -1082,8 +1082,9 @@
 %    deficiencies, see pr/3160.
 % \task{?}{Improve this and document its problems, see pr/3160}
 % \changes{v1.9z}{2000/01/30}{Macro reimplemented (pr/3160)}
+% \changes{v2.0r}{2020/07/27}{Don't make the command \cs{long} (gh/354)}
 %    \begin{macrocode}
-\DeclareRobustCommand\UseTextAccent[3]{%
+\DeclareRobustCommand*\UseTextAccent[3]{%
   \hmode@start@before@group
    {%
 %    \end{macrocode}
@@ -1098,8 +1099,9 @@
 %    \end{macrocode}
 %
 % \changes{v1.9z}{2000/01/30}{Macro reimplemented (pr/3160)}
+% \changes{v2.0r}{2020/07/27}{Don't make the command \cs{long} (gh/354)}
 %    \begin{macrocode}
-\DeclareRobustCommand\UseTextSymbol[2]{%
+\DeclareRobustCommand*\UseTextSymbol[2]{%
        \hmode@start@before@group
        {%
           \def\@wrong@font@char{\MessageBreak

--- a/base/ltpage.dtx
+++ b/base/ltpage.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltpage.dtx}
-             [2019/08/27 v1.0l LaTeX Kernel (page style setup)]
+             [2020/07/27 v1.0m LaTeX Kernel (page style setup)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltpage.dtx}
@@ -201,8 +201,9 @@
 %    expansion, CAR}
 % \changes{v1.0j}{2000/05/26}{Reimplementation to fix expansion
 %                             error (pr/3203).}
+% \changes{v1.0m}{2020/07/27}{Don't make the command \cs{long} (gh/354)}
 %    \begin{macrocode}
-\DeclareRobustCommand\markboth[2]{%
+\DeclareRobustCommand*\markboth[2]{%
   \begingroup
     \let\label\relax \let\index\relax \let\glossary\relax
     \unrestored@protected@xdef\@themark {{#1}{#2}}%
@@ -212,8 +213,9 @@
   \if@nobreak\ifvmode\nobreak\fi\fi}
 %    \end{macrocode}
 %
+% \changes{v1.0m}{2020/07/27}{Don't make the command \cs{long} (gh/354)}
 %    \begin{macrocode}
-\DeclareRobustCommand\markright[1]{%
+\DeclareRobustCommand*\markright[1]{%
   \begingroup
     \let\label\relax \let\index\relax \let\glossary\relax
 %    \end{macrocode}

--- a/base/ltpictur.dtx
+++ b/base/ltpictur.dtx
@@ -32,7 +32,7 @@
 %<*driver>
 % \fi
       \ProvidesFile{ltpictur.dtx}
-                      [2020/05/12 v1.1o LaTeX Kernel (Picture Mode)]
+                      [2020/07/27 v1.1p LaTeX Kernel (Picture Mode)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltpictur.dtx}
@@ -289,8 +289,9 @@
 %
 % \begin{macro}{\linethickness}
 % \changes{v1.1n}{2020/02/14}{Suppress spaces following the declaration (gh/274)}
+% \changes{v1.1p}{2020/07/27}{Don't make the command \cs{long} (gh/354)}
 %    \begin{macrocode}
-\DeclareRobustCommand\linethickness[1]
+\DeclareRobustCommand*\linethickness[1]
    {\@wholewidth #1\relax \@halfwidth .5\@wholewidth \ignorespaces}
 %    \end{macrocode}
 % \end{macro}

--- a/base/ltsect.dtx
+++ b/base/ltsect.dtx
@@ -31,7 +31,7 @@
 %%% From File: ltsect.dtx
 %<*driver>
 % \fi
-\ProvidesFile{ltsect.dtx}[2019/08/27 v1.1d LaTeX Kernel (Sectioning)]
+\ProvidesFile{ltsect.dtx}[2020/07/27 v1.1e LaTeX Kernel (Sectioning)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltsect.dtx}
@@ -137,20 +137,22 @@
 %
 %  \begin{macro}{\author}
 % \changes{LaTeX2e}{1993/12/11}{Added default}
+% \changes{v1.1e}{2020/07/27}{Don't make the command \cs{long} (gh/354)}
 %
 %  |\author| for use in |\maketitle|. If not given |\maketitle| will
 %  produce a warning message.
 %
 %    \begin{macrocode}
-\DeclareRobustCommand\author[1]{\gdef\@author{#1}}
+\DeclareRobustCommand*\author[1]{\gdef\@author{#1}}
 %    \end{macrocode}
 %  \end{macro}
 %
 %  \begin{macro}{\date}
 %    |\date| for use in |\maketitle|. If not given |\maketitle| will
 %    produce |\today| as the default.
+% \changes{v1.1e}{2020/07/27}{Don't make the command \cs{long} (gh/354)}
 %    \begin{macrocode}
-\DeclareRobustCommand\date[1]{\gdef\@date{#1}}
+\DeclareRobustCommand*\date[1]{\gdef\@date{#1}}
 %    \end{macrocode}
 %  \end{macro}
 %


### PR DESCRIPTION

# Internal housekeeping

## Status of pull request


- Feedback wanted 
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added (not needed I think)
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` updated (n/a)
