### PR TITLE
Ensure the macro can safely expand before calling \@if@newcommand

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,11 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 ================================================================================
 
+2021-07-20  Phelype Oleinik  <phelype.oleinik@latex-project.org>
+
+	* ltcmdhooks.dtx:
+	Fix usage of \@if@newcommand when patching a robust command (gh/623).
+
 2021-07-16  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 
 	* ltplain.dtx (section{Plain \TeX}):

--- a/base/ltcmdhooks.dtx
+++ b/base/ltcmdhooks.dtx
@@ -13,8 +13,8 @@
 %
 %%% From File: ltcmdhooks.dtx
 %
-\def\ltcmdhooksversion{v1.0b}
-\def\ltcmdhooksdate{2021/05/26}
+\def\ltcmdhooksversion{v1.0c}
+\def\ltcmdhooksdate{2021/07/20}
 %
 %
 %
@@ -592,17 +592,28 @@
 %
 %   With \cs{@@_patch_DeclareRobustCommand:Nnn} we check if the command
 %   has an optional argument (with a test counter-intuitively called
-%   \tn{@if@newcommand}).  If so, we forward the action to
-%   \cs{@@_patch_newcommand:Nnn}, otherwise call the patching engine
+%   \tn{@if@newcommand}; also make sure the command doesn't take args by
+%   calling \cs{robust@command@chk@safe}).  If so, we forward the action
+%   to \cs{@@_patch_newcommand:Nnn}, otherwise call the patching engine
 %   \cs{@@_patch_expand_redefine:NNnn} with a \cs{c_false_bool} to
 %   indicate that there is no optional argument.
+%
+%   \changes{v1.0c}{2021/07/20}
+%           {Use \cs{robust@command@chk@safe} before \cs{@if@newcommand}.}
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_patch_DeclareRobustCommand:Nnn #1
   {
-    \exp_args:Nc \@if@newcommand { \cs_to_str:N #1 ~ }
-      { \exp_args:Nc \@@_patch_newcommand:Nnn }
-      { \exp_args:NNc \@@_patch_expand_redefine:NNnn \c_false_bool }
-        { \cs_to_str:N #1 ~ }
+    \exp_args:Nc \@@_patch_DeclareRobustCommand_aux:Nnn
+      { \cs_to_str:N #1 ~ }
+  }
+\cs_new_protected:Npn \@@_patch_DeclareRobustCommand_aux:Nnn #1
+  {
+    \robust@command@chk@safe #1
+      { \@if@newcommand #1 }
+      { \use_ii:nn }
+        { \@@_patch_newcommand:Nnn }
+        { \@@_patch_expand_redefine:NNnn \c_false_bool }
+          #1
   }
 %    \end{macrocode}
 % \end{macro}

--- a/base/testfiles-lthooks/ltcmdhooks-012.lvt
+++ b/base/testfiles-lthooks/ltcmdhooks-012.lvt
@@ -1,0 +1,18 @@
+\RequirePackage[enable-debug,check-declarations]{expl3}
+\ExplSyntaxOn
+\debug_on:n { deprecation }
+\ExplSyntaxOff
+
+\input{regression-test}
+
+\csname __hook_cmd_begindocument_code:\endcsname
+
+\START
+
+\DeclareRobustCommand\blub[2]{{\typeout{(#1/#2)}}}
+
+\AddToHook{cmd/blub/before}[X]{\typeout{X}}
+
+\blub{1}{2}
+
+\END

--- a/base/testfiles-lthooks/ltcmdhooks-012.tlg
+++ b/base/testfiles-lthooks/ltcmdhooks-012.tlg
@@ -1,0 +1,4 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+X
+(1/2)


### PR DESCRIPTION
Fixes #623

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [x] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [n/a] `ltnewsX.tex` (and/or `latexchanges.tex`) updated&mdash;bug fix
