### PR TITLE
Gh516

### DIFF
--- a/base/doc/ltnews33.tex
+++ b/base/doc/ltnews33.tex
@@ -461,6 +461,16 @@ and \cs{texthorizontalbar}, respectively.
 
 \section{Changes to packages in the \pkg{graphics} category}
 
+\subsection{Removed spurious warning for generic graphics rules}
+
+A previous release mistakenly caused a warning to appear when loading a graphics
+file with an unknown extension through a generic graphics rule.  The warning
+would incorrectly say that the file was not found, whereas the file would be
+included correctly.  The warning now doesn't show up in that case.
+%
+\githubissue{516}
+
+
 \subsection{\ldots}
 
 %

--- a/required/graphics/changes.txt
+++ b/required/graphics/changes.txt
@@ -4,6 +4,10 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 =======================================================================
 
+2021-03-03  Phelype Oleinik  <phelype.oleinik@latex-project.org>
+
+	* graphics.dtx: Avoid warning when loading a file using a generic rule (gh/516).
+
 ================================================================================
 All changes above are only part of the development branch for the next release.
 ================================================================================

--- a/required/graphics/graphics.dtx
+++ b/required/graphics/graphics.dtx
@@ -27,7 +27,7 @@
 %<driver> \ProvidesFile{graphics.drv}
 % \fi
 %         \ProvidesFile{graphics.dtx}
-          [2020/08/30 v1.4d  Standard LaTeX Graphics (DPC,SPQR)]
+          [2021/03/03 v1.4d  Standard LaTeX Graphics (DPC,SPQR)]
 %
 % \iffalse
 %<*driver>

--- a/required/graphics/graphics.dtx
+++ b/required/graphics/graphics.dtx
@@ -27,7 +27,7 @@
 %<driver> \ProvidesFile{graphics.drv}
 % \fi
 %         \ProvidesFile{graphics.dtx}
-          [2020/08/30 v1.4c  Standard LaTeX Graphics (DPC,SPQR)]
+          [2020/08/30 v1.4d  Standard LaTeX Graphics (DPC,SPQR)]
 %
 % \iffalse
 %<*driver>
@@ -1148,14 +1148,17 @@
 %     {Try adding an extension even if the filename had a dot AND
 %      if the filename without the extension exists (but doesn't have
 %      a known extension).}
+% \changes{v1.4d}{2021/03/03}
+%     {Avoid warning when loading a file using a generic rule.}
 %    \begin{macrocode}
     \ifnum0%
         \ifx\Gin@ext\relax 1%
         \else \@ifundefined{Gin@rule@\Gin@ext}{1}{0}%
         \fi >0
-      \let\Gin@ext\relax
+      \let\Gin@extsaved\Gin@ext
       \let\Gin@savedbase\filename@base
       \let\Gin@savedext\filename@ext
+      \let\Gin@ext\relax
       \edef\filename@base{\filename@base\Gin@sepdefault\filename@ext}%
       \let\filename@ext\relax
       \@for\Gin@temp:=\Gin@extensions\do{%
@@ -1166,6 +1169,7 @@
 % Restore if no file found using the known extensions.
 %    \begin{macrocode}
       \ifx\Gin@ext\relax
+        \let\Gin@ext\Gin@extsaved
         \let\filename@base\Gin@savedbase
         \let\filename@ext\Gin@savedext
       \fi

--- a/required/graphics/testfiles/github-0516.lvt
+++ b/required/graphics/testfiles/github-0516.lvt
@@ -1,0 +1,30 @@
+%
+% https://tug.org/pipermail/tex-live/2021-March/046525.html
+%
+\input{regression-test}
+\begin{filecontents}[overwrite]{graph-test.1}
+%!PS
+%%BoundingBox: -1 -1 29 29 
+%%Page: 1 1
+newpath
+0 0 moveto
+29 0 lineto
+29 29 lineto
+0 29 lineto
+closepath stroke
+showpage
+%%EOF
+\end{filecontents}
+\RequirePackage{graphics}
+
+\START
+
+\DeclareGraphicsRule{*}{eps}{*}{}
+\sbox0{\includegraphics{graph-test.1}}
+
+\tracingonline=1
+\showboxdepth10
+\showboxbreadth10
+\showbox0
+
+\END

--- a/required/graphics/testfiles/github-0516.tlg
+++ b/required/graphics/testfiles/github-0516.tlg
@@ -1,0 +1,11 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+LaTeX Warning: File `graph-test.1' not found on input line ....
+File: graph-test.1 Graphic file (type eps)
+<graph-test.1>
+> \box...=
+\hbox(30.11249+0.0)x30.11249
+.\hbox(30.11249+0.0)x30.11249
+..\special{PSfile="graph-test.1" llx=-1 lly=-1 urx=29 ury=29 rwi=300 }
+! OK.
+l. ...\showbox0

--- a/required/graphics/testfiles/github-0516.tlg
+++ b/required/graphics/testfiles/github-0516.tlg
@@ -1,6 +1,5 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-LaTeX Warning: File `graph-test.1' not found on input line ....
 File: graph-test.1 Graphic file (type eps)
 <graph-test.1>
 > \box...=

--- a/required/graphics/testfiles/github-0516.xetex.tlg
+++ b/required/graphics/testfiles/github-0516.xetex.tlg
@@ -1,0 +1,10 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+File: graph-test.1 Graphic file (type eps)
+<graph-test.1>
+> \box...=
+\hbox(30.11249+0.0)x30.11249
+.\hbox(30.11249+0.0)x30.11249
+..\special{PSfile="graph-test.1" llx=0 lly=0 urx=30 ury=30 rwi=300 }
+! OK.
+l. ...\showbox0


### PR DESCRIPTION
This PR fixes #516: A change to `graphics.dtx` introduced a spurious warning when loading a file through the default graphics rule.

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [x] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [x] `ltnewsX.tex` updated
