### PR TITLE
fix for #658

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,11 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 ================================================================================
 
+2021-09-06  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
+
+	* ltfinal.dtx (subsection{Lccodes and uccodes}):
+	Correctly upper and lowercase \ij and \IJ (gh/658)
+
 2021-08-30  Phelype Oleinik  <phelype.oleinik@latex-project.org>
 
 	* lthooks.dtx (subsection{Using the hook}):

--- a/base/doc/ltnews34.tex
+++ b/base/doc/ltnews34.tex
@@ -541,6 +541,31 @@ will now correctly apply \cs{TrimSpaces} to both arguments.
 
 
 
+\subsection{Correct case changes for \cs{ij} and \cs{IJ}}
+
+
+The the ligatures \enquote{\ij} and \enquote{\IJ}, as used in Dutch,
+are only available in most \TeX{} fonts, if the commands \cs{ij} or
+\cs{IJ} are used or when you enter them as UTF-8 characters U+0133 or
+U+0132.
+%
+However, when using \texttt{OT1} or \texttt{T1} encoded fonts in
+\pdfTeX, the upper or lower casing with \cs{MakeUppercase} and
+\cs{MakeLowercase} would always fail regardless of the input method.
+This has now been corrected.
+%
+\githubissue{658}
+
+
+\subsection{???}
+
+%
+\githubissue{000}
+
+
+
+
+
 
 \section{Changes to packages in the \pkg{graphics} category}
 

--- a/base/doc/ltnews34.tex
+++ b/base/doc/ltnews34.tex
@@ -544,7 +544,7 @@ will now correctly apply \cs{TrimSpaces} to both arguments.
 \subsection{Correct case changes for \cs{ij} and \cs{IJ}}
 
 
-The the ligatures \enquote{\ij} and \enquote{\IJ}, as used in Dutch,
+The ligatures \enquote{\ij} and \enquote{\IJ}, as used in Dutch,
 are only available in most \TeX{} fonts, if the commands \cs{ij} or
 \cs{IJ} are used or when you enter them as UTF-8 characters U+0133 or
 U+0132.

--- a/base/ltfinal.dtx
+++ b/base/ltfinal.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltfinal.dtx}
-             [2021/08/08 v2.2p LaTeX Kernel (Final Settings)]
+             [2021/09/06 v2.2q LaTeX Kernel (Final Settings)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltfinal.dtx}
@@ -1074,9 +1074,11 @@
    }}
 %    \end{macrocode}
 %
+% \changes{v2.2q}{2021/09/06}{Correctly upper and lowercase
+%                             \cs{ij} and \cs{IJ} (gh/658)}
 %    \begin{macrocode}
 \def\@uclclist{\oe\OE\o\O\ae\AE
-      \dh\DH\dj\DJ\l\L\ng\NG\ss\SS\th\TH}
+      \dh\DH\dj\DJ\l\L\ng\NG\ss\SS\ij\IJ\th\TH}
 %    \end{macrocode}
 %    The above code works, but has the nasty side-effect that if you
 %    say something like:

--- a/base/testfiles-legacy/github-0658.lvt
+++ b/base/testfiles-legacy/github-0658.lvt
@@ -1,0 +1,34 @@
+
+\documentclass{article}
+
+\input{test2e}
+
+\showoutput
+
+\begin{document}
+
+\START
+
+\MakeUppercase{\ij} \MakeLowercase{\IJ} % should print IJ ij
+
+\MakeUppercase{ĳ} \MakeLowercase{Ĳ}     % should also print IJ ij
+
+\bigskip
+
+\parbox{6pt}{a b \ij{} c d}  % this is wanted!
+
+\bigskip
+
+% same with T1
+
+\fontencoding{T1}\selectfont
+
+\MakeUppercase{\ij} \MakeLowercase{\IJ}  % should print IJ ij
+
+\MakeUppercase{ĳ} \MakeLowercase{Ĳ}      % should also print IJ ij
+
+\bigskip
+
+\parbox{6pt}{a b \ij{} c d}
+  
+\end{document}

