### PR TITLE
add missing default to quiet key

### DIFF
--- a/required/graphics/changes.txt
+++ b/required/graphics/changes.txt
@@ -8,6 +8,11 @@ are not part of the distribution.
 All changes above are only part of the development branch for the next release.
 ================================================================================
 
+2020-12-05 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
+
+	* graphics.dtx: fix missing default in quiet key.
+
+
 #########################
 # 2020-10-01 Release
 #########################

--- a/required/graphics/graphicx.dtx
+++ b/required/graphics/graphicx.dtx
@@ -17,7 +17,7 @@
 %<driver> \ProvidesFile{graphicx.drv}
 % \fi
 %         \ProvidesFile{graphicx.dtx}
-          [2020/09/09 v1.2b  Enhanced LaTeX Graphics (DPC,SPQR)]
+          [2020/12/05 v1.2c  Enhanced LaTeX Graphics (DPC,SPQR)]
 %
 % \iffalse
 %<*driver>
@@ -507,9 +507,10 @@
 %
 % \begin{key}{Gin}{quiet}
 % \changes{v1.1a}{2017/06/01}{New quiet key}
+% \changes{v1.2c}{2020/12/05}{fix missing default value}
 %   Skip writing to the log.
 %    \begin{macrocode}
-\define@key{Gin}{quiet}{%
+\define@key{Gin}{quiet}[]{%
   \let\Gin@log\@gobble
 }
 %    \end{macrocode}


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

## Status of pull request

- Ready to merge

Reference: https://tex.stackexchange.com/questions/573738/problem-with-keys-in-graphicx-package-keyval-error-no-value-specified-for
It is broken since 2017, when the key was moved from pdftex.def to graphicx. So I don't think that it is needed to go to master. 

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added (no, don't think it is needed?)
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` updated


