### PR TITLE
Add l3keys2e code as ltkeys

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -84,6 +84,11 @@ are not part of the distribution.
 
 	* All *.dtx: Replaced \StopEventually by \MaybeStop
 
+2021-11-26 Joseph Wright <joseph.wright@latex-project.org>
+
+  * ltkeys.dtx
+	New file to integrate keyval option processing into the kernel
+
 2021-11-17  Marcel Krüger  <Marcel.Krueger@latex-project.org>
 
 	* ltluatex.dtx:

--- a/base/changes.txt
+++ b/base/changes.txt
@@ -84,6 +84,11 @@ are not part of the distribution.
 
 	* All *.dtx: Replaced \StopEventually by \MaybeStop
 
+2021-11-30 Joseph Wright <joseph.wright@latex-project.org>
+
+  * ltclasses.dtx
+	New option handling routine using ltkeys
+
 2021-11-26 Joseph Wright <joseph.wright@latex-project.org>
 
   * ltkeys.dtx

--- a/base/doc/ltnews35.tex
+++ b/base/doc/ltnews35.tex
@@ -207,31 +207,31 @@ package options. This ability has now been integrated directly into the kernel.
 As part of this integration, the syntax for processing keyval options has been
 refined, such that
 \begin{verbatim}
-\ProcessKeysOptions
+\ProcessKeyOptions
 \end{verbatim}
 will now automatically pick up the package name as the key \emph{family}, which
 can otherwise be given as an optional argument
 \begin{verbatim}
-\ProcessKeysOptions[family]
+\ProcessKeyOptions[family]
 \end{verbatim}
 A version which does not consider global options,
-\cs{ProcessKeysPackageOptions}, is also available.
+\cs{ProcessKeyPackageOptions}, is also available.
 
 To support creating key options in for this mechanism, the new command
-\cs{DeclareKeysOptions} has been added. This works using the same general
+\cs{DeclareKeys} has been added. This works using the same general
 approach as \pkg{l3keys} or \pkg{pgfkeys}: each key has one or more
 \emph{properties} which define its behavior.
 
 Options for packages which use this new approach will not be checked for
 clashes by the kernel. Instead, each time a \cs{usepackage} or
 \cs{RequirePackage} line is encountered, the list of options given will be
-passed to \cs{ProcessKeysPackageOptions}. Options which can only be given
+passed to \cs{ProcessKeyPackageOptions}. Options which can only be given
 the first time a package is loaded can be marked using the property
 \texttt{.usage = load}, and will result in a warning if used in a subsequent
 package loading line.
 
 Package options defined in this way can also be set within a package using
-the new command \cs{SetKeysOptions}, which again takes an optional argument
+the new command \cs{SetKeys}, which again takes an optional argument
 to specify the \emph{family}, plus a mandatory one for the options themselves.
 
 \subsection{Floating point and integer calculations}

--- a/base/doc/ltnews35.tex
+++ b/base/doc/ltnews35.tex
@@ -202,15 +202,15 @@ instead. To-date, this has required the use of additional packages, for example
 \pkg{kvoptions}.
 
 The \LaTeX{} team have for some time offered the package \pkg{l3keys2e} to
-allow keyvals defined using the \pkg{expl3} module \pkg{l3keys} to act as
-package options. This ability has now been integrated directly into the kernel.
-As part of this integration, the syntax for processing keyval options has been
-refined, such that
+allow keyvals defined using the L3 programming layer module \pkg{l3keys} to act
+as package options. This ability has now been integrated directly into the
+kernel. As part of this integration, the syntax for processing keyval options
+has been refined, such that
 \begin{verbatim}
 \ProcessKeyOptions
 \end{verbatim}
-will now automatically pick up the package name as the key \emph{family}, which
-can otherwise be given as an optional argument
+will now automatically pick up the package name as the key \emph{family},
+unless explicitly given as an optional argument.
 \begin{verbatim}
 \ProcessKeyOptions[family]
 \end{verbatim}

--- a/base/doc/ltnews35.tex
+++ b/base/doc/ltnews35.tex
@@ -215,6 +215,11 @@ can otherwise be given as an optional argument
 \ProcessKeysOptions[family]
 \end{verbatim}
 
+To support creating key options in for this mechanism, the new command
+\cs{DeclareKeysOptions} has been added. This works using the same general
+approach as \pkg{l3keys} or \pkg{pgfkeys}: each key has one or more
+\emph{properties} which define its behavior.
+
 \subsection{Floating point and integer calculations}
 
 The L3 programming layer offers expandable commands for calculating

--- a/base/doc/ltnews35.tex
+++ b/base/doc/ltnews35.tex
@@ -193,6 +193,28 @@ and also in the documentation of the \pkg{pdfmanagement-testphase} package.
 
 \section{New or improved commands}
 
+\subsection{A kevyal approach to option handling}
+
+The classical \LaTeXe{} method for handling options, using \cs{ProcessOptions},
+treats each entry in the list as a string. Many package authors have sought to
+extend this handling by treating each entry as a key--value pair (keyval)
+instead. To-date, this has required the use of additional packages, for example
+\pkg{kvoptions}.
+
+The \LaTeX{} team have for some time offered the package \pkg{l3keys2e} to
+allow keyvals defined using the \pkg{expl3} module \pkg{l3keys} to act as
+package options. This ability has now been integrated directly into the kernel.
+As part of this integration, the syntax for processing keyval options has been
+refined, such that
+\begin{verbatim}
+\ProcessKeysOptions
+\end{verbatim}
+will now automatically pick up the package name as the key \emph{family}, which
+can otherwise be given as an optional argument
+\begin{verbatim}
+\ProcessKeysOptions[family]
+\end{verbatim}
+
 \subsection{Floating point and integer calculations}
 
 The L3 programming layer offers expandable commands for calculating

--- a/base/doc/ltnews35.tex
+++ b/base/doc/ltnews35.tex
@@ -214,6 +214,8 @@ can otherwise be given as an optional argument
 \begin{verbatim}
 \ProcessKeysOptions[family]
 \end{verbatim}
+A version which does not consider global options,
+\cs{ProcessKeysPackageOptions}, is also available.
 
 To support creating key options in for this mechanism, the new command
 \cs{DeclareKeysOptions} has been added. This works using the same general

--- a/base/doc/ltnews35.tex
+++ b/base/doc/ltnews35.tex
@@ -222,6 +222,14 @@ To support creating key options in for this mechanism, the new command
 approach as \pkg{l3keys} or \pkg{pgfkeys}: each key has one or more
 \emph{properties} which define its behavior.
 
+Options for packages which use this new approach will not be checked for
+clashes by the kernel. Instead, each time a \cs{usepackage} or
+\cs{RequirePackage} line is encountered, the list of options given will be
+passed to \cs{ProcessKeysPackageOptions}. Options which can only be given
+the first time a package is loaded can be marked using the property
+\texttt{.usage = load}, and will result in a warning if used in a subsequent
+package loading line.
+
 \subsection{Floating point and integer calculations}
 
 The L3 programming layer offers expandable commands for calculating

--- a/base/doc/ltnews35.tex
+++ b/base/doc/ltnews35.tex
@@ -230,6 +230,10 @@ the first time a package is loaded can be marked using the property
 \texttt{.usage = load}, and will result in a warning if used in a subsequent
 package loading line.
 
+Package options defined in this way can also be set within a package using
+the new command \cs{SetKeysOptions}, which again takes an optional argument
+to specify the \emph{family}, plus a mandatory one for the options themselves.
+
 \subsection{Floating point and integer calculations}
 
 The L3 programming layer offers expandable commands for calculating

--- a/base/doc/source2e.tex
+++ b/base/doc/source2e.tex
@@ -328,6 +328,8 @@ page_precedence "rnaA"
 
  \DocInclude{ltclass}  % Package & Class interface
 
+ \DocInclude{ltkeys}   % Key-based option management (L3 module)
+
  \DocInclude{ltfilehook}  % Hook management for files (L3 module)
 
  \DocInclude{ltshipout}% \shipout redefinition (L3 module)