--- a/base/testfiles-legacy/github-0658.tlg
+++ b/base/testfiles-legacy/github-0658.tlg
@@ -1,0 +1,219 @@
+This is a generated file for the LaTeX2e validation system.
+Don't change this file in any respect.
+Underfull \hbox (badness 10000) in paragraph at lines 18--18
+[]\OT1/cmr/m/n/10 a
+\hbox(4.30554+0.0)x6.0
+.\hbox(0.0+0.0)x0.0
+.\OT1/cmr/m/n/10 a
+.\glue(\rightskip) 0.0
+Underfull \hbox (badness 10000) in paragraph at lines 18--18
+\OT1/cmr/m/n/10 b
+\hbox(6.94444+0.0)x6.0
+.\OT1/cmr/m/n/10 b
+.\glue(\rightskip) 0.0
+Overfull \hbox (6.29997pt too wide) in paragraph at lines 18--18
+\OT1/cmr/m/n/10 ij c
+\hbox(6.67859+1.94444)x6.0, glue set - 1.0
+.\OT1/cmr/m/n/10 i
+.\kern -0.20004
+.\OT1/cmr/m/n/10 j
+.\penalty 10000
+.\glue 0.0
+.\glue 3.33333 plus 1.66666 minus 1.11111
+.\OT1/cmr/m/n/10 c
+.\glue(\rightskip) 0.0
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <7> on input line ....
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <5> on input line ....
+Underfull \hbox (badness 10000) in paragraph at lines 32--32
+[]\T1/cmr/m/n/10 a
+\hbox(4.3045+0.0)x6.0
+.\hbox(0.0+0.0)x0.0
+.\T1/cmr/m/n/10 a
+.\glue(\rightskip) 0.0
+Underfull \hbox (badness 10000) in paragraph at lines 32--32
+\T1/cmr/m/n/10 b
+\hbox(6.8872+0.0)x6.0
+.\T1/cmr/m/n/10 b
+.\glue(\rightskip) 0.0
+Underfull \hbox (badness 10000) in paragraph at lines 32--32
+\T1/cmr/m/n/10 ^^bc
+\hbox(6.63332+1.94397)x6.0
+.\T1/cmr/m/n/10 ^^bc
+.\glue(\rightskip) 0.0
+Underfull \hbox (badness 10000) in paragraph at lines 32--32
+\T1/cmr/m/n/10 c
+\hbox(4.3045+0.0)x6.0
+.\T1/cmr/m/n/10 c
+.\glue(\rightskip) 0.0
+Completed box being shipped out [1]
+\vbox(633.0+0.0)x407.0
+.\glue 16.0
+.\vbox(617.0+0.0)x345.0, shifted 62.0
+..\vbox(12.0+0.0)x345.0, glue set 12.0fil
+...\glue 0.0 plus 1.0fil
+...\hbox(0.0+0.0)x345.0
+....\hbox(0.0+0.0)x345.0
+..\glue 25.0
+..\glue(\lineskip) 0.0
+..\vbox(550.0+0.0)x345.0, glue set 378.5739fil
+...\write-{}
+...\glue(\topskip) 3.16669
+...\hbox(6.83331+1.94444)x345.0, glue set 312.48338fil
+....\hbox(0.0+0.0)x15.0
+....\glue 0.0
+....\OT1/cmr/m/n/10 I
+....\kern -0.20004
+....\OT1/cmr/m/n/10 J
+....\penalty 10000
+....\glue 0.0
+....\glue 3.33333 plus 1.66498 minus 1.11221
+....\penalty 10000
+....\glue 0.0
+....\OT1/cmr/m/n/10 i
+....\kern -0.20004
+....\OT1/cmr/m/n/10 j
+....\penalty 10000
+....\glue 0.0
+....\kern 0.0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty 10000
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 3.22224
+...\hbox(6.83331+1.94444)x345.0, glue set 312.48338fil
+....\hbox(0.0+0.0)x15.0
+....\glue 0.0
+....\OT1/cmr/m/n/10 I
+....\kern -0.20004
+....\OT1/cmr/m/n/10 J
+....\penalty 10000
+....\glue 0.0
+....\glue 3.33333 plus 1.66498 minus 1.11221
+....\penalty 10000
+....\glue 0.0
+....\OT1/cmr/m/n/10 i
+....\kern -0.20004
+....\OT1/cmr/m/n/10 j
+....\penalty 10000
+....\glue 0.0
+....\kern 0.0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue 12.0 plus 4.0 minus 4.0
+...\glue 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\lineskip) 1.0
+...\hbox(22.65277+17.65277)x345.0, glue set 324.0fil
+....\hbox(0.0+0.0)x15.0
+....\mathon
+....\vbox(22.65277+17.65277)x6.0
+.....\hbox(4.30554+0.0)x6.0
+......\hbox(0.0+0.0)x0.0
+......\OT1/cmr/m/n/10 a
+......\glue(\rightskip) 0.0
+.....\penalty 150
+.....\glue(\baselineskip) 5.05556
+.....\hbox(6.94444+0.0)x6.0
+......\OT1/cmr/m/n/10 b
+......\glue(\rightskip) 0.0
+.....\glue(\baselineskip) 5.32141
+.....\hbox(6.67859+1.94444)x6.0, glue set - 1.0
+......\OT1/cmr/m/n/10 i
+......\kern -0.20004
+......\OT1/cmr/m/n/10 j
+......\penalty 10000
+......\glue 0.0
+......\glue 3.33333 plus 1.66666 minus 1.11111
+......\OT1/cmr/m/n/10 c
+......\glue(\rightskip) 0.0
+.....\penalty 150
+.....\glue(\baselineskip) 3.11111
+.....\hbox(6.94444+0.0)x6.0, glue set 0.44443fil
+......\OT1/cmr/m/n/10 d
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+....\mathoff
+....\kern 0.0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue 12.0 plus 4.0 minus 4.0
+...\glue 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\lineskip) 1.0
+...\hbox(6.8872+1.94397)x345.0, glue set 312.22656fil
+....\hbox(0.0+0.0)x15.0
+....\T1/cmr/m/n/10 ^^9c
+....\glue 3.33252 plus 1.66458 minus 1.11194
+....\T1/cmr/m/n/10 ^^bc
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 3.16882
+...\hbox(6.8872+1.94397)x345.0, glue set 312.22656fil
+....\hbox(0.0+0.0)x15.0
+....\T1/cmr/m/n/10 ^^9c
+....\glue 3.33252 plus 1.66458 minus 1.11194
+....\T1/cmr/m/n/10 ^^bc
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue 12.0 plus 4.0 minus 4.0
+...\glue 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\lineskip) 1.0
+...\hbox(28.65225+23.65225)x345.0, glue set 324.0fil
+....\hbox(0.0+0.0)x15.0
+....\mathon
+....\vbox(28.65225+23.65225)x6.0
+.....\hbox(4.3045+0.0)x6.0
+......\hbox(0.0+0.0)x0.0
+......\T1/cmr/m/n/10 a
+......\glue(\rightskip) 0.0
+.....\penalty 150
+.....\glue(\baselineskip) 5.1128
+.....\hbox(6.8872+0.0)x6.0
+......\T1/cmr/m/n/10 b
+......\glue(\rightskip) 0.0
+.....\glue(\baselineskip) 5.36668
+.....\hbox(6.63332+1.94397)x6.0
+......\T1/cmr/m/n/10 ^^bc
+......\glue(\rightskip) 0.0
+.....\glue(\baselineskip) 5.75153
+.....\hbox(4.3045+0.0)x6.0
+......\T1/cmr/m/n/10 c
+......\glue(\rightskip) 0.0
+.....\penalty 150
+.....\glue(\baselineskip) 5.1128
+.....\hbox(6.8872+0.0)x6.0, glue set 0.4458fil
+......\T1/cmr/m/n/10 d
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0
+....\mathoff
+....\kern 0.0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue -5.0
+...\glue 0.0 plus 1.0fil
+...\glue 0.0
+...\glue 0.0 plus 0.0001fil
+..\glue(\baselineskip) 23.55556
+..\hbox(6.44444+0.0)x345.0
+...\hbox(6.44444+0.0)x345.0, glue set 170.0fil
+....\glue 0.0 plus 1.0fil
+....\OT1/cmr/m/n/10 1
+....\glue 0.0 plus 1.0fil
+(github-0658.aux)


### PR DESCRIPTION
# Internal housekeeping

## Status of pull request

This only implements the uc/lc handling because the nobreak in OT1 seems to be in the right place (it is a deficiency, but we know that OT1 is deficient) and it is better to prevent a break in a place where one would be allowed to allowing a break where it is definitely not right (e.g., between ij and a following punctuation). after all one can always add a `\allowbreak`but you can't undo an allowed break.

- Ready to merge

## Checklist of required changes before merge will be approved
- [x] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [x] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
