### PR TITLE
do not create backrefs if they don't exist (fixes part of #445)

### DIFF
--- a/base/source2edoc.cls
+++ b/base/source2edoc.cls
@@ -2,7 +2,7 @@
 % This class is buggy and needs fixing
 
 \ProvidesClass{source2edoc}
-              [2020/08/16 v0.1 Quick hack to typeset source2.tex
+              [2020/12/02 v0.2 Quick hack to typeset source2.tex
                (not usable for anything else and buggy -- will vanish again)!]
 
 \LoadClass{l3doc}
@@ -14,8 +14,43 @@
 
 
 
-% l3doc's def are buggy (already fixed there but not distributed yet)
+
 \ExplSyntaxOn
+
+% in 2e we have a lot of functions that have no ``user-level'' documentation so we disable
+% a bogus backref in that case. Over time the sources should be clean up to have such documentation.
+
+\cs_set_protected:Npn \__codedoc_print_documented:
+  {
+    \seq_gset_filter:NNn \g__codedoc_nested_names_seq
+      \g__codedoc_nested_names_seq
+      { ! \__codedoc_if_macro_internal_p:n {##1} }
+    \seq_if_empty:NF \g__codedoc_nested_names_seq
+      {
+% This is a crude change: we grab the first name
+        \__codedoc_get_hyper_target:xN
+          { \seq_item:Nn \g__codedoc_nested_names_seq { 1 } }
+          \l__codedoc_tmpa_tl
+% ... and check if it has a reference
+        \cs_if_exist:cT{ r@\l__codedoc_tmpa_tl }
+% If it does we show it, if not we don't.
+         {
+           \int_set:Nn \l__codedoc_tmpa_int
+             { \seq_count:N \g__codedoc_nested_names_seq }
+           \int_compare:nNnTF \l__codedoc_tmpa_int = 1 {~This~} {~These~}
+           \bool_if:NTF \l__codedoc_macro_var_bool {variable} {function}
+           \int_compare:nNnTF \l__codedoc_tmpa_int = 1 {~is~} {s~are~}
+           documented~on~page~
+           \exp_args:Nx \pageref { \l__codedoc_tmpa_tl } .
+         }
+      }
+    \seq_gclear:N \g__codedoc_nested_names_seq
+  }
+
+
+  
+% some l3doc's def are buggy (already fixed there but not distributed yet)
+
 \RenewDocumentCommand \DocInclude { m }
   {
     \relax\clearpage


### PR DESCRIPTION
# Internal housekeeping

This only drops non-existent backrefs, over time missing documentation should be added instead so this issue should stay open on "long-term"

## Status of pull request
- Ready to merge

## Checklist of required changes before merge will be approved
- [n/a] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [n/a] Relevant `changes.txt` updated
- [n/a] `ltnewsX.tex` updated
