### PR TITLE
fix for #640

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,11 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 ================================================================================
 
+2021-08-08  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
+
+	* ltfinal.dtx (subsection{Prepare for suporting PDF management in backends}):
+	Default definition for \IfPDFManagementActiveTF added (gh/640)
+
 2021-07-31  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 
 	* ltoutput.dtx (subsubsection{Float control}):

--- a/base/ltfinal.dtx
+++ b/base/ltfinal.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltfinal.dtx}
-             [2021/04/18 v2.2o LaTeX Kernel (Final Settings)]
+             [2021/08/08 v2.2p LaTeX Kernel (Final Settings)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltfinal.dtx}
@@ -1244,6 +1244,38 @@
 % \end{macro}
 % \end{macro}
 %
+%  \subsection{Prepare for suporting PDF management in backends}
+%
+%    At the current point in time support for PDF management in
+%    backends is not part of \LaTeX{} core but provided by external.
+%    packages. At some time in the future that work will be placed
+%    into the kernel but for now it is separate and has to be
+%    explicitly loaded in the document.
+%
+%    There is a command \cs{IfPDFManagementActiveTF} in that code
+%    which checks if the PDF management code is activated, which can
+%    be used by packages to execute different code branches depending
+%    on the state.
+%
+%    To make this also work properly if the external package is not
+%    loaded at all this command is already made available in the
+%    kernel (with a trivial definition) so that other packages can
+%    query the state in a circumstances.  Once the PDF management
+%    support moves to the kernel this definition here will vanish
+%    again or rather will be replaced by a real test.
+%
+% 
+%  \begin{macro}{\IfPDFManagementActiveTF}
+%    While the PDF management code is not loaded, the test will
+%    alsways return the false branch. Once this code is loaded, it
+%    is replaced by a real test (as then it is possible that the
+%    management code is activate or not activated).
+% \changes{v2.2p}{2021/08/08}{Default definition added (gh/640)}
+%    \begin{macrocode}
+\let \IfPDFManagementActiveTF \@secondoftwo
+%    \end{macrocode}
+%  \end{macro}
+%
 %
 %
 % \subsection{Do some temporary work for pre-release}
@@ -1253,7 +1285,7 @@
 %    \begin{macrocode}
 %    \end{macrocode}
 %
-%    \subsection{Some last minute initializations \ldots}
+% \subsection{Some last minute initializations \ldots}
 %
 %    Load the first aid set of definitions for external packages that await updates.
 % \changes{v2.2j}{2020/09/26}

--- a/base/ltfinal.dtx
+++ b/base/ltfinal.dtx
@@ -1244,10 +1244,10 @@
 % \end{macro}
 % \end{macro}
 %
-%  \subsection{Prepare for suporting PDF management in backends}
+%  \subsection{Prepare for supporting PDF management in backends}
 %
 %    At the current point in time support for PDF management in
-%    backends is not part of \LaTeX{} core but provided by external.
+%    backends is not part of \LaTeX{} core but provided by external
 %    packages. At some time in the future that work will be placed
 %    into the kernel but for now it is separate and has to be
 %    explicitly loaded in the document.
@@ -1260,14 +1260,14 @@
 %    To make this also work properly if the external package is not
 %    loaded at all this command is already made available in the
 %    kernel (with a trivial definition) so that other packages can
-%    query the state in a circumstances.  Once the PDF management
+%    query the state in all circumstances.  Once the PDF management
 %    support moves to the kernel this definition here will vanish
 %    again or rather will be replaced by a real test.
 %
 % 
 %  \begin{macro}{\IfPDFManagementActiveTF}
 %    While the PDF management code is not loaded, the test will
-%    alsways return the false branch. Once this code is loaded, it
+%    always return the false branch. Once this code is loaded, it
 %    is replaced by a real test (as then it is possible that the
 %    management code is activate or not activated).
 % \changes{v2.2p}{2021/08/08}{Default definition added (gh/640)}


### PR DESCRIPTION
# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [n/a] Test file(s) added
- [x] Version and date string updated in changed source files
- [n/a] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [n/a] `ltnewsX.tex` (and/or `latexchanges.tex`) updated

This is only relevant for a few package developers so announcement in ltnews seems to be over the top
