### PR TITLE
Load Lua module during format building

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,14 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 ================================================================================
 
+2020-08-10  Marcel Krüger     <Marcel.Krueger@latex-project.org>
+
+	* ltoutenc.dtx, ltluatex.dtx:
+	Moved \now@and@everyjob to ltluatex and load luatexbase during format building.
+
+	* ltluatex.dtx:
+	new_graf callback type changed to exclusive
+
 2020-08-08  Johannes Braams  <Johannes.Braams@latex-project.org>
 
 	* ltclass.dtx:

--- a/base/ltluatex.dtx
+++ b/base/ltluatex.dtx
@@ -28,7 +28,7 @@
 \ProvidesFile{ltluatex.dtx}
 %</driver>
 %<*tex>
-[2020/08/03 v1.1q
+[2020/08/10 v1.1r
 %</tex>
 %<plain>  LuaTeX support for plain TeX (core)
 %<*tex>
@@ -777,14 +777,27 @@
 % \end{macro}
 %
 % \subsection{Lua loader}
+% \changes{v1.1r}{2020/08/10}{Load ltluatex Lua module during format building}
+%
+% Lua code loaded in the format often has to to be loaded again at the
+% beginning of every job, so we define a helper whch allows us to avoid
+% duplicated code:
+%
+%    \begin{macrocode}
+\def\now@and@everyjob#1{%
+  \everyjob\expandafter{\the\everyjob
+    #1%
+  }%
+  #1%
+}
+%    \end{macrocode}
 %
 % Load the Lua code at the start of every job.
 % For the conversion of \TeX{} into numbers at the Lua side we need some
 % known registers: for convenience we use a set of systematic names, which
 % means using a group around the Lua loader.
 %    \begin{macrocode}
-%<2ekernel>\everyjob\expandafter{%
-%<2ekernel>  \the\everyjob
+%<2ekernel>\now@and@everyjob{%
   \begingroup
     \attributedef\attributezero=0 %
     \chardef     \charzero     =0 %

--- a/base/ltoutenc.dtx
+++ b/base/ltoutenc.dtx
@@ -37,14 +37,14 @@
 %<TS1>\ProvidesFile{ts1enc.def}[2001/06/05 v3.0e (jk/car/fm)
 %<TU>\ProvidesFile{tuenc.def}
 %<package>\ProvidesPackage{fontenc}
-%<OT1|T1|OMS|OML|OT4|TU|package> [2020/04/22 v2.0p
+%<OT1|T1|OMS|OML|OT4|TU|package> [2020/08/10 v2.0s
 %<OT1|T1|OMS|OML|OT4|TS1|TU>      Standard LaTeX file]
 %<package>                        Standard LaTeX package]
 %
 %<*driver>
 % \fi
 \ProvidesFile{ltoutenc.dtx}
-             [2020/07/21 v2.0r LaTeX Kernel (font encodings)]
+             [2020/08/10 v2.0s LaTeX Kernel (font encodings)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltoutenc.dtx}
@@ -2900,12 +2900,6 @@
       }
     \else
       \newluafunction\@remove@tlig@@@@
-%    \end{macrocode}
-% We are in the format and Lua functions can not be dumped, so we have to repeat
-% the code during |\everyjob|. Therefore we first define a helper to both execute
-% some code and same it for |\everyjob|:
-%    \begin{macrocode}
-      \def\now@and@everyjob#1{\toksapp\everyjob{#1}#1}
 %    \end{macrocode}
 % Now we can define the function. Mostly we just have to insert a protected glyph
 % node, which is a glyph node with subtype 256. But we have to keep track of the


### PR DESCRIPTION
Load ltluatex's Lua module during format building to make the luatexbase available. (The main motivation is to allow expl3 to rely on having the allocators available from Lua)

The `\now@and@everyjob` helper could also be moved into the generic part and then reused in `ltvers.dtx`, but there the everyjob and the immediate code are slightly different for reasons I do not see, so I kept them for now.

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added -- No observable difference intended outside of iniTeX
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` updated
