### PR TITLE
docs: Add syntax entries for `\LogHook` and `\hook_log:n`

### DIFF
--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -32,7 +32,7 @@
 %
 %    \begin{macrocode}
 \def\lthooksversion{v1.0s}
-\def\lthooksdate{2021/11/26}
+\def\lthooksdate{2021/12/31}
 %    \end{macrocode}
 %
 %<*driver>
@@ -783,6 +783,7 @@
 % \begin{function}{\ShowHook,\LogHook}
 %   \begin{syntax}
 %     \cs{ShowHook} \Arg{hook}
+%     \cs{LogHook}  \Arg{hook}
 %   \end{syntax}
 %   Displays information about the \meta{hook} such as
 %   \begin{itemize}
@@ -1081,6 +1082,7 @@
 % \begin{function}{\hook_show:n,\hook_log:n}
 %   \begin{syntax}
 %     \cs{hook_show:n} \Arg{hook}
+%     \cs{hook_log:n}  \Arg{hook}
 %   \end{syntax}
 %   Displays information about the \meta{hook} such as
 %   \begin{itemize}


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

After a second look, I changed my idea to only add syntax entries for `\LogHook` and `\hook_log:n`.

Closes #738

## Status of pull request

- Feedback wanted
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
