### PR TITLE
Use OpenType version of Latin Modern Upright

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -27,6 +27,11 @@ are not part of the distribution.
 	* ltfiles.dtx (section{File Handling}):
 	Make include/.../name one-time hooks (gh/626)
 
+2021-07-23  Marcel Krüger  <marcel.krueger@latex-project.org>
+
+	* tulm.fdd:
+	For Unicode engines, use OpenType version of Latin Modern Upright Italic.
+
 2021-07-20  Phelype Oleinik  <phelype.oleinik@latex-project.org>
 
 	* ltcmdhooks.dtx:

--- a/base/doc/ltnews34.tex
+++ b/base/doc/ltnews34.tex
@@ -258,6 +258,12 @@ will work without needing \verb|\DeclareUnicodeCharacter| declarations.
 \githubissue{593}
 
 
+\subsection{Use OpenType version of Latin Modern Upright Italic}
+When Latin Modern is used with the TU encoding under \XeTeX\ or \LuaTeX\
+and fontshape \texttt{ui} is requested, \LaTeX\ now uses the OpenType
+version instead of substituting the (T1 encoded) Type 1 version.
+
+
 \subsection{Pick up all arguments to \cs{contentsline}}
 
 The \cs{contentsline} commands in the TOC file are always followed by

--- a/base/tulm.fdd
+++ b/base/tulm.fdd
@@ -1,6 +1,6 @@
 % \iffalse meta-comment
 %
-% Copyright 2016-2019
+% Copyright 2016-2021
 % The LaTeX Project and any individual authors listed elsewhere
 % in this file.
 %
@@ -30,7 +30,7 @@
 %\iffalse        This is a META comment
 %
 % File `cmfonts.fdd'.
-% Copyright (C) 2016-2019 LaTeX Project
+% Copyright (C) 2016-2021 LaTeX Project
 %
 %
 %<TUlmr>\ProvidesFile{tulmr.fd}
@@ -42,7 +42,7 @@
 %<*driver>
              \ProvidesFile{tulm.drv}
 %</driver>
-        [2017/01/26 v1.8 Standard LaTeX font definitions for Latin Modern]
+        [2021/07/23 v1.8a Standard LaTeX font definitions for Latin Modern]
 %
 %<*driver>
 \documentclass{ltxdoc}
@@ -63,6 +63,7 @@
 %\fi
 %
 % \section{TUlmr}
+% \changes{v1.8a}{2021/07/23}{Use OpenType font for TU/lmr/m/ui}
 %    \begin{macrocode}
 %<*TUlmr>
 \DeclareFontFamily{TU}{lmr}{}
@@ -93,7 +94,7 @@
 \DeclareFontShape{TU}{lmr}{m}{sc}%
   {<-> \UnicodeFontFile{lmromancaps10-regular}{\UnicodeFontTeXLigatures}}{}
 \DeclareFontShape{TU}{lmr}{m}{ui}%
-  {<-> ec-lmu10}{}
+  {<-> \UnicodeFontFile{lmromanunsl10-regular}{\UnicodeFontTeXLigatures}}{}
 \DeclareFontShape{TU}{lmr}{m}{scsl}%
   {<-> \UnicodeFontFile{lmromancaps10-oblique}{\UnicodeFontTeXLigatures}}{}
 \DeclareFontShape{TU}{lmr}{b}{n}


### PR DESCRIPTION
*Pull requests in this repository are intended for LaTeX Team members only.*

For some (I guess historic) reason, LaTeX uses the Type 1 version of LM Upright Italic even for the TU encoding.
Beside being inconsistent and missing many characters, this also isn't encoded correctly.
Let's use the OpenType version instead.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [x] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
