### PR TITLE
Fix typo

### DIFF
--- a/required/amsmath/amsldoc.tex
+++ b/required/amsmath/amsldoc.tex
@@ -64,7 +64,7 @@ Bug reports can be opened (category \texttt{#1}) at\\%
 
 \title{User's Guide for the \nipkg{amsmath} Package (Version~2.1)}
 \author{American Mathematical Society, \LaTeX\ Project}
-\date{1999-12-13\\(revised 2002-02-25, 2016-11-14, 2018-04-05, 2019-10-14, 2020-02-18)}
+\date{1999-12-13\\(revised 2002-02-25, 2016-11-14, 2018-04-05, 2019-10-14, 2020-02-18, 2021-08-22)}
 \makeatletter
 \def\@thanks{\bigskip\MaintainedByLaTeXTeam{amslatex}}
 \makeatother
@@ -1616,7 +1616,7 @@ bar symbols:
 \end{verbatim}
 whereupon the document would contain |\abs{z}| to produce $\lvert
 z\rvert$ and |\norm{v}| to produce $\lVert v\rVert$.
-The \pkg{mathools} provides the command \cn{DeclarePairedDelimiter}
+The \pkg{mathtools} provides the command \cn{DeclarePairedDelimiter}
 for defining |\abs|-like macros with scaling delimiters.
 \index{delimiters|)}
 


### PR DESCRIPTION
The file `amsldoc.tex` contains the typo `mathools`.