### PR TITLE
Lua callback for shipout box preparation

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,11 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 ================================================================================
 
+2021-01-22  Marcel Krüger  <Marcel.Krueger@latex-project.org>
+
+	* ltshipout.dtx:
+	Define and call Lua callback pre_shipout_filter.
+
 2021-01-19  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 
 	* ltshipout.dtx: Reordered execution of shipout hooks so that code

--- a/base/doc/ltnews33.tex
+++ b/base/doc/ltnews33.tex
@@ -139,6 +139,17 @@ the name. The coding has now been slightly altered to allow for this.
 \githubissue{427}
 
 
+\subsection{Add a Lua callback to ltshipout to provide a uniform location for applying custom attributes}
+
+Just before shipping out a page, a new \LuaTeX{} callback
+``\texttt{pre\_shipout\_filter}'' is now called to allow final
+adjustments to the box to be shipped out. This is particularly for
+Lua\TeX\ packages which flag certain elements of the page (e.g. using
+attributes or properties) in order to apply certain effects to these
+elements at shipout. An example for this is the \pkg{luacolor}
+package which could insert the color commands using this callback.
+
+
 
 \subsection{Provide hook in \cs{selectfont}}
 

--- a/base/ltshipout.dtx
+++ b/base/ltshipout.dtx
@@ -364,7 +364,7 @@
 %
 %
 %
-% \subsection{Provided Lua\Tex\ callbacks}
+% \subsection{Provided Lua\TeX\ callbacks}
 % 
 %  \begin{variable}{pre_shipout_filter}
 %    Under Lua\TeX, additionally the \texttt{pre_shipout_filter} callback is

--- a/base/ltshipout.dtx
+++ b/base/ltshipout.dtx
@@ -363,6 +363,20 @@
 %    names as given below.
 %
 %
+%
+% \subsection{Provided Lua\Tex\ callbacks}
+% 
+%  \begin{variable}{pre_shipout_filter}
+%    Under Lua\TeX, additionally the \texttt{pre_shipout_filter} callback is
+%    provided. The signature is
+%    \begin{verbatim}
+%     function(<node> head)
+%       return true | false | <node> newhead
+%     end
+%    \end{verbatim}
+%    This callback is invoked after all \TeX-level hooks described above.
+%  \end{variable}
+%
 % \subsection{Information counters}
 %
 %
@@ -691,6 +705,33 @@
 %  \end{macro}
 %
 %
+%  \begin{macro}{\@@_finalize_box:}
+%    For Lua\TeX{} invoke the \texttt{pre\_shipout\_filter} callback.
+%    \begin{macrocode}
+\sys_if_engine_luatex:TF
+  {
+    \newluafunction \@@_finalize_box:
+    \exp_args:Nx \everyjob {
+      \exp_not:V \everyjob
+      \exp_not:N \lua_now:n {
+        luatexbase.create_callback('pre_shipout_filter', 'list')
+        local~call, getbox, setbox = luatexbase.call_callback, tex.getbox, tex.setbox~
+        lua.get_functions_table()[\the \@@_finalize_box:] = function()
+          local~result = call('pre_shipout_filter', getbox(\the \l_shipout_box))
+          if~not (result == true) then~
+            setbox(\the \l_shipout_box, result~or~nil)
+          end~
+        end
+      }
+    }
+    \protected \luadef \@@_finalize_box: \the \@@_finalize_box:
+  } {
+    \cs_set_eq:NN \@@_finalize_box: \scan_stop:
+  }
+%    \end{macrocode}
+%  \end{macro}
+%
+%
 %  \begin{macro}{\@@_execute:}
 %    This is going to the be the code run by \cs{shipout}. The code
 %    follows closely the  ideas from \pkg{atbegshi}, so not
@@ -941,6 +982,7 @@
                     }
                     \bool_gset_true:N \g_@@_lastpage_handled_bool
                 }
+              \@@_finalize_box:
 %    \end{macrocode}
 %    Finally we run the actual \TeX{} primitive for shipout. As that will
 %    expand delayed \cs{write} statements inside the page in which

--- a/base/ltshipout.dtx
+++ b/base/ltshipout.dtx
@@ -32,8 +32,8 @@
 %%% From File: ltshipout.dtx
 %
 %    \begin{macrocode}
-\providecommand\ltshipoutversion{v1.0h}
-\providecommand\ltshipoutdate{2021/01/19}
+\providecommand\ltshipoutversion{v1.0i}
+\providecommand\ltshipoutdate{2021/01/22}
 %    \end{macrocode}
 %
 %<*driver>
@@ -367,14 +367,16 @@
 % \subsection{Provided Lua\TeX\ callbacks}
 % 
 %  \begin{variable}{pre_shipout_filter}
-%    Under Lua\TeX, additionally the \texttt{pre_shipout_filter} callback is
-%    provided. The signature is
+%    Under Lua\TeX{} the \texttt{pre\_shipout\_filter} Lua callback is
+%    provided which gets called immediately before the shipout primitive gets invoked.
+%    The signature is
 %    \begin{verbatim}
 %     function(<node> head)
-%       return true | false | <node> newhead
+%       return true
 %     end
 %    \end{verbatim}
-%    This callback is invoked after all \TeX-level hooks described above.
+%    The \texttt{head} is the list node corresponding to the box to be shipped out.
+%    The return value should always be \texttt{true}.
 %  \end{variable}
 %
 % \subsection{Information counters}
@@ -707,6 +709,7 @@
 %
 %  \begin{macro}{\@@_finalize_box:}
 %    For Lua\TeX{} invoke the \texttt{pre\_shipout\_filter} callback.
+%  \changes{v1.0i}{2021/01/22}{Add \texttt{pre\_shipout\_filter} Lua callback}
 %    \begin{macrocode}
 \sys_if_engine_luatex:TF
   {

--- a/base/testfiles/tlb-callbacks-001.lvt
+++ b/base/testfiles/tlb-callbacks-001.lvt
@@ -15,6 +15,8 @@
 % current ltluatex user-callbacks
  expected_user_callbacks['pre_mlist_to_hlist_filter']=1
  expected_user_callbacks['post_mlist_to_hlist_filter']=1
+%
+ expected_user_callbacks['pre_shipout_filter']=1
 % curent luaotfload user-callbacks
  expected_user_callbacks['luaotfload.patch_font_unsafe']=1
  expected_user_callbacks['luaotfload.resolve_font']=1


### PR DESCRIPTION
A Lua callback which can be used for luacolor and similar code to apply changes indicated using Attributes directly before shipout, making sure that even content added in hooks is picked up.

Uses ltluatex's callback functionality instead of a TeX hook in order to be usable from Lua code. Currently no sorting is supported (well luatexbase adds a priority system, but that's rarely usable in practice) but this coul be added more generally to the callback system.

Lua code can use this with `luatexbase.add_to_callback('pre_shipout_filter', ...)`, e.g.

```
luatexbase.add_to_callback('pre_shipout_filter', function(head)
  -- Do something with the list node passed in head
  print("Shipping out list node ", head)

  return true
end, 'my_pre_shipout_code')
```

# Internal housekeeping

## Status of pull request

- Feedback wanted 
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [x] `ltnewsX.tex` updated
