### PR TITLE
guard refstepcounter with mathopen, issue #652

### DIFF
--- a/required/amsmath/amsmath.dtx
+++ b/required/amsmath/amsmath.dtx
@@ -86,7 +86,7 @@ Bug reports can be opened (category \texttt{#1}) at\\%
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\ProvidesPackage{amsmath}[2021/07/08 v2.17j AMS math features]
+\ProvidesPackage{amsmath}[2021/08/24 v2.17k AMS math features]
 %    \end{macrocode}
 %
 % \section{Catcode defenses}
@@ -3194,10 +3194,11 @@ ill-advised in LaTeX.%
   \global\@eqnswfalse
 }
 %    \end{macrocode}
-%
+%\changes{v2.17k}{2021/08/24}{Guard the refstepcounter with a mathopen for better
+% compability with hyperref, issue gh/652}
 %    \begin{macrocode}
 \def\print@eqnum{\tagform@\theequation}
-\def\incr@eqnum{\refstepcounter{equation}\let\incr@eqnum\@empty}
+\def\incr@eqnum{\refstepcounter{equation}\ifmmode\mathopen{}\fi\let\incr@eqnum\@empty}
 %    \end{macrocode}
 %  \end{macro}
 %

--- a/required/amsmath/changes.txt
+++ b/required/amsmath/changes.txt
@@ -2,6 +2,11 @@
 All changes above are only part of the development branch for the next release.
 ================================================================================
 
+2021-08-24 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
+	* amsmath.dtx (subsection{Implementing tags and labels}):
+	Guard the refstepcounter in \incr@eqnum with a mathopen for better
+    compability with hyperref, issue gh/652
+
 #########################
 # 2021-06-01 Release
 #########################


### PR DESCRIPTION

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added (I don't know how to make a sensible test file without hyperref)
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated (no sure if needed?)