--- a/base/format.ins
+++ b/base/format.ins
@@ -204,6 +204,7 @@ the system are in the document `cfgguide.tex'.
           \from{ltbibl.dtx}{2ekernel}
           \from{ltpage.dtx}{2ekernel}
          \from{ltclass.dtx}{2ekernel,tracerollback}
+          \from{ltkeys.dtx}{2ekernel}           % L3 layer module
           \from{ltfilehook.dtx}{2ekernel}       % L3 layer module
           \from{ltshipout.dtx}{2ekernel}        % L3 layer module
           \from{ltoutput.dtx}{2ekernel}

--- a/base/ltclass.dtx
+++ b/base/ltclass.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltclass.dtx}
-             [2021/08/25 v1.4f LaTeX Kernel (Class & Package Interface)]
+             [2021/11/30 v1.5a LaTeX Kernel (Class & Package Interface)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltclass.dtx}
@@ -2175,27 +2175,21 @@
 %    \begin{macrocode}
   \@ifl@aded\@currext\@currname
 %    \end{macrocode}
-%    If the package is already loaded, check that there were no option
-%    clashes:
-% \changes{v1.1b}{1998/05/07}
-%         {Modify help message for latex/2805}
+%    In the current preferred approach, a key family name will exist for
+%    processing using \pkg{ltkeys}.In that case, we replace the previous
+%    package options with with the new ones, then call the key handler.
+%    Otherwise, we use the more classical clash handler.
 %    \begin{macrocode}
-    {\@if@ptions\@currext{\@currname}{#2}{}%
-      {\@latex@error
-        {Option clash for \@cls@pkg\space \@currname}%
-        {The package \@currname\space has already been loaded
-         with options:\MessageBreak
-         \space\space[\@ptionlist{\@currname.\@currext}]\MessageBreak
-         There has now been an attempt to load it
-          with options\MessageBreak
-         \space\space[#2]\MessageBreak
-         Adding the global options:\MessageBreak
-         \space\space
-              \@ptionlist{\@currname.\@currext},#2\MessageBreak
-         to your \noexpand\documentclass declaration may fix this.%
-         \MessageBreak
-         Try typing \space <return> \space to proceed.}}%
-     \@firstofone}%
+    {%
+      \@ifundefined{opt@fam@\@currname.\@currext}
+        {\@onefilewithoptions@clashchk{#2}}
+        {%
+          \@namedef{opt@\@currname.\@currext}{#2}%
+          \expandafter\expandafter\expandafter\ProcessKeysPackageOptions
+            \expandafter\expandafter\expandafter
+              [\csname opt@fam@\@currname.\@currext\endcsname]%
+        }%
+    }%
     {\makeatletter
 %    \end{macrocode}
 %    The next line seems to be necessary for 2.09 compatibility (the
@@ -2297,6 +2291,34 @@
     \@popfilename
     \@reset@ptions}
 %    \end{macrocode}
+%
+% \begin{macro}{\@onefilewithoptions@clashchk}
+%    If the package is already loaded, check that there were no option
+%    clashes.
+% \changes{v1.1b}{1998/05/07}
+%         {Modify help message for latex/2805}
+% \changes{v1.5a}{2021/11/30}
+%         {Separated out from \cs{@onefilewithoptions}}
+%    \begin{macrocode}
+\def\@onefilewithoptions@clashchk#1
+  {\@if@ptions\@currext{\@currname}{#1}{}%
+      {\@latex@error
+        {Option clash for \@cls@pkg\space \@currname}%
+        {The package \@currname\space has already been loaded
+         with options:\MessageBreak
+         \space\space[\@ptionlist{\@currname.\@currext}]\MessageBreak
+         There has now been an attempt to load it
+          with options\MessageBreak
+         \space\space[#1]\MessageBreak
+         Adding the global options:\MessageBreak
+         \space\space
+              \@ptionlist{\@currname.\@currext},#1\MessageBreak
+         to your \noexpand\documentclass declaration may fix this.%
+         \MessageBreak
+         Try typing \space <return> \space to proceed.}}%
+     \@firstofone}
+%    \end{macrocode}
+% \end{macro}
 %
 %    \begin{macrocode}
 \let\@currpkg@reqd\@empty

--- a/base/ltclass.dtx
+++ b/base/ltclass.dtx
@@ -2300,8 +2300,8 @@
 % \changes{v1.5a}{2021/11/30}
 %         {Separated out from \cs{@onefilewithoptions}}
 %    \begin{macrocode}
-\def\@onefilewithoptions@clashchk#1
-  {\@if@ptions\@currext{\@currname}{#1}{}%
+\def\@onefilewithoptions@clashchk#1{%
+  \@if@ptions\@currext{\@currname}{#1}{}%
       {\@latex@error
         {Option clash for \@cls@pkg\space \@currname}%
         {The package \@currname\space has already been loaded

--- a/base/ltclass.dtx
+++ b/base/ltclass.dtx
@@ -2185,7 +2185,7 @@
         {\@onefilewithoptions@clashchk{#2}}
         {%
           \@namedef{opt@\@currname.\@currext}{#2}%
-          \expandafter\expandafter\expandafter\ProcessKeysPackageOptions
+          \expandafter\expandafter\expandafter\ProcessKeyPackageOptions
             \expandafter\expandafter\expandafter
               [\csname opt@fam@\@currname.\@currext\endcsname]%
         }%

--- a/base/ltclass.dtx
+++ b/base/ltclass.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltclass.dtx}
-             [2021/11/30 v1.5a LaTeX Kernel (Class & Package Interface)]
+             [2021/12/09 v1.5a LaTeX Kernel (Class & Package Interface)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltclass.dtx}
@@ -338,7 +338,7 @@
 % or the old name \cs{@ifpackagelater}.
 
 % \DescribeMacro\IfFormatAtLeastTF
-% To test the format date use 
+% To test the format date use
 % \begin{quote}
 % |\IfFormatAtLeastTF{|\meta{date}|}{|^^A
 % \meta{true}|}{|\meta{false}|}|
@@ -1833,7 +1833,7 @@
 %</2ekernel|latexrelease>
 %<latexrelease>\EndIncludeInRelease
 %    \end{macrocode}
-%    
+%
 %    \begin{macrocode}
 %<latexrelease>\IncludeInRelease{0000/00/00}%
 %<latexrelease>                 {\RequirePackageWithOptions}{Unused options issue}%
@@ -2176,7 +2176,7 @@
   \@ifl@aded\@currext\@currname
 %    \end{macrocode}
 %    In the current preferred approach, a key family name will exist for
-%    processing using \pkg{ltkeys}.In that case, we replace the previous
+%    processing using \pkg{ltkeys}. In that case, we replace the previous
 %    package options with with the new ones, then call the key handler.
 %    Otherwise, we use the more classical clash handler.
 %    \begin{macrocode}
@@ -2644,7 +2644,7 @@
 %<latexrelease>\EndIncludeInRelease
 %<*2ekernel>
 %    \end{macrocode}
-%    
+%
 %    \begin{macrocode}
 \@onlypreamble\AtBeginDocument
 %    \end{macrocode}
@@ -2848,7 +2848,7 @@
 %    \end{macrocode}
 %
 % \changes{v1.3m}{2020-08-08}{define \cs{q@curr@file} directly as the
-%    quotes have already been removed (gh/220)} 
+%    quotes have already been removed (gh/220)}
 %    \begin{macrocode}
 \gdef\filec@ntents#1{%
   \set@curr@file{\filec@ntents@checkdir#1}%

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -390,13 +390,10 @@
       {
         \clist_map_inline:Nn \l_@@_tmpa_tl
           {
-            \keys_set:nn {#1}
+            \keys_define:nn {#1}
               {
                 ##1 .code:n =
-                  \prop_get:NnNTF \l_@@_options_module_prop {#1} \l_@@_tmpa_tl
-                    { \exp_args:NV \@@_options_loaded:nn \l_@@_tmpa_tl }
-                    { \@@_options_loaded:nn {#1} }
-                      {##1}
+                  \@@_options_loaded:nn {#1} {##1}
               }
           }
       }
@@ -404,9 +401,11 @@
 \cs_new_protected:Npn \@@_options_loaded:nn #1#2
   {
     \bool_if:NTF \l_@@_options_loading_bool
-      { \msg_warning:nnn { keys } { load-option-ignored } }
-      { \msg_error:nnnn { keys } { load-only } }
-        {#1} {#2}
+      {
+        \msg_warning:nnxx { keys } { load-option-ignored }
+          { \use:c { opt@fam@\@currname.\@currext } } {#2}
+      }
+      { \msg_error:nnnn { keys } { load-only } {#1} {#2} }
   }
 \msg_new:nnn { keys } { load-option-ignored }
   { Package~"#1"~has~already~been~loaded:~ignoring~load-time~option~"#2". }

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -193,8 +193,8 @@
         \cs_set_protected:Npn \@@_option_end:
           { \keys_define:nn {#2} { unknown .undefine: } }
       }
-    \bool_set_true: \l_@@_options_loading_bool
-    \keys_set:nn {#2} \l_@@_options_clist
+    \bool_set_true:N \l_@@_options_loading_bool
+    \keys_set:nV {#2} \l_@@_options_clist
     \bool_set_false:N \l_@@_options_loading_bool
     \cs_set_eq:NN \@unprocessedoptions \scan_stop:
     \@@_option_end:
@@ -316,12 +316,12 @@
 %
 % \subsection{The document interfaces}
 %
-% \begin{macro}{\DeclareKeysOption}
+% \begin{macro}{\DeclareKeysOptions}
 % \begin{macro}{\@@_options_define:nn}
 %   Defining key options is quite straight-forward: we have an intermediate
 %   function to allow for potential set-up steps.
 %    \begin{macrocode}
-\NewDocumentCommand \DeclareKeysOption { o +m }
+\NewDocumentCommand \DeclareKeysOptions { o +m }
   {
     \IfNoValueTF {#1}
       { \exp_args:NV \@@_options_define:nn \@currname }

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -99,7 +99,7 @@
 %     \cs{ProcessKeysOptions} \oarg{family}
 %   \end{syntax}
 %   The \cs{ProcessKeysOptions} function is used to check the current
-%   option list against the keys defined for \Arg{module}. Global (class)
+%   option list against the keys defined for \meta{family}. Global (class)
 %   options and local (package) options are checked when this function
 %   is called in a package.
 % \end{function}
@@ -119,7 +119,7 @@
 %   \begin{syntax}
 %     \cs{SetKeysOptions} \oarg{family} \Arg{keyvals}
 %   \end{syntax}
-%   Sets (applies) the explict list of \meta{keyvals}  for the \emta{family}:
+%   Sets (applies) the explict list of \meta{keyvals}  for the \meta{family}:
 %   it the latter is not given, the value of \cs{@currname} used. This command
 %   may be used within a package to set options before or after using
 %   \cs{ProcessKeysOptions}/\cs{ProcessKeysPackageOptions}.

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -115,6 +115,16 @@
 %   classical \cs{ProcessOptions} command).
 % \end{function}
 %
+% \begin{function}{\SetKeysOptions}
+%   \begin{syntax}
+%     \cs{SetKeysOptions} \oarg{family} \Arg{keyvals}
+%   \end{syntax}
+%   Sets (applies) the explict list of \meta{keyvals}  for the \emta{family}:
+%   it the latter is not given, the value of \cs{@currname} used. This command
+%   may be used within a package to set options before or after using
+%   \cs{ProcessKeysOptions}/\cs{ProcessKeysPackageOptions}.
+% \end{function}
+%
 % \StopEventually{}
 %
 % \subsection{Implementation of \pkg{ltkeys}}
@@ -433,6 +443,21 @@
     before~\begin{document}.~You~will~need~to~set~the~key~earlier.
   }
 %    \end{macrocode}
+%
+% \subsection{General key setting}
+%
+% \begin{macro}{\SetKeysOptions}
+%   A simple wrapper.
+%    \begin{macrocode}
+\NewDocumentCommand \SetKeysOptions { o +m }
+  {
+    \IfNoValueTF {#1}
+      { \keys_set:Vn \@currname }
+      { \keys_set:nn {#1} }
+        {#2}
+  }
+%    \end{macrocode}
+% \end{macro}
 %
 %    \begin{macrocode}
 \ExplSyntaxOff

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltkeys.dtx}
-             [2021/04/20 v1.3c LaTeX Kernel (Kevyal options)]
+             [2021/11/30 v1.0a LaTeX Kernel (Kevyal options)]
 % \iffalse
 \documentclass{l3doc}
 \GetFileInfo{ltkeys.dtx}

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -401,7 +401,7 @@
           }
       }
   }
-\cs_new_protected:Npn \@@_options_loaded:nn
+\cs_new_protected:Npn \@@_options_loaded:nn #1#2
   {
     \bool_if:NTF \l_@@_options_loading_bool
       { \msg_warning:nnn { keys } { load-option-ignored } }

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -425,9 +425,9 @@
   {
     \prop_map_inline:Nn \l_keys_usage_preamble_prop
       {
-        \clist_map_inline:nn {#1}
+        \clist_map_inline:nn {#2}
           {
-            \keys_set:nn {#1}
+            \keys_define:nn {#1}
               {
                 ##1 .code:n =
                   \msg_error:nnn { keys } { preamble-only } {##1}

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -151,13 +151,6 @@
 %    \end{macrocode}
 % \end{variable}
 %
-% \begin{variable}{\l_@@_options_module_prop}
-%   To track non-standard module names.
-%    \begin{macrocode}
-\prop_new:N \l_@@_options_module_prop
-%    \end{macrocode}
-% \end{variable}
-%
 % \begin{macro}{\@@_options:Nn}
 % \begin{macro}{\@@_options_end:}
 %   The main function calls functions to collect up the global and local
@@ -165,12 +158,14 @@
 %   underlying functions to actually do the processing. So that a suitable
 %   message is produced if the option is unknown, the special
 %   \texttt{unknown} key is set if it does not already exist for the
-%   current family, and is cleaned up afterwards if required.
+%   current family, and is cleaned up afterwards if required. To allow
+%   the \LaTeXe{} layer to know this mechanism is active, and to deal
+%   with the key family not matching the file name, we store the family
+%   in all cases.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_options:Nn #1#2
   {
-    \str_if_eq:nVF {#2} \@currname
-      { \prop_put:NnV \l_@@_options_module_prop {#2} \@currname }
+    \cs_gset_nopar:cpn { opt@fam@\@currname.\@currext } {#2}
     \cs_set_protected:Npn \@@_option_end: { }
     \clist_clear:N \l_@@_options_clist
     \@@_options_global:Nn #1 {#2}

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -331,7 +331,9 @@
   {
     \peek_meaning:NTF \c_group_begin_token
       { \@@_options:Nn #1 }
-      { \exp_args:NV \@@_options:Nn #1 \@currname }
+      {
+        \exp_args:NNV \@@_options:Nn #1 \@currname
+      }
   }
 %    \end{macrocode}
 % \end{macro}

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -143,6 +143,21 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{variable}{\l_@@_options_loading_bool}
+%   Used to indicate we are in the loading phase: controls the outcome
+%   of warnings.
+%    \begin{macrocode}
+\bool_new:N \l_@@_options_loading_bool
+%    \end{macrocode}
+% \end{variable}
+%
+% \begin{variable}{\l_@@_options_module_prop}
+%   To track non-standard module names.
+%    \begin{macrocode}
+\prop_new:N \l_@@_options_module_prop
+%    \end{macrocode}
+% \end{variable}
+%
 % \begin{macro}{\@@_options:Nn}
 % \begin{macro}{\@@_options_end:}
 %   The main function calls functions to collect up the global and local
@@ -154,6 +169,8 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_options:Nn #1#2
   {
+    \str_if_eq:nVF {#2} \@currname
+      { \prop_put:NnV \l_@@_options_module_prop {#2} \@currname }
     \cs_set_protected:Npn \@@_option_end: { }
     \clist_clear:N \l_@@_options_clist
     \@@_options_global:Nn #1 {#2}
@@ -171,7 +188,9 @@
         \cs_set_protected:Npn \@@_option_end:
           { \keys_define:nn {#2} { unknown .undefine: } }
       }
+    \bool_set_true: \l_@@_options_loading_bool
     \keys_set:nn {#2} \l_@@_options_clist
+    \bool_set_false:N \l_@@_options_loading_bool
     \cs_set_eq:NN \@unprocessedoptions \scan_stop:
     \@@_option_end:
   }
@@ -317,13 +336,19 @@
   {
     \IfNoValueTF {#1}
       { \@@_options_group_check:N \c_true_bool }
-      { \@@_options:Nn \c_true_bool {#1} }
+      {
+        \@@_options:Nn \c_true_bool {#1}
+        \@@_options_loaded:n {#1}
+      }
   }
 \NewDocumentCommand \ProcessKeysPackageOptions { o }
   {
     \IfNoValueTF {#1}
       { \@@_options_group_check:N \c_false_bool }
-      { \@@_options:Nn \c_false_bool {#1} }
+      {
+        \@@_options:Nn \c_false_bool {#1}
+        \@@_options_loaded:n {#1}
+      }
   }
 \@onlypreamble \ProcessKeysOptions
 \@onlypreamble \ProcessKeysPackageOptions
@@ -333,6 +358,7 @@
       { \@@_options:Nn #1 }
       {
         \exp_args:NNV \@@_options:Nn #1 \@currname
+        \exp_args:NV \@@_options_loaded:n \@currname
       }
   }
 %    \end{macrocode}
@@ -341,17 +367,61 @@
 %
 % \subsection{Option usage scope}
 %
+% \begin{macro}{\@@_options_loaded:n}
+% \begin{macro}{\@@_options_loaded:nn}
+%   Indicates that the load-time options for a package have been processed:
+%   once this has happened, make them unavailable either with a warning or
+%   an error.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_options_loaded:n #1
+  {
+    \prop_get:NnNT \l_keys_usage_load_prop {#1} \l_@@_tmpa_tl
+      {
+        \clist_map_inline:Nn \l_@@_tmpa_tl
+          {
+            \keys_set:nn {#1}
+              {
+                ##1 .code:n =
+                  \prop_get:NnNTF \l_@@_options_module_prop {#1} \l_@@_tmpa_tl
+                    { \exp_args:NV \@@_options_loaded:nn \l_@@_tmpa_tl }
+                    { \@@_options_loaded:nn {#1} }
+                      {##1}
+              }
+          }
+      }
+  }
+\cs_new_protected:Npn \@@_options_loaded:nn
+  {
+    \bool_if:NTF \l_@@_options_loading_bool
+      { \msg_warning:nnn { keys } { load-option-ignored } }
+      { \msg_error:nnnn { keys } { load-only } }
+        {#1} {#2}
+  }
+\msg_new:nnn { keys } { load-option-ignored }
+  { Package~"#1"~has~already~been~loaded:~ignoring~load-time~option~"#2". }
+\msg_new:nnnn { keys } { load-only }
+  { Key~"#2"~may~only~be~used~in~the~during~loading~of~package~"#1". }
+  {
+    LaTeX~was~asked~to~set~a~key~called~"#2",~but~this~is~only~allowed~
+    in~the~optional~argument~when~loading~package~"#1".
+  }
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
+%
 %  Disable all preamble options in one shot.
 %    \begin{macrocode}
 \tl_gput_left:Nn \@kernel@after@begindocument
   {
-    \seq_map_inline:Nn \l_keys_usage_preamble_seq
+    \prop_map_inline:Nn \l_keys_usage_preamble_prop
       {
-        \keys_set:nn { }
+        \clist_map_inline:nn {#1}
           {
-            #1 .code:n =
-              \msg_error:nnx { keys } { preamble-only }
-                { \l_keys_key_str }
+            \keys_set:nn {#1}
+              {
+                ##1 .code:n =
+                  \msg_error:nnn { keys } { preamble-only } {##1}
+              }
           }
       }
   }

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -343,7 +343,7 @@
 %    \begin{macrocode}
 \tl_gput_left:Nn \@kernel@after@begindocument
   {
-    \seq_map_inline:Nn \g_keys_usage_preamble_seq
+    \seq_map_inline:Nn \l_keys_usage_preamble_seq
       {
         \keys_set:nn { }
           {

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -57,13 +57,18 @@
 % as general key--value settings: this will depend on the nature of the
 % underlying code.
 %
-% \begin{function}{\DeclareKeysOptions}
+% \begin{function}{\DeclareKeys}
 %   \begin{syntax}
-%     \cs{DeclareKeysOptions} \oarg{family} \marg{declarations}
+%     \cs{DeclareKeys} \oarg{family} \marg{declarations}
 %   \end{syntax}
 %   Creates a series of options from a comma-separated \meta{declarations} list.
-%   Each entry in this list is a key--value pair, in which the \meta{key} should
-%   have a \meta{property}, taken from the list
+%   Each entry in this list is a key--value pair, with the \meta{key} having one
+%   or more \meta{properties}. A small number of \enquote{basic}
+%   \meta{properties} are described below. The full range of properties,
+%   provided by \pkg{l3keys}, can also be used for more powerful processing.
+%   See \texttt{interface3} for the full details.
+%   
+%   The basic properties provided here are
 %   \begin{itemize}
 %     \item \texttt{.if} --- sets a \TeX{} \cs{if...} switch
 %     \item \texttt{.store} --- stores a value in a macro
@@ -77,7 +82,7 @@
 %
 %   For example, with
 %   \begin{verbatim}
-%     \DeclareKeysOptions[mypkg]
+%     \DeclareKeys[mypkg]
 %       {
 %         draft.if          = @mypkg@draft      ,
 %         draft.usage       = preamble          ,
@@ -92,37 +97,40 @@
 %   save whatever value it is given in \cs{@mypkg@name}. Finally, the option
 %   \texttt{second-name} can be given anywhere, and will save its value in
 %   \cs{@mypkg@other@name}.
+%
+%   Keys created \emph{before} the use of
+%   \cs{ProcessKeyOptions}/\cs{ProcessKeyPackageOptions} act as package options.
 % \end{function}
 %
-% \begin{function}{\ProcessKeysOptions}
+% \begin{function}{\ProcessKeyOptions}
 %   \begin{syntax}
-%     \cs{ProcessKeysOptions} \oarg{family}
+%     \cs{ProcessKeyOptions} \oarg{family}
 %   \end{syntax}
-%   The \cs{ProcessKeysOptions} function is used to check the current
+%   The \cs{ProcessKeyOptions} function is used to check the current
 %   option list against the keys defined for \meta{family}. Global (class)
 %   options and local (package) options are checked when this function
 %   is called in a package.
 % \end{function}
 %
-% \begin{function}{\ProcessKeysPackageOptions}
+% \begin{function}{\ProcessKeyPackageOptions}
 %   \begin{syntax}
-%     \cs{ProcessKeysPackageOptions} \oarg{family}
+%     \cs{ProcessKeyPackageOptions} \oarg{family}
 %   \end{syntax}
-%   This function works in a similar manner to \cs{ProcessKeysOptions}.
-%   When used in a package, \cs{ProcessKeysPackageOptions}
+%   This function works in a similar manner to \cs{ProcessKeyOptions}.
+%   When used in a package, \cs{ProcessKeyPackageOptions}
 %   will not examine any global (class) class options available. In contrast,
-%   \cs{ProcessKeysOptions} does parse class options (in common with the
+%   \cs{ProcessKeyOptions} does parse class options (in common with the
 %   classical \cs{ProcessOptions} command).
 % \end{function}
 %
-% \begin{function}{\SetKeysOptions}
+% \begin{function}{\SetKeys}
 %   \begin{syntax}
-%     \cs{SetKeysOptions} \oarg{family} \Arg{keyvals}
+%     \cs{SetKeys} \oarg{family} \Arg{keyvals}
 %   \end{syntax}
-%   Sets (applies) the explict list of \meta{keyvals}  for the \meta{family}:
+%   Sets (applies) the explicit list of \meta{keyvals}  for the \meta{family}:
 %   it the latter is not given, the value of \cs{@currname} used. This command
 %   may be used within a package to set options before or after using
-%   \cs{ProcessKeysOptions}/\cs{ProcessKeysPackageOptions}.
+%   \cs{ProcessKeyOptions}/\cs{ProcessKeyPackageOptions}.
 % \end{function}
 %
 % \StopEventually{}
@@ -161,7 +169,7 @@
 %    \end{macrocode}
 % \end{variable}
 %
-% \begin{macro}{\@@_options:Nn}
+% \begin{macro}{\@@_options:Nn, \@@_options:NV}
 % \begin{macro}{\@@_options_end:}
 %   The main function calls functions to collect up the global and local
 %   options into \cs{l_@@_options_clist} before calling the
@@ -198,7 +206,9 @@
     \bool_set_false:N \l_@@_options_loading_bool
     \cs_set_eq:NN \@unprocessedoptions \scan_stop:
     \@@_option_end:
+    \@@_options_loaded:n {#2}
   }
+\cs_generate_variant:Nn \@@_options:Nn { NV }
 \msg_new:nnnn { keys } { option-unknown }
   { Unknown~option~'#1'~for~package~#2. }
   {
@@ -316,64 +326,41 @@
 %
 % \subsection{The document interfaces}
 %
-% \begin{macro}{\DeclareKeysOptions}
-% \begin{macro}{\@@_options_define:nn}
+% \begin{macro}{\DeclareKeys}
 %   Defining key options is quite straight-forward: we have an intermediate
 %   function to allow for potential set-up steps.
 %    \begin{macrocode}
-\NewDocumentCommand \DeclareKeysOptions { o +m }
+\NewDocumentCommand \DeclareKeys { o +m }
   {
     \IfNoValueTF {#1}
-      { \exp_args:NV \@@_options_define:nn \@currname }
-      { \@@_options_define:nn {#1} }
+      { \exp_args:NV \keys_define:nn \@currname }
+      { \keys_define:nn {#1} }
         {#2}
-  }
-\cs_new_protected:Npn \@@_options_define:nn #1#2
-  {
-    \keys_define:nn {#1} {#2}
   }
 %    \end{macrocode}
 % \end{macro}
-% \end{macro}
 %
-% \begin{macro}{\ProcessKeysOptions}
-% \begin{macro}{\ProcessKeysPackageOptions}
+% \begin{macro}{\ProcessKeyOptions, \ProcessKeyPackageOptions}
 %   We need to deal with the older interface from \pkg{l3keys2e} here: it had
 %   a mandatory argument. We can mop that up using a look-ahead, and then
 %   exploit that information to determine whether the package option handling
 %   is set up for the new approach for clash handling.
 %    \begin{macrocode}
-\NewDocumentCommand \ProcessKeysOptions { o }
+\NewDocumentCommand \ProcessKeyOptions { o }
   {
     \IfNoValueTF {#1}
-      { \@@_options_group_check:N \c_true_bool }
-      {
-        \@@_options:Nn \c_true_bool {#1}
-        \@@_options_loaded:n {#1}
-      }
+      { \@@_options:NV \c_true_bool \@currname }
+      { \@@_options:Nn \c_true_bool {#1} }
   }
-\NewDocumentCommand \ProcessKeysPackageOptions { o }
+\NewDocumentCommand \ProcessKeyPackageOptions { o }
   {
     \IfNoValueTF {#1}
-      { \@@_options_group_check:N \c_false_bool }
-      {
-        \@@_options:Nn \c_false_bool {#1}
-        \@@_options_loaded:n {#1}
-      }
+      { \@@_options:NV \c_false_bool \@currname }
+      { \@@_options:Nn \c_false_bool {#1} }
   }
-\@onlypreamble \ProcessKeysOptions
-\@onlypreamble \ProcessKeysPackageOptions
-\cs_new_protected:Npn \@@_options_group_check:N #1
-  {
-    \peek_meaning:NTF \c_group_begin_token
-      { \@@_options:Nn #1 }
-      {
-        \exp_args:NNV \@@_options:Nn #1 \@currname
-        \exp_args:NV \@@_options_loaded:n \@currname
-      }
-  }
+\@onlypreamble \ProcessKeyOptions
+\@onlypreamble \ProcessKeyPackageOptions
 %    \end{macrocode}
-% \end{macro}
 % \end{macro}
 %
 % \subsection{Option usage scope}
@@ -445,10 +432,10 @@
 %
 % \subsection{General key setting}
 %
-% \begin{macro}{\SetKeysOptions}
+% \begin{macro}{\SetKeys}
 %   A simple wrapper.
 %    \begin{macrocode}
-\NewDocumentCommand \SetKeysOptions { o +m }
+\NewDocumentCommand \SetKeys { o +m }
   {
     \IfNoValueTF {#1}
       { \keys_set:Vn \@currname }

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -181,7 +181,7 @@
           {
             unknown .code:n =
               {
-                \msg_error:nnxx { keyvalue } { option-unknown }
+                \msg_error:nnxx { keys } { option-unknown }
                   { \l_keys_key_str } { \@currname }
               }
           }
@@ -193,6 +193,12 @@
     \bool_set_false:N \l_@@_options_loading_bool
     \cs_set_eq:NN \@unprocessedoptions \scan_stop:
     \@@_option_end:
+  }
+\msg_new:nnnn { keys } { option-unknown }
+  { Unknown~option~'#1'~for~package~#2. }
+  {
+    LaTeX~has~been~asked~to~set~an~option~called~'#1'~
+    but~the~#2~package~has~not~created~an~option~with~this~name.
   }
 %    \end{macrocode}
 % \end{macro}

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -53,7 +53,46 @@
 %
 % As with any key--value input, using key--value pairs as package or
 % class options has two parts: creating the key options and setting (using)
-% them.
+% them. Options created in this way \emph{may} be used after package loading
+% as general key--value settings: this will depend on the nature of the
+% underlying code.
+%
+% \begin{function}{\DeclareKeysOptions}
+%   \begin{syntax}
+%     \cs{DeclareKeysOptions} \oarg{family} \marg{declarations}
+%   \end{syntax}
+%   Creates a series of options from a comma-separated \meta{declarations} list.
+%   Each entry in this list is a key--value pair, in which the \meta{key} should
+%   have a \meat{property}, taken from the list
+%   \begin{itemize}
+%     \item \texttt{.if} --- sets a \TeX{} \cs{if...} switch
+%     \item \texttt{.store} --- stores a value in a macro
+%     \item \texttt{.usage} -- defines whether the option can be given only
+%       when loading (\texttt{load}), in the preamble (\texttt{preamble}) or
+%       has no limitation on scope (\texttt{general})
+%   \end{itemize}
+%   The part of the \meta{key} before the \meta{property} is the \meta{name},
+%   with the \meta{value} working with the \meta{property} to define the
+%   behaviour of the option.
+%
+%   For example, with
+%   \begin{verbatim}
+%     \DeclareKeysOptions[mypkg]
+%       {
+%         draft.if          = @mypkg@draft      ,
+%         draft.usage       = preamble          ,
+%         name.store        = \@mypkg@name      ,
+%         name.usage        = load              ,
+%         second-name.store = \@mypkg@other@name
+%       }
+%   \end{verbatim}
+%   three options would be create. The option \texttt{draft} can be given
+%   anywhere in the preamble, and will set a switch called \cs{if@mypkg@draft}.
+%   The option \texttt{name} can only be given during package loading, and will
+%   save whatever value it is given in \cs{@mypkg@name}. Finally, the option
+%   \texttt{second-name} can be given anywhere, and will save its value in
+%   \cs{@mypkg@other@name}.
+% \end{function}
 %
 % \begin{function}{\ProcessKeysOptions}
 %   \begin{syntax}
@@ -246,6 +285,26 @@
 % \end{macro}
 %
 % \subsection{The document interfaces}
+%
+% \begin{macro}{\DeclareKeysOption}
+% \begin{macro}{\@@_options_define:nn}
+%   Defining key options is quite straight-forward: we have an intermediate
+%   function to allow for potential set-up steps.
+%    \begin{macrocode}
+\NewDocumentCommand \DeclareKeysOption { o +m }
+  {
+    \IfNoValueTF {#1}
+      { \exp_args:NV \@@_options_define:nn \@currname }
+      { \@@_options_define:nn {#1} }
+        {#2}
+  }
+\cs_new_protected:Npn \@@_options_define:nn #1#2
+  {
+    \keys_define:nn {#1} {#2}
+  }
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
 %
 % \begin{macro}{\ProcessKeysOptions}
 % \begin{macro}{\ProcessKeysPackageOptions}

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -261,7 +261,7 @@
           {
             \clist_map_inline:cn { opt@ \@currname . \@currext }
               {
-                \keys_if_exist:nxTF
+                \keys_if_exist:neTF
                   {#1} { \@@_remove_equals:n {##1} }
                   { \clist_put_right:Nn \l_@@_options_clist {##1} }
                   { \clist_put_right:Nn \@unusedoptionlist {##1} }
@@ -282,7 +282,7 @@
   {
     \clist_map_inline:Nn \@classoptionslist
       {
-        \keys_if_exist:nxT {#1} { \@@_remove_equals:n {##1} }
+        \keys_if_exist:neT {#1} { \@@_remove_equals:n {##1} }
           {
             \clist_put_right:Nn \l_@@_options_clist {##1}
             \clist_remove_all:Nn \@unusedoptionlist {##1}

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -63,7 +63,7 @@
 %   \end{syntax}
 %   Creates a series of options from a comma-separated \meta{declarations} list.
 %   Each entry in this list is a key--value pair, in which the \meta{key} should
-%   have a \meat{property}, taken from the list
+%   have a \meta{property}, taken from the list
 %   \begin{itemize}
 %     \item \texttt{.if} --- sets a \TeX{} \cs{if...} switch
 %     \item \texttt{.store} --- stores a value in a macro

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -1,0 +1,287 @@
+% \iffalse meta-comment
+%
+% Copyright (C) 2021
+% The LaTeX Project and any individual authors listed elsewhere
+% in this file.
+%
+% This file is part of the LaTeX base system.
+% -------------------------------------------
+%
+% It may be distributed and/or modified under the
+% conditions of the LaTeX Project Public License, either version 1.3c
+% of this license or (at your option) any later version.
+% The latest version of this license is in
+%    https://www.latex-project.org/lppl.txt
+% and version 1.3c or later is part of all distributions of LaTeX
+% version 2008 or later.
+%
+% This file has the LPPL maintenance status "maintained".
+%
+% The list of all files belonging to the LaTeX base distribution is
+% given in the file `manifest.txt'. See also `legal.txt' for additional
+% information.
+%
+% The list of derived (unpacked) files belonging to the distribution
+% and covered by LPPL is defined by the unpacking scripts (with
+% extension .ins) which are part of the distribution.
+%
+% \fi
+%
+% \iffalse
+%%% From File: ltkeys.dtx
+%
+%<*driver>
+% \fi
+\ProvidesFile{ltkeys.dtx}
+             [2021/04/20 v1.3c LaTeX Kernel (Kevyal options)]
+% \iffalse
+\documentclass{l3doc}
+\GetFileInfo{ltkeys.dtx}
+\title{\filename}
+\date{\filedate}
+\author{%
+  \LaTeX{} Team}
+
+\begin{document}
+ \maketitle
+ \DocInput{ltkeys.dtx}
+\end{document}
+%</driver>
+% \fi
+%
+% \section{Creating and using keyval options}
+%
+% As with any key--value input, using key--value pairs as package or
+% class options has two parts: creating the key options and setting (using)
+% them.
+%
+% \begin{function}{\ProcessKeysOptions}
+%   \begin{syntax}
+%     \cs{ProcessKeysOptions} \oarg{family}
+%   \end{syntax}
+%   The \cs{ProcessKeysOptions} function is used to check the current
+%   option list against the keys defined for \Arg{module}. Global (class)
+%   options and local (package) options are checked when this function
+%   is called in a package.
+% \end{function}
+%
+% \begin{function}{\ProcessKeysPackageOptions}
+%   \begin{syntax}
+%     \cs{ProcessKeysPackageOptions} \oarg{family}
+%   \end{syntax}
+%   This function works in a similar manner to \cs{ProcessKeysOptions}.
+%   When used in a package, \cs{ProcessKeysPackageOptions}
+%   will not examine any global (class) class options available. In contrast,
+%   \cs{ProcessKeysOptions} does parse class options (in common with the
+%   classical \cs{ProcessOptions} command).
+% \end{function}
+%
+% \StopEventually{}
+%
+% \subsection{Implementation of \pkg{ltkeys}}
+%
+%    \begin{macrocode}
+%<@@=keys>
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%<*2ekernel>
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+\ExplSyntaxOn
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+\cs_generate_variant:Nn \clist_put_right:Nn { Nv }
+%    \end{macrocode}
+%
+% \begin{macro}{\l_@@_options_clist}
+%   A single list is used for all options, into which they are collected
+%   before processing.
+%    \begin{macrocode}
+\clist_new:N \l_@@_options_clist
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\@@_options:Nn}
+% \begin{macro}{\@@_options_end:}
+%   The main function calls functions to collect up the global and local
+%   options into \cs{l_@@_options_clist} before calling the
+%   underlying functions to actually do the processing. So that a suitable
+%   message is produced if the option is unknown, the special
+%   \texttt{unknown} key is set if it does not already exist for the
+%   current family, and is cleaned up afterwards if required.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_options:Nn #1#2
+  {
+    \cs_set_protected:Npn \@@_option_end: { }
+    \clist_clear:N \l_@@_options_clist
+    \@@_options_global:Nn #1 {#2}
+    \@@_options_local:
+    \keys_if_exist:nnF {#2} { unknown }
+      {
+        \keys_define:nn {#2}
+          {
+            unknown .code:n =
+              {
+                \msg_error:nnxx { keyvalue } { option-unknown }
+                  { \l_keys_key_str } { \@currname }
+              }
+          }
+        \cs_set_protected:Npn \@@_option_end:
+          { \keys_define:nn {#2} { unknown .undefine: } }
+      }
+    \keys_set:nn {#2} \l_@@_options_clist
+    \cs_set_eq:NN \@unprocessedoptions \scan_stop:
+    \@@_option_end:
+  }
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
+%
+% \begin{macro}{\@@_options_global:Nn}
+%   Global (class) options are handled differently for \LaTeXe{} packages
+%   and classes. Hence this function is essentially a check on the current
+%  file type. The initial test is needed as \LaTeXe{} allows variables to
+%   be equal to \cs{scan_stop:}, which is usually forbidden in \pkg{expl3}
+%   code.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_options_global:Nn #1#2
+  {
+    \cs_if_eq:NNF \@classoptionslist \scan_stop:
+      {
+        \cs_if_eq:NNTF \@currext \@clsextension
+          { \@@_options_class:n {#2} }
+          {
+            \bool_if:NT #1
+             { \@@_options_package:n {#2} }
+          }
+      }
+  }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\@@_options_class:n}
+%   For classes, each option (stripped of any content after |=|)
+%   is checked for existence as a key. If found, the option is added to
+%   the combined list for processing. On the other hand, unused options
+%   are stored up in \cs{@unusedoptionlist}. Before any of that, though,
+%   there is a simple check to see if there is an |unknown| key. If there
+%   is, then \emph{everything} will match and the mapping can be skipped.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_options_class:n #1
+  {
+    \cs_if_free:cF { opt@ \@currname . \@currext }
+      {
+        \keys_if_exist:nnTF {#1} { unknown }
+          {
+            \clist_put_right:Nv \l_@@_options_clist
+              { opt@ \@currname . \@currext }
+          }
+          {
+            \clist_map_inline:cn { opt@ \@currname . \@currext }
+              {
+                \keys_if_exist:nxTF
+                  {#1} { \@@_remove_equals:n {##1} }
+                  { \clist_put_right:Nn \l_@@_options_clist {##1} }
+                  { \clist_put_right:Nn \@unusedoptionlist {##1} }
+              }
+          }
+      }
+  }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\@@_options_package:n}
+%   For global options when processing a package, the tasks are slightly
+%   different from those for a class. The check is the same, but here
+%   there is nothing to do if the option is not applicable. Each valid
+%   option also needs to be removed from \cs{@unusedoptionlist}.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_options_package:n #1
+  {
+    \clist_map_inline:Nn \@classoptionslist
+      {
+        \keys_if_exist:nxT {#1} { \@@_remove_equals:n {##1} }
+          {
+            \clist_put_right:Nn \l_@@_options_clist {##1}
+            \clist_remove_all:Nn \@unusedoptionlist {##1}
+          }
+      }
+  }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\@@_options_local:}
+%   If local options are found, the are added to the processing list.
+%   \LaTeXe{} stores options for each file in a macro which may or may not
+%   exist, hence the need to use \cs{cs_if_exist:c}.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_options_local:
+  {
+    \cs_if_eq:NNF \@currext \@clsextension
+      {
+        \cs_if_exist:cT { opt@ \@currname . \@currext }
+          {
+            \clist_put_right:Nv \l_@@_options_clist
+              { opt@ \@currname . \@currext }
+          }
+      }
+  }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[EXP]{\@@_remove_equals:n}
+% \begin{macro}[EXP]{\@@_remove_equals:w}
+%   As the name suggests, this is a simple function to remove an equals
+%   sign from the input. This is all wrapped up in an \texttt{n} function
+%   so that there will always be a sign available.
+%    \begin{macrocode}
+\cs_new:Npn \@@_remove_equals:n #1
+  { \@@_remove_equals:w #1 = \s_@@_stop }
+\cs_new:Npn \@@_remove_equals:w #1 = #2 \s_@@_stop { \exp_not:n {#1} }
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
+%
+% \subsection{The document interfaces}
+%
+% \begin{macro}{\ProcessKeysOptions}
+% \begin{macro}{\ProcessKeysPackageOptions}
+%   We need to deal with the older interface from \pkg{l3keys2e} here: it had
+%   a mandatory argument. We can mop that up using a look-ahead, and then
+%   exploit that information to determine whether the package option handling
+%   is set up for the new approach for clash handling.
+%    \begin{macrocode}
+\NewDocumentCommand \ProcessKeysOptions { o }
+  {
+    \IfNoValueTF {#1}
+      { \@@_options_group_check:N \c_true_bool }
+      { \@@_options:Nn \c_true_bool {#1} }
+  }
+\NewDocumentCommand \ProcessKeysPackageOptions { o }
+  {
+    \IfNoValueTF {#1}
+      { \@@_options_group_check:N \c_false_bool }
+      { \@@_options:Nn \c_false_bool {#1} }
+  }
+\@onlypreamble \ProcessKeysOptions
+\@onlypreamble \ProcessKeysPackageOptions
+\cs_new_protected:Npn \@@_options_group_check:N #1
+  {
+    \peek_meaning:NTF \c_group_begin_token
+      { \@@_options:Nn #1 }
+      { \exp_args:NV \@@_options:Nn #1 \@currname }
+  }
+%    \end{macrocode}
+%\end{macro}
+%\end{macro}
+%
+%    \begin{macrocode}
+\ExplSyntaxOff
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%</2ekernel>
+%    \end{macrocode}

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -337,6 +337,30 @@
 % \end{macro}
 % \end{macro}
 %
+% \subsection{Option usage scope}
+%
+%  Disable all preamble options in one shot.
+%    \begin{macrocode}
+\tl_gput_left:Nn \@kernel@after@begindocument
+  {
+    \seq_map_inline:Nn \g_keys_usage_preamble_seq
+      {
+        \keys_set:nn { }
+          {
+            #1 .code:n =
+              \msg_error:nnx { keys } { preamble-only }
+                { \l_keys_key_str }
+          }
+      }
+  }
+\msg_new:nnnn { keys } { preamble-only }
+  { Key~"#1"~may~only~be~used~in~the~preamble. }
+  {
+    LaTeX~was~asked~to~set~a~key~called~"#1",~but~this~is~only~allowed~
+    before~\begin{document}.~You~will~need~to~set~the~key~earlier.
+  }
+%    \end{macrocode}
+%
 %    \begin{macrocode}
 \ExplSyntaxOff
 %    \end{macrocode}

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -334,8 +334,8 @@
       { \exp_args:NV \@@_options:Nn #1 \@currname }
   }
 %    \end{macrocode}
-%\end{macro}
-%\end{macro}
+% \end{macro}
+% \end{macro}
 %
 %    \begin{macrocode}
 \ExplSyntaxOff

--- a/base/testfiles-lthooks/ltcmdhooks-001.tlg
+++ b/base/testfiles-lthooks/ltcmdhooks-001.tlg
@@ -58,7 +58,7 @@ l. ...\ShowHook{cmd/foo/after}
 #1#2->FOO #1 #2.
 l. ...\show\foo
 > \@kernel@after@begindocument=macro:
-->\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
+->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##1}{\keys_set:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
 l. ...\show\@kernel@after@begindocument
 Update code for hook 'para/before' on input line ...:
 Update code for hook 'para/after' on input line ...:

--- a/base/testfiles-lthooks/ltcmdhooks-001.tlg
+++ b/base/testfiles-lthooks/ltcmdhooks-001.tlg
@@ -58,7 +58,7 @@ l. ...\ShowHook{cmd/foo/after}
 #1#2->FOO #1 #2.
 l. ...\show\foo
 > \@kernel@after@begindocument=macro:
-->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##1}{\keys_set:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
+->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##2}{\keys_define:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
 l. ...\show\@kernel@after@begindocument
 Update code for hook 'para/before' on input line ...:
 Update code for hook 'para/after' on input line ...:

--- a/base/testfiles/github-0710.lvt
+++ b/base/testfiles/github-0710.lvt
@@ -1,0 +1,36 @@
+\documentclass{article}
+\begin{filecontents}{mypkg.sty}
+\DeclareKeysOptions{
+  load-option-A .store = \my@A ,
+  load-option-A .usage = load  ,
+  load-option-B .store = \my@B ,
+  load-option-B .usage = load  ,
+  general-option-C .store = \my@C
+}
+\ProcessKeysOptions
+\newcommand\mypkgtest{%
+  \begingroup
+    \edef\x{\my@A:\my@B:\my@C}%
+    \show\x
+  \endgroup
+}
+\end{filecontents}
+\input{test2e}
+
+\START
+\AUTHOR{Joseph Wright}
+
+\usepackage[load-option-A = 111]{mypkg}                           % 1
+\mypkgtest
+\usepackage[load-option-A = 222]{mypkg}                           % 2
+\mypkgtest
+\usepackage[load-option-A = 333, general-option-C  = 333]{mypkg}  % 3
+\mypkgtest
+\usepackage{mypkg}                                                % 4
+\mypkgtest
+\usepackage[load-option-B = 555]{mypkg}                           % 5
+\mypkgtest
+\SetKeysOptions[mypkg]{load-option-A = 666}                       % 6 
+\mypkgtest
+
+\END

--- a/base/testfiles/github-0710.lvt
+++ b/base/testfiles/github-0710.lvt
@@ -32,11 +32,11 @@
 \mypkgtest
 \usepackage[load-option-B = 555]{mypkg}                           % 5
 \mypkgtest
-\SetKeys[mypkg]{load-option-A = 666}                       % 6 
+\SetKeys[mypkg]{load-option-A = 666}                       % 6
 \mypkgtest
 \usepackage[preamble-option-D = 777]{mypkg}                       % 7
 \mypkgtest
-\SetKeys[mypkg]{preamble-option-D = 888}                   % 8 
+\SetKeys[mypkg]{preamble-option-D = 888}                   % 8
 \mypkgtest
 
 \OMIT
@@ -44,7 +44,7 @@
 \TIMO
 
 \SetKeys[mypkg]{general-option-C = 999,
-  preamble-option-D = 999} % 9 
+  preamble-option-D = 999} % 9
 \mypkgtest
 
 \END

--- a/base/testfiles/github-0710.lvt
+++ b/base/testfiles/github-0710.lvt
@@ -5,12 +5,14 @@
   load-option-A .usage = load  ,
   load-option-B .store = \my@B ,
   load-option-B .usage = load  ,
-  general-option-C .store = \my@C
+  general-option-C .store = \my@C ,
+  preamble-option-D .store = \my@D ,
+  preamble-option-D .usage = preamble
 }
 \ProcessKeysOptions
 \newcommand\mypkgtest{%
   \begingroup
-    \edef\x{\my@A:\my@B:\my@C}%
+    \edef\x{\my@A:\my@B:\my@C:\my@D}%
     \show\x
   \endgroup
 }
@@ -31,6 +33,17 @@
 \usepackage[load-option-B = 555]{mypkg}                           % 5
 \mypkgtest
 \SetKeysOptions[mypkg]{load-option-A = 666}                       % 6 
+\mypkgtest
+\usepackage[preamble-option-D = 777]{mypkg}                       % 7
+\mypkgtest
+\SetKeysOptions[mypkg]{preamble-option-D = 888}                   % 8 
+\mypkgtest
+
+\OMIT
+\begin{document}
+\TIMO
+
+\SetKeysOptions[mypkg]{general-option-C = 999, preamble-option-D = 999} % 9 
 \mypkgtest
 
 \END

--- a/base/testfiles/github-0710.lvt
+++ b/base/testfiles/github-0710.lvt
@@ -43,7 +43,8 @@
 \begin{document}
 \TIMO
 
-\SetKeysOptions[mypkg]{general-option-C = 999, preamble-option-D = 999} % 9 
+\SetKeysOptions[mypkg]{general-option-C = 999,
+  preamble-option-D = 999} % 9 
 \mypkgtest
 
 \END

--- a/base/testfiles/github-0710.lvt
+++ b/base/testfiles/github-0710.lvt
@@ -1,6 +1,6 @@
 \documentclass{article}
-\begin{filecontents}{mypkg.sty}
-\DeclareKeysOptions{
+\begin{filecontents}[overwrite]{mypkg.sty}
+\DeclareKeys{
   load-option-A .store = \my@A ,
   load-option-A .usage = load  ,
   load-option-B .store = \my@B ,
@@ -9,7 +9,7 @@
   preamble-option-D .store = \my@D ,
   preamble-option-D .usage = preamble
 }
-\ProcessKeysOptions
+\ProcessKeyOptions
 \newcommand\mypkgtest{%
   \begingroup
     \edef\x{\my@A:\my@B:\my@C:\my@D}%
@@ -32,18 +32,18 @@
 \mypkgtest
 \usepackage[load-option-B = 555]{mypkg}                           % 5
 \mypkgtest
-\SetKeysOptions[mypkg]{load-option-A = 666}                       % 6 
+\SetKeys[mypkg]{load-option-A = 666}                       % 6 
 \mypkgtest
 \usepackage[preamble-option-D = 777]{mypkg}                       % 7
 \mypkgtest
-\SetKeysOptions[mypkg]{preamble-option-D = 888}                   % 8 
+\SetKeys[mypkg]{preamble-option-D = 888}                   % 8 
 \mypkgtest
 
 \OMIT
 \begin{document}
 \TIMO
 
-\SetKeysOptions[mypkg]{general-option-C = 999,
+\SetKeys[mypkg]{general-option-C = 999,
   preamble-option-D = 999} % 9 
 \mypkgtest
 

--- a/base/testfiles/github-0710.tlg
+++ b/base/testfiles/github-0710.tlg
@@ -37,8 +37,8 @@ l. ...\mypkgtest
 (LaTeX3)        package "mypkg".
 For immediate help type H <return>.
  ...                                              
-l. ...\SetKeysOptions[mypkg]{load-option-A = 666}
-                                                                       % 6
+l. ...\SetKeys[mypkg]{load-option-A = 666}
+                                                                % 6
 LaTeX was asked to set a key called "load-option-A", but this is only allowed
 in the optional argument when loading package "mypkg".
 > \x=macro:

--- a/base/testfiles/github-0710.tlg
+++ b/base/testfiles/github-0710.tlg
@@ -1,0 +1,48 @@
+This is a generated file for the LaTeX2e validation system.
+Don't change this file in any respect.
+Author: Joseph Wright
+(mypkg.sty)
+> \x=macro:
+->111::.
+\mypkgtest ...f \x {\my@A :\my@B :\my@C }\show \x 
+                                                  \endgroup 
+l. ...\mypkgtest
+LaTeX3 Warning: Package "mypkg" has already been loaded: ignoring load-time
+(LaTeX3)        option "load-option-A".
+> \x=macro:
+->111::.
+\mypkgtest ...f \x {\my@A :\my@B :\my@C }\show \x 
+                                                  \endgroup 
+l. ...\mypkgtest
+LaTeX3 Warning: Package "mypkg" has already been loaded: ignoring load-time
+(LaTeX3)        option "load-option-A".
+> \x=macro:
+->111::333.
+\mypkgtest ...f \x {\my@A :\my@B :\my@C }\show \x 
+                                                  \endgroup 
+l. ...\mypkgtest
+> \x=macro:
+->111::333.
+\mypkgtest ...f \x {\my@A :\my@B :\my@C }\show \x 
+                                                  \endgroup 
+l. ...\mypkgtest
+LaTeX3 Warning: Package "mypkg" has already been loaded: ignoring load-time
+(LaTeX3)        option "load-option-B".
+> \x=macro:
+->111::333.
+\mypkgtest ...f \x {\my@A :\my@B :\my@C }\show \x 
+                                                  \endgroup 
+l. ...\mypkgtest
+! LaTeX3 Error: Key "load-option-A" may only be used in the during loading of
+(LaTeX3)        package "mypkg".
+For immediate help type H <return>.
+ ...                                              
+l. ...\SetKeysOptions[mypkg]{load-option-A = 666}
+                                                                       % 6
+LaTeX was asked to set a key called "load-option-A", but this is only allowed
+in the optional argument when loading package "mypkg".
+> \x=macro:
+->111::333.
+\mypkgtest ...f \x {\my@A :\my@B :\my@C }\show \x 
+                                                  \endgroup 
+l. ...\mypkgtest

--- a/base/testfiles/github-0710.tlg
+++ b/base/testfiles/github-0710.tlg
@@ -3,34 +3,34 @@ Don't change this file in any respect.
 Author: Joseph Wright
 (mypkg.sty)
 > \x=macro:
-->111::.
-\mypkgtest ...f \x {\my@A :\my@B :\my@C }\show \x 
+->111:::.
+\mypkgtest ...my@A :\my@B :\my@C :\my@D }\show \x 
                                                   \endgroup 
 l. ...\mypkgtest
 LaTeX3 Warning: Package "mypkg" has already been loaded: ignoring load-time
 (LaTeX3)        option "load-option-A".
 > \x=macro:
-->111::.
-\mypkgtest ...f \x {\my@A :\my@B :\my@C }\show \x 
+->111:::.
+\mypkgtest ...my@A :\my@B :\my@C :\my@D }\show \x 
                                                   \endgroup 
 l. ...\mypkgtest
 LaTeX3 Warning: Package "mypkg" has already been loaded: ignoring load-time
 (LaTeX3)        option "load-option-A".
 > \x=macro:
-->111::333.
-\mypkgtest ...f \x {\my@A :\my@B :\my@C }\show \x 
+->111::333:.
+\mypkgtest ...my@A :\my@B :\my@C :\my@D }\show \x 
                                                   \endgroup 
 l. ...\mypkgtest
 > \x=macro:
-->111::333.
-\mypkgtest ...f \x {\my@A :\my@B :\my@C }\show \x 
+->111::333:.
+\mypkgtest ...my@A :\my@B :\my@C :\my@D }\show \x 
                                                   \endgroup 
 l. ...\mypkgtest
 LaTeX3 Warning: Package "mypkg" has already been loaded: ignoring load-time
 (LaTeX3)        option "load-option-B".
 > \x=macro:
-->111::333.
-\mypkgtest ...f \x {\my@A :\my@B :\my@C }\show \x 
+->111::333:.
+\mypkgtest ...my@A :\my@B :\my@C :\my@D }\show \x 
                                                   \endgroup 
 l. ...\mypkgtest
 ! LaTeX3 Error: Key "load-option-A" may only be used in the during loading of
@@ -42,7 +42,29 @@ l. ...\SetKeysOptions[mypkg]{load-option-A = 666}
 LaTeX was asked to set a key called "load-option-A", but this is only allowed
 in the optional argument when loading package "mypkg".
 > \x=macro:
-->111::333.
-\mypkgtest ...f \x {\my@A :\my@B :\my@C }\show \x 
+->111::333:.
+\mypkgtest ...my@A :\my@B :\my@C :\my@D }\show \x 
+                                                  \endgroup 
+l. ...\mypkgtest
+> \x=macro:
+->111::333:777.
+\mypkgtest ...my@A :\my@B :\my@C :\my@D }\show \x 
+                                                  \endgroup 
+l. ...\mypkgtest
+> \x=macro:
+->111::333:888.
+\mypkgtest ...my@A :\my@B :\my@C :\my@D }\show \x 
+                                                  \endgroup 
+l. ...\mypkgtest
+! LaTeX3 Error: Key "preamble-option-D" may only be used in the preamble.
+For immediate help type H <return>.
+ ...                                              
+l. ......l-option-C = 999, preamble-option-D = 999}
+                                                   % 9
+LaTeX was asked to set a key called "preamble-option-D", but this is only
+allowed before \begin {document}. You will need to set the key earlier.
+> \x=macro:
+->111::999:888.
+\mypkgtest ...my@A :\my@B :\my@C :\my@D }\show \x 
                                                   \endgroup 
 l. ...\mypkgtest

--- a/base/testfiles/github-0710.tlg
+++ b/base/testfiles/github-0710.tlg
@@ -59,8 +59,8 @@ l. ...\mypkgtest
 ! LaTeX3 Error: Key "preamble-option-D" may only be used in the preamble.
 For immediate help type H <return>.
  ...                                              
-l. ......l-option-C = 999, preamble-option-D = 999}
-                                                   % 9
+l. ...  preamble-option-D = 999}
+                                % 9
 LaTeX was asked to set a key called "preamble-option-D", but this is only
 allowed before \begin {document}. You will need to set the key earlier.
 > \x=macro:

--- a/base/testfiles/tlb-rollback-005.luatex.tlg
+++ b/base/testfiles/tlb-rollback-005.luatex.tlg
@@ -1,7 +1,7 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 > \@kernel@after@begindocument=macro:
-->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##1}{\keys_set:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
+->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##2}{\keys_define:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
 l. ...\makeatletter\show\@kernel@after@begindocument
                                                 \makeatother
 (latexrelease.sty
@@ -709,7 +709,7 @@ Applying: [....-..-..] UTF-8 default on input line ....
 Already applied: [....-..-..] UTF-8 default on input line ....
 )
 > \@kernel@after@begindocument=macro:
-->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##1}{\keys_set:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
+->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##2}{\keys_define:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
 l. ...\makeatletter\show\@kernel@after@begindocument
                                                  \makeatother
 (minimal.cls

--- a/base/testfiles/tlb-rollback-005.luatex.tlg
+++ b/base/testfiles/tlb-rollback-005.luatex.tlg
@@ -1,7 +1,7 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 > \@kernel@after@begindocument=macro:
-->\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
+->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##1}{\keys_set:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
 l. ...\makeatletter\show\@kernel@after@begindocument
                                                 \makeatother
 (latexrelease.sty
@@ -709,7 +709,7 @@ Applying: [....-..-..] UTF-8 default on input line ....
 Already applied: [....-..-..] UTF-8 default on input line ....
 )
 > \@kernel@after@begindocument=macro:
-->\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
+->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##1}{\keys_set:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
 l. ...\makeatletter\show\@kernel@after@begindocument
                                                  \makeatother
 (minimal.cls

--- a/base/testfiles/tlb-rollback-005.tlg
+++ b/base/testfiles/tlb-rollback-005.tlg
@@ -1,7 +1,7 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 > \@kernel@after@begindocument=macro:
-->\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
+->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##1}{\keys_set:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
 l. ...\makeatletter\show\@kernel@after@begindocument
                                                   \makeatother
 (latexrelease.sty
@@ -1132,7 +1132,7 @@ Now handling font encoding U ...
 Already applied: [....-..-..] UTF-8 default on input line ....
 )
 > \@kernel@after@begindocument=macro:
-->\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
+->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##1}{\keys_set:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
 l. ......eatletter\show\@kernel@after@begindocument
                                                   \makeatother
 (minimal.cls

--- a/base/testfiles/tlb-rollback-005.tlg
+++ b/base/testfiles/tlb-rollback-005.tlg
@@ -1,7 +1,7 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 > \@kernel@after@begindocument=macro:
-->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##1}{\keys_set:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
+->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##2}{\keys_define:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
 l. ...\makeatletter\show\@kernel@after@begindocument
                                                   \makeatother
 (latexrelease.sty
@@ -1132,7 +1132,7 @@ Now handling font encoding U ...
 Already applied: [....-..-..] UTF-8 default on input line ....
 )
 > \@kernel@after@begindocument=macro:
-->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##1}{\keys_set:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
+->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##2}{\keys_define:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
 l. ......eatletter\show\@kernel@after@begindocument
                                                   \makeatother
 (minimal.cls

--- a/base/testfiles/tlb-rollback-005.xetex.tlg
+++ b/base/testfiles/tlb-rollback-005.xetex.tlg
@@ -1,7 +1,7 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 > \@kernel@after@begindocument=macro:
-->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##1}{\keys_set:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
+->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##2}{\keys_define:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
 l. ...\makeatletter\show\@kernel@after@begindocument
                                                   \makeatother
 (latexrelease.sty
@@ -706,7 +706,7 @@ Applying: [....-..-..] UTF-8 default on input line ....
 Already applied: [....-..-..] UTF-8 default on input line ....
 )
 > \@kernel@after@begindocument=macro:
-->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##1}{\keys_set:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
+->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##2}{\keys_define:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
 l. ......eatletter\show\@kernel@after@begindocument
                                                   \makeatother
 (minimal.cls

--- a/base/testfiles/tlb-rollback-005.xetex.tlg
+++ b/base/testfiles/tlb-rollback-005.xetex.tlg
@@ -1,7 +1,7 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 > \@kernel@after@begindocument=macro:
-->\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
+->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##1}{\keys_set:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
 l. ...\makeatletter\show\@kernel@after@begindocument
                                                   \makeatother
 (latexrelease.sty
@@ -706,7 +706,7 @@ Applying: [....-..-..] UTF-8 default on input line ....
 Already applied: [....-..-..] UTF-8 default on input line ....
 )
 > \@kernel@after@begindocument=macro:
-->\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
+->\prop_map_inline:Nn \l_keys_usage_preamble_prop {\clist_map_inline:nn {##1}{\keys_set:nn {##1}{####1.code:n=\msg_error:nnn {keys}{preamble-only}{####1}}}}\__hook_cmd_begindocument_code: \bool_gset_true:N \g__pdf_init_bool .
 l. ......eatletter\show\@kernel@after@begindocument
                                                   \makeatother
 (minimal.cls


### PR DESCRIPTION
There are a few internal changes, but the main obvious
one is that the family name is made optional:
this will likely help 'detect' that code has been updated.

**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

-  Feedback wanted 
- Under development
- [X] Ready to merge

## Checklist of required changes before merge will be approved
- [X] Test file(s) added
- [X] Version and date string updated in changed source files
- [X] Relevant `\changes` entries in source included
- [X] Relevant `changes.txt` updated
- [X] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
