### PR TITLE
Switch from Umathchar to Umathcode for Unicode detection

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -7,6 +7,11 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 ================================================================================
 
+2020-08-01  Marcel Krüger     <Marcel.Krueger@latex-project.org>
+
+	* fontdef.dtx, inputenc.dtx, ltfinal.dtx, ltluatex.dtx:
+	More consistently use \Umathcode to check for Unicode-aware engines. (gh/279)
+
 2020-07-27  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 
 	* ltpage.dtx (section| command.):

--- a/base/fontdef.dtx
+++ b/base/fontdef.dtx
@@ -39,7 +39,7 @@
 %<driver, >\ProvidesFile{fontdef.drv}
 % \fi
 %          \ProvidesFile{fontdef.dtx}
-%<-latexrelease>           [2020/04/24 v3.0h LaTeX Kernel
+%<-latexrelease>           [2020/08/01 v3.0i LaTeX Kernel
 % \iftrue  (\else
 %<text,   >(Text
 %<math,   >(Math
@@ -269,7 +269,7 @@
 %
 % \changes{v3.0a}{2016/12/03}{(DPC) Default to TU encoding for Unicode TeX engines}
 %    \begin{macrocode}
-\ifx\Umathchar\@undefined
+\ifx\Umathcode\@undefined
 %    \end{macrocode}
 %
 %    We then set the default text font encoding. This will
@@ -436,7 +436,7 @@
 %    The following three definitions set up the meaning for
 %    |\rmfamily|, |\sffamily|, and |\ttfamily|.
 %    \begin{macrocode}
-\ifx\Umathchar\@undefined
+\ifx\Umathcode\@undefined
 \newcommand\encodingdefault{OT1}
 \newcommand\rmdefault{cmr}
 \newcommand\sfdefault{cmss}
@@ -451,7 +451,7 @@
 %</text>
 %<latexrelease>\IncludeInRelease{2017/01/01}%
 %<latexrelease>                 {\encodingdefault}{TU encoding default}%
-%<latexrelease>\ifx\Umathchar\@undefined
+%<latexrelease>\ifx\Umathcode\@undefined
 %<latexrelease>\renewcommand\encodingdefault{OT1}
 %<latexrelease>\fontencoding{\encodingdefault}
 %<latexrelease>\renewcommand\rmdefault{cmr}

--- a/base/inputenc.dtx
+++ b/base/inputenc.dtx
@@ -410,7 +410,7 @@
 %<cp1252&!ansinew>  \ProvidesFile{cp1252.def}
 %<cp1250>  \ProvidesFile{cp1250.def}
 %<cp1257>  \ProvidesFile{cp1257.def}
-   [2020/04/14 v1.3c Input encoding file]
+   [2020/08/01 v1.3d Input encoding file]
 %<cp850>%%
 %<cp850>%% If you need a Euro symbol, try cp858 instead.
 %<cp850>%%
@@ -545,7 +545,7 @@
 %    produces a warning message if no suitable definitions get read.
 %
 %    \begin{macrocode}
-\ifx\Umathchar\@undefined
+\ifx\Umathcode\@undefined
 %    \end{macrocode}
 %
 %    \begin{macrocode}

--- a/base/ltfinal.dtx
+++ b/base/ltfinal.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltfinal.dtx}
-             [2020-07-16 v2.2f LaTeX Kernel (Final Settings)]
+             [2020-08-01 v2.2g LaTeX Kernel (Final Settings)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltfinal.dtx}
@@ -590,7 +590,7 @@
 % Skip this section in Unicode TeX, or if  MLTeX and EncTeX are enabled.
 %    \begin{macrocode}
 \ifnum0%
-  \ifx\Umathchar\@undefined\else 1\fi
+  \ifx\Umathcode\@undefined\else 1\fi
   \ifx\mubyte\@undefined\else 1\fi
   \ifx\charsubdef\@undefined\else 1\fi
   =\z@

--- a/base/ltluatex.dtx
+++ b/base/ltluatex.dtx
@@ -28,7 +28,7 @@
 \ProvidesFile{ltluatex.dtx}
 %</driver>
 %<*tex>
-[2020/06/10 v1.1n
+[2020/08/01 v1.1o
 %</tex>
 %<plain>  LuaTeX support for plain TeX (core)
 %<*tex>
@@ -459,7 +459,7 @@
 %    \end{macrocode}
 % luatex/xetex also allow more math fam.
 %    \begin{macrocode}
-\edef \et@xmaxfam {\ifx\Umathchar\@undefined\sixt@@n\else\@cclvi\fi}
+\edef \et@xmaxfam {\ifx\Umathcode\@undefined\sixt@@n\else\@cclvi\fi}
 %    \end{macrocode}
 %
 %    \begin{macrocode}

--- a/base/testfiles/github-0060.lvt
+++ b/base/testfiles/github-0060.lvt
@@ -5,7 +5,7 @@
 \documentclass{article}
 
 \START
-\ifx\Umathchar\undefined\else\expandafter\END\fi
+\ifx\Umathcode\undefined\else\expandafter\END\fi
 
 \typeout{^^J===Declare 10FFFF}
 \DeclareUnicodeCharacter{10FFFF}{U+10FFFF\typeout{MAX VALUE!!}}

--- a/base/testfiles/tlb-umath-001.lvt
+++ b/base/testfiles/tlb-umath-001.lvt
@@ -11,7 +11,7 @@
 
 \START
 
-\ifx\Umathchar\undefined\else
+\ifx\Umathcode\undefined\else
 
 \Umathchardef\alpha"0"0"010B
 \protected\def\hat{\Umathaccent fixed 7\symoperators "00302\relax}

--- a/base/testfiles/tlb4024.lvt
+++ b/base/testfiles/tlb4024.lvt
@@ -10,8 +10,8 @@
 \documentclass{article}
 \input{test2e}
 % trigger xetex behavour udf pdftex
-\ifx\Umathchar\xxundefined
-\let\Umathchar\relax
+\ifx\Umathcode\xxundefined
+\let\Umathcode\relax
 \fi
 
 \usepackage[utf8]{inputenc}

--- a/support/fonttext.cfg
+++ b/support/fonttext.cfg
@@ -1,9 +1,9 @@
 
 
-\let\SAVEDUmathchar\Umathchar
-\let\Umathchar\undefined
+\let\SAVEDUmathcode\Umathcode
+\let\Umathcode\undefined
 
-\ifx\SAVEDUmathchar\undefined
+\ifx\SAVEDUmathcode\undefined
 
 \input{fonttext.ltx}
 
@@ -22,7 +22,7 @@
 \fi
 
 
-\let\Umathchar\SAVEDUmathchar
+\let\Umathcode\SAVEDUmathcode
 
 % just so you can check this format is being used
 \def\FONTTEXTCONFIG{OT1-testing}


### PR DESCRIPTION
Fixes #279. Given that this is only for internal consistency and should never lead to any change in behavior and also doesn't change the documentation, I had the feeling that `\changes` lines would not provide any benefit and just distract from more useful changes. I'm not sure how we handle such cases though, so I can add them if you feel that they are useful.

# Internal housekeeping

## Status of pull request

- Feedback wanted 
- Ready to merge

## Checklist of required changes before merge will be approved
- n/a Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included -- see above
- [x] Relevant `changes.txt` updated
- n/a `ltnewsX.tex` updated
