### PR TITLE
Normalize shift of null delimiters in LuaTeX tests

### DIFF
--- a/build-config.lua
+++ b/build-config.lua
@@ -37,7 +37,7 @@ checksuppfiles = checksuppfiles     or
     "lualibs*.lua", 
     "fontloader*.lua",
     "luaotfload*.lua",
-    "luaotfloat.sty"
+    "fixup_mathaxis.lua",
   }
 stdengine      = stdengine          or "etex"
 tagfiles       = tagfiles or {"*.dtx","*.ins","*.tex","README.md"}

--- a/support/fixup_mathaxis.lua
+++ b/support/fixup_mathaxis.lua
@@ -1,0 +1,14 @@
+local hlist_id = node.id'hlist'
+local vlist_id = node.id'vlist'
+local function recurse(h)
+  for n, id, sub in node.traverse(h) do
+    if id == hlist_id or id == vlist_id then
+      if sub == 13 and (not n.head) and n.shift == 0 then
+        n.shift = -tex.getmath("axis", "text")
+      end
+      recurse(n.head)
+    end
+  end
+  return true
+end
+luatexbase.add_to_callback('post_mlist_to_hlist_filter', recurse, 'l3build.shift')

--- a/support/regression-test.tex
+++ b/support/regression-test.tex
@@ -174,6 +174,9 @@
       >>
   }
 \fi
+\ifx\directlua\@undefined\else
+  \directlua{require'fixup_mathaxis'}%
+\fi
 \reset@catcodes
 %% 
 %%

--- a/support/test2e.tex
+++ b/support/test2e.tex
@@ -277,6 +277,7 @@ else
 end
 }
 %\fi
+\directlua{require'fixup_mathaxis'}%
 \fi
 
 % Load the map file early so it does not appear in the log.


### PR DESCRIPTION
*Pull requests in this repository are intended for LaTeX Team members only.*

Avoids differences in test files caused by LuaTeX not shifting empty boxes for missing delimiters.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` updated
