### PR TITLE
Make a wide table narrower

### DIFF
--- a/base/doc/fntguide.tex
+++ b/base/doc/fntguide.tex
@@ -362,8 +362,8 @@ The author commands for fonts set the five attributes:
     |\textsc{..}| or |\scshape|        & shape  & |sc|      \\
     |\textssc{..}| or |\sscshape|      & shape  & |ssc|     \\
     |\textsw{..}| or |\swshape|        & shape  & |sw|      \\
-    |\textulc{..}| or |\ulcshape|      & shape  & |ulc| (virtual) $\to$ |n|, |it|, |sl| or |ssc| \\
-    |\textup{..}| or |\upshape|        & shape  & |up|  (virtual) $\to$ |n| or |sc|    \\[1pt]
+    |\textulc{..}| or |\ulcshape|      & shape  & |ulc|\textsuperscript{*} \\
+    |\textup{..}| or |\upshape|        & shape  & |up|\textsuperscript{**} \\[1pt]
     |\tiny|                            & size   & |5pt|     \\
     |\scriptsize|                      & size   & |7pt|     \\
     |\footnotesize|                    & size   & |8pt|     \\
@@ -373,7 +373,10 @@ The author commands for fonts set the five attributes:
     |\Large|                           & size   & |14.4pt|  \\
     |\LARGE|                           & size   & |17.28pt| \\
     |\huge|                            & size   & |20.74pt| \\
-    |\Huge|                            & size   & |24.88pt|
+    |\Huge|                            & size   & |24.88pt| \\[3pt]
+    \multicolumn{3}{@{}p{8cm}}{\footnotesize
+    \textsuperscript{*}\,(virtual) $\to$ |n|, |it|, |sl| or |ssc|\quad
+    \textsuperscript{**}\,(virtual) $\to$ |n| or |sc|}
   \end{tabular}
 \end{center}
 The values used by these commands are determined by the document class,


### PR DESCRIPTION
* base/doc/fntguide.tex (subsection{Text font attributes}): Narrow
a wide table with a footnote.