### PR TITLE
[base/config-filenames.lua] Fix `checkengines` table

### DIFF
--- a/base/config-filenames.lua
+++ b/base/config-filenames.lua
@@ -1,5 +1,5 @@
 -- Tests for non Unicode engines
 
-checkengines = {"pdftex,"xetex","luatex""}
+checkengines = {"pdftex","xetex","luatex"}
 checksearch  = false
 testfiledir  = "testfiles-filenames"


### PR DESCRIPTION
Unbalanced quotes, as per https://www.lua.org/pil/3.6.html they need to be balanced, and you probably want this balancing (assumed typo).

# Internal housekeeping

## Status of pull request

- Ready to merge