### PR TITLE
Testmetadata

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -5,6 +5,10 @@ It is provided for convenience only.  It therefore makes no claims to
 completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 ================================================================================
+2021-12-30 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
+
+	* ltmeta.dtx:
+	Adapted bundle name to new name `LaTeX-lab'
 
 2021-12-27  Marcel Krüger  <Marcel.Krueger@latex-project.org>
   * ltluatex.dtx:

--- a/base/doc/ltnews35.tex
+++ b/base/doc/ltnews35.tex
@@ -34,7 +34,7 @@
 
 \documentclass{ltnews}
 
-%%  Maybe needed only for Chris' inadequate system:  
+%%  Maybe needed only for Chris' inadequate system:
 \providecommand\Dash {\unskip \textemdash}
 
 %% NOTE:  Chris' preferred hyphens!
@@ -70,7 +70,7 @@
           	    {github issue#1 #2}%
            )}%
      \par\smallskip}
-%% But Chris has to mostly disable \href for his TEXPAD app:  
+%% But Chris has to mostly disable \href for his TEXPAD app:
 %%  \def\href #1{}  % Only For Chris' deficient TeX engine
 
 % simple solution right now (just link to the first issue if there are more)
@@ -178,6 +178,10 @@ using it. At the same time, not using the new consolidated interface
 means that existing documents are in no way affected by the work that
 is carried out and is in a wider alpha or beta test phase.
 
+Documentation about the new command and 
+already existing keys are in \file{l3meta.pdf} and \file{documentmetadata-support.pdf} 
+and also in the documentation of the \pkg{pdfmanagement-testphase} package.
+
 \emph{either add info about some already existing keys or add a
   reference to the place the the right documentation about this is
   stored (to be determined).}
@@ -204,13 +208,13 @@ document-level, the small package \pkg{xfp} defined \cs{fpeval} and
 
 An example of use could be the following:
 \begin{verbatim}
-\LaTeX{} can now compute: 
+\LaTeX{} can now compute:
 \[ \frac{\sin (3.5)}{2} + 2\cdot 10^{-3}
     = \fpeval{sin(3.5)/2 + 2e-3}         \]
 \end{verbatim}
 which produces the following output:
 \begin{quote}
-\LaTeX{} can now compute: 
+\LaTeX{} can now compute:
 \[ \frac{\sin (3.5)}{2} + 2\cdot 10^{-3}
    = \fpeval{sin(3.5)/2 + 2e-3}         \]
 \end{quote}
@@ -223,7 +227,7 @@ other three commands are essentially thin wrappers for \cs{numexpr},
 peculiars and limitations in expressiveness.
 \begin{verbatim}
 \newcommand\calulateheight[1]{%
-  \setlength\textheight{\dimeval{\topskip 
+  \setlength\textheight{\dimeval{\topskip
         + \baselineskip * \inteval{#1-1}}}}
 \end{verbatim}
 The above, for example, calculates the appropriate \cs{textheight} for

--- a/base/ltmeta.dtx
+++ b/base/ltmeta.dtx
@@ -134,13 +134,13 @@
 %    The above file is changing \cs{DocumentMetadata} to a suitable
 %    definition (or so we hope), so that we can try again --- if not
 %    tough.
-% 
+%
 %    If the file can't be found we say so and carry on without it.
 %    \begin{macrocode}
      {%
        \@latex@error{No support files for
                     \noexpand\DocumentMetadata found}
-         {Is the 'documentmetadata-support' bundle installed?%
+         {Is the 'LaTeX-lab' bundle installed?%
          \MessageBreak
          Without it, the declaration is ignored.}%
 %    \end{macrocode}

--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -1,5 +1,11 @@
-2021-12-16  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
+2021-12-30 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
+
+	* documentmeta-support.dtx:
+	cleaned up keys and bundle name
+    * added latex-lab-testphase.dtx for wrappers for the testphase
+    key.
+
+2021-12-16 Frank Mittelbach <Frank.Mittelbach@latex-project.org>
 
 	* README.md:
 	Add the bundle to support project work.
-

--- a/required/latex-lab/documentmetadata-support.dtx
+++ b/required/latex-lab/documentmetadata-support.dtx
@@ -85,6 +85,7 @@
 %    \item[\texttt{firstaidoff}] This accepts a comma lists of keywords and disables the patches
 %    related to them. More information can be found in the documentation of
 %    \pkg{pdfmanagement-firstaid}.%
+%    \end{description}
 % \end{description}
 %
 %

--- a/required/latex-lab/documentmetadata-support.dtx
+++ b/required/latex-lab/documentmetadata-support.dtx
@@ -166,24 +166,16 @@
         \cs_set_protected:Npn \DocumentMetadata ##1
           {
             \keys_set_filter:nnn  { document / metadata } { init } { ##1 }
-%FMi
             \str_remove_all:cn {opt@hyperref.sty}{customdriver=hgeneric-testphase}
-%FMi this doesn't seem to need the F case if we move the removal to
-%    the front
             \bool_if:NT \g__pdfmanagement_active_bool
              {
-%FMi               \str_remove_all:cn {opt@hyperref.sty}{customdriver=hgeneric-testphase}
                \PassOptionsToPackage{customdriver=hgeneric-testphase}{hyperref}
              }
-%FMi             {
-%FMi               \str_remove_all:cn {opt@hyperref.sty}{customdriver=hgeneric-testphase}
-%FMi             }
           }
 %    \end{macrocode}
-% Load more modules, the testphase code and the firstaid code.
+% Load more modules, the testphase code and the firstaid code. The code is only
+% loaded in the first \cs{DocumentMetadata} call!
 %    \begin{macrocode}
-%FMi this doesn't look correct -- testphase code is not loaded if only
-%    in second call --- see test 001
         \g_@@_testphase_tl
         \RequirePackage{pdfmanagement-firstaid}
       }
@@ -199,6 +191,7 @@
 %FMi
 %FMi \clist_new:N \g_@@_firstaidoff_clist
 %FMi \tl_new:N \g_@@_testphase_tl
+% UFi should the definition move to here?
 \keys_define:nn { document / metadata }
   {
     backend .choices:nn =
@@ -341,32 +334,3 @@
 %
 % \Finale
 %
-
-\endinput
-
-\prop_new:N \g__pdfmanagement_documentproperties_prop %
-\NewDocumentCommand\AddToDocumentProperties{O{\@currname}mm}
-  {
-    \exp_args:NNx
-      \prop_gput:Nnn \g__pdfmanagement_documentproperties_prop
-        {
-          \tl_if_blank:eTF {#1}{top-level/}{#1/} #2
-        }
-        { #3}
-  }
-\NewExpandableDocumentCommand\GetDocumentProperties{m}
-  {
-    \prop_item:Nn \g__pdfmanagement_documentproperties_prop {#1}
-  }
-\msg_new:nnn  { pdfmanagement } { show-properties }
-  {
-    The~following~document~properties~have~been~stored:
-    #1
-  }
-\NewDocumentCommand\ShowDocumentProperties {}
-  {
-    \msg_show:nnx {pdfmanagement}{show-properties}
-      {
-        \prop_map_function:NN \g__pdfmanagement_documentproperties_prop \msg_show_item:nn
-      }
-  }

--- a/required/latex-lab/documentmetadata-support.dtx
+++ b/required/latex-lab/documentmetadata-support.dtx
@@ -41,57 +41,52 @@
 %
 %    Currently the following keys are implemented:
 %
-%    \begin{description}
-%       \item[\texttt{backend}] to specify the backend to use; this is
-%          usually determined automatically.
-%          A backend which can't be detected automatically like |dvipdfmx|,
-%          must be set in the first \cs{DocumentMetadata}.
-%^^A       This will probably be extended to  pass the value also to packages.
+% Currently the following keys are implemented
 %
-%       \item[\texttt{pdfversion}] e.g. \texttt{pdfversion=1.7}
+% \begin{description}
+%    \item[\texttt{backend}] passes the backend name to expl3.
+%^^A    This will probably be extended to  pass the value also to packages.
+%    \item[\texttt{pdfversion}] e.g. \texttt{pdfversion=1.7}
+%    \item[\texttt{uncompress}] no value. Forces an uncompressed pdf.
+%    \item[\texttt{lang}] to set the Lang entry in the Catalog.
+%    E.g. \texttt{lang=de-DE}. The initial value is |en-US|
+%    \item[\texttt{pdfstandard}] Choice key to set the pdf standard.
+%      Currently |A-1b|, |A-2a|, |A-2b|, |A-2u|, |A-3a|, |A-3b| and |A-3u| are accepted as
+%      values. The casing is irrelevant, |a-1b| works too.
+%      The underlying code to ensure the requirements (as far as they
+%      can be ensured) is incomplete, but a color profile is included and the
+%      /OutputIntent is set. The |u| variants for example do not force unicode,
+%      but they will pass the information to hyperref and hyperxmp. The |a| variants
+%      do \emph{not} enforce (or even test) a tagged pdf yet.
+%      More information can be found in the documentation
+%      of \pkg{l3pdfmeta}.
+%    \item[\texttt{colorprofiles}] This allows to load icc-colorprofiles. Details
+%    are described in the documentation of \pkg{l3pdfmeta}.
+%    \item[\texttt{testphase}] This key is used to load testphase code. The values it accepts
+%    and their effect will change over time, when testphase packages are added or
+%    removed when the code is moved into the kernel. The value
+%    \texttt{tagpdf} will load the tagpdf package. It will also issue
+%    |\tagpdfsetup{activate,paratagging,interwordspace}| and so activate tagging.
+%    Other values will be added later.
+%    The |testphase| key can only be used in the first \cs{DocumentMetadata}.
+%    \item[\texttt{activate}] This key is used to enable some document wide functions. It is
+%    currently in an experimental state. The values and their behaviour are subject to change.
+%    Currently the only value is |tagging|,
+%    which will do |\tagpdfsetup{activate,paratagging,interwordspace}|. It requires that
+%    \pkg{tagpdf} has been loaded first with the |testphase| key.
+%    \item[\texttt{debug}] This key activates some debug options. It takes a list of key-values
+%    as value. Currently the following keys are known:
+%     \begin{description}
+%     \item[\texttt{para}] with the default and only value |show|. It will activate the |paratagging-show|
+%     option of \pkg{tagpdf},
+%     \item[\texttt{log}]  with the values as described in the documentation \pkg{tagpdf},
+%     \item[\texttt{uncompress}] which does the same as |uncompress| as main key
+%     \item[\texttt{pdfmanagement}] a boolean which allows to deactivate the pdfmanagement.
+%    \item[\texttt{firstaidoff}] This accepts a comma lists of keywords and disables the patches
+%    related to them. More information can be found in the documentation of
+%    \pkg{pdfmanagement-firstaid}.%
+% \end{description}
 %
-%       \item[\texttt{uncompress}] no value. Forces an uncompressed pdf.
-%
-%       \item[\texttt{lang}] to set the Lang entry in the Catalog.
-%          E.g. \texttt{lang=de-DE}. The initial value is |en-US|
-%
-%       \item[\texttt{pdfstandard}] Choice key to set the pdf standard.
-%         Currently |A-1b|, |A-2a|, |A-2b|, |A-2u|, |A-3a|, |A-3b| and |A-3u| are accepted as
-%         values. The casing is irrelevant, |a-1b| works too.
-%         The underlying code to ensure the requirements (as far as they
-%         can be ensured) is incomplete, but a color profile is included and the
-%         /OutputIntent is set. The |u| variants for example do not force unicode,
-%         but they will pass the information to hyperref and hyperxmp. The |a| variants
-%         do \emph{not} enforce (or even test) a tagged pdf yet.
-%         More information can be found in the documentation
-%         of \pkg{l3pdfmeta}.
-%
-%       \item[\texttt{colorprofiles}] This allows to load icc-colorprofiles. Details
-%       are described in the documentation of \pkg{l3pdfmeta}.
-%
-%       \item[\texttt{pdfmanagement}] Boolean. This activates/deactivates
-%         the core management code. By default the value is true.
-%
-%       \item[\texttt{firstaidoff}] This accepts a comma lists of keywords and disables the patches
-%       related to them. More information can be found in the documentation of
-%       \pkg{pdfmanagement-firstaid}.
-%
-%       \item[\texttt{testphase}] This key is used to load testphase code. The values it accepts
-%       and their effect will change over time, when testphase packages are added or
-%       removed when the code is moved into the kernel. Currently the accepted values are
-%       \texttt{tagpdf} (this loads the tagpdf package), \texttt{headings} (this loads
-%       code which reimplements heading commands), and \texttt{ptagging}, which loads code
-%       to allow paragraph tagging to work with engines other than luatex.
-%       \item[\texttt{activate}] This key is used to enable some document wide functions. It is
-%       currently in an experimental state. The values and their behaviour are subject to change.
-%       Currently the only value is |tagging|,
-%       which will do |\tagpdfsetup{activate,paratagging,interwordspace}|. It requires that
-%       \pkg{tagpdf} has been loaded first with the |testphase| key.
-%       \item[\texttt{debug}] This key activates some debug options. Currently only the
-%       keys |para| (with the default and only value |show|),
-%       and |log| (with the values of \pkg{tagpdf}) and |uncompress| (which does the same
-%       as |uncompress| as main key)  are known.
-%    \end{description}
 %
 %
 %
@@ -148,10 +143,10 @@
           \file_input:n {l3backend-testphase-\c_sys_backend_str.def}
         \ExplSyntaxOff\makeatother
 %    \end{macrocode}
-%    Set the default language, process the rest of the keys,
+%    Set the default language (this requires that the backend has been loaded),
+%    process the rest of the keys,
 %    and setup the generic driver.
 %    \begin{macrocode}
-%FMi wouldn't it be cleaner to set the default when declaring the key?
         \keys_set_filter:nnn  { document / metadata } { init } { lang=en-US, #1 }
         \bool_if:NT \g__pdfmanagement_active_bool
           {
@@ -191,7 +186,7 @@
         \g__pdfmanagement_testphase_tl
         \RequirePackage{pdfmanagement-firstaid}
       }
-}
+  }
 %    \end{macrocode}
 %  \end{macro}
 
@@ -199,20 +194,22 @@
 
 
 %    \begin{macrocode}
-
 %FMi defined elsewhere
 %FMi
 %FMi \clist_new:N \g__pdfmanagement_firstaidoff_clist
 %FMi \tl_new:N \g__pdfmanagement_testphase_tl
+\keys_define:nn { document / metadata }
+  {
+    backend .choices:nn =
+      { dvipdfmx , dvips , dvisvgm , luatex , pdftex , pdfmode , xdvipdfmx , xetex }
+      {
+        \sys_load_backend:n {#1}
+      },
+    backend .groups:n = { init } ,
+  }
 
 \keys_define:nn { document / metadata }
   {
-     backend .choices:nn =
-       { dvipdfmx , dvips , dvisvgm , luatex , pdftex , pdfmode , xdvipdfmx , xetex }
-       {
-        \sys_load_backend:n {#1}
-      },
-    ,backend .groups:n = { init }
     ,pdfversion .code:n =
       {
         \pdf_version_gset:n { #1 }
@@ -248,57 +245,38 @@
       {
         \msg_warning:nnn{pdf}{unknown-standard}{#1}
       }
-    ,pdfmanagement .bool_gset:N = \g__pdfmanagement_active_bool
-    ,firstaidoff .clist_gset:N = \g__pdfmanagement_firstaidoff_clist
     ,testphase .multichoice:
     ,testphase / tagpdf .code:n =
       {
-        \tl_gput_right:Nn\g__pdfmanagement_testphase_tl
+        \tl_gput_right:Nn\g_@@_testphase_tl
           {
-            \RequirePackage{tagpdf}
-            \AddToDocumentProperties [document]{testphase/tagpdf}{loaded}
-          }
-      }
-    ,testphase / headings .code:n =
-      {
-        \tl_gput_right:Nn\g__pdfmanagement_testphase_tl
-          {
-            \RequirePackage{headings-testphase}
-            \AddToDocumentProperties [document]{testphase/headings}{loaded}
-          }
-      }
-    ,testphase / ptagging .code:n =
-      {
-        \tl_gput_right:Nn\g__pdfmanagement_testphase_tl
-          {
-            \AddToHook{class/after}
+            \file_if_exist_input:nF {tagpdf-latex-lab-testphase.ltx}
               {
-                \RequirePackage{ptagging-testphase}
-                \AddToDocumentProperties [document]{testphase/ptagging}{loaded}
+                \RequirePackage{tagpdf}
+                \AddToDocumentProperties [document]{testphase/tagpdf}{loaded}
+                \tagpdfsetup{activate,paratagging,interwordspace}
+                \AddToDocumentProperties [document]{tagging}{active}
+                \AddToDocumentProperties [document]{tagging/para}{active}
+                \AddToDocumentProperties [document]{tagging/interwordspace}{active}
               }
           }
       }
     ,testphase / unknown .code:n =
       {
-        \tl_gput_right:Nn\g__pdfmanagement_testphase_tl
+        \tl_gput_right:Nn\g_@@_testphase_tl
            {
-             \AddToHook{class/after}
-               {
-                 \RequirePackage{#1-testphase}
-                 \AddToDocumentProperties [document]{testphase/#1}{loaded}
-               }
+             \file_if_exist_input:nF {#1-latex-lab-testphase.ltx}
+              {
+                 \msg_warning:nnn{meta}{latex-lab-pkg-missing}{#1}
+              }
            }
       }
     ,activate .multichoice:
     ,activate / tagging .code:n =
       {
-        \AddToHook{package/after/tagpdf}
-          {
-            \tagpdfsetup{activate,paratagging,interwordspace}
-            \AddToDocumentProperties [document]{tagging}{active}
-            \AddToDocumentProperties [document]{tagging/para}{active}
-            \AddToDocumentProperties [document]{tagging/interwordspace}{active}
-          }
+        \PackageWarning{pdfmanagement-testphase}
+         {The~activate~key~is~deprecated.\MessageBreak
+          Tagging~is~activated~with~'testphase=tagpdf'~directly}{}
       }
     ,debug .code:n =
       {
@@ -306,30 +284,48 @@
       }
     ,debug / para .code:n =
       {
-        \AddToHook{package/after/tagpdf}
+        \AddToHook
           {
-            \tagpdfsetup{paratagging-show}
+            package/tagpdf/after
+          }
+          {
+             \tagpdfsetup{paratagging-show}
           }
       }
     ,debug / log .code:n =
       {
-        \AddToHook{package/after/tagpdf}
+        \AddToHook
           {
-            \tagpdfsetup{log=#1}
+           package/tagpdf/after
+          }
+          {
+             \tagpdfsetup{log=#1}
           }
       }
     ,debug / uncompress .code:n =
       {
         \pdf_uncompress:
       }
+    ,debug / pdfmanagement .bool_gset:N = \g_@@_active_bool
+    ,debug / firstaidoff .clist_gset:N = \g_@@_firstaidoff_clist
   }
+
+
 %    \end{macrocode}
-%
+% \subsection{Messages}
 %    \begin{macrocode}
-\msg_new:nnn  { meta } { after-class }
-              {
+%UFi is meta the right module name here?
+\prop_gput:Nnn \g_msg_module_type_prop { meta } { LaTeX }
+\prop_gput:Nnn \g_msg_module_name_prop { meta } { DocumentMetadata }
+
+\msg_new:nnn { meta } { after-class }
+             {
                 \token_to_str:N \DocumentMetadata \c_space_tl
                 should~be~used~only~before~\token_to_str:N\documentclass
+             }
+\msg_new:nnn { meta } { latex-lab-pkg-missing }
+             {
+               LaTeX-lab~package~'#1'~not~found.
               }
 %    \end{macrocode}
 %
@@ -344,8 +340,6 @@
 %
 % \Finale
 %
-
-
 
 \endinput
 

--- a/required/latex-lab/documentmetadata-support.dtx
+++ b/required/latex-lab/documentmetadata-support.dtx
@@ -339,7 +339,7 @@
 %
 %
 %    \begin{macrocode}
-%<*code>
+%</code>
 %    \end{macrocode}
 %
 % \Finale

--- a/required/latex-lab/documentmetadata-support.dtx
+++ b/required/latex-lab/documentmetadata-support.dtx
@@ -39,9 +39,8 @@
 %
 % \section{Introduction}
 %
-%    Currently the following keys are implemented:
+% Currently the following keys are implemented for \cs{DocumentMetadata}:
 %
-% Currently the following keys are implemented
 %
 % \begin{description}
 %    \item[\texttt{backend}] passes the backend name to expl3.

--- a/required/latex-lab/documentmetadata-support.dtx
+++ b/required/latex-lab/documentmetadata-support.dtx
@@ -12,7 +12,7 @@
 %
 % The development version of the bundle can be found below
 %
-%    https://github.com/FrankMittelbach/
+%    https://github.com/latex3/latex2e
 %
 % for those people who are interested or want to report an issue.
 %
@@ -43,7 +43,9 @@
 %
 %    \begin{description}
 %       \item[\texttt{backend}] to specify the backend to use; this is
-%           usually determined automatically.
+%          usually determined automatically.
+%          A backend which can't be detected automatically like |dvipdfmx|,
+%          must be set in the first \cs{DocumentMetadata}.
 %^^A       This will probably be extended to  pass the value also to packages.
 %
 %       \item[\texttt{pdfversion}] e.g. \texttt{pdfversion=1.7}
@@ -114,7 +116,7 @@
 
 
 %  \begin{macro}{\DocumentMetadata}
-%    
+%
 %    \cs{DocumentMetadata} should not be used after
 %    \cs{documentclass} so we error in this case.
 %    It can be used more than once
@@ -322,7 +324,7 @@
       }
   }
 %    \end{macrocode}
-%    
+%
 %    \begin{macrocode}
 \msg_new:nnn  { meta } { after-class }
               {
@@ -373,4 +375,3 @@
         \prop_map_function:NN \g__pdfmanagement_documentproperties_prop \msg_show_item:nn
       }
   }
-

--- a/required/latex-lab/documentmetadata-support.dtx
+++ b/required/latex-lab/documentmetadata-support.dtx
@@ -96,6 +96,7 @@
 % \section{The Implementation}
 %
 %    \begin{macrocode}
+%<@@=pdfmanagement>
 %<*code>
 %    \end{macrocode}
 %
@@ -129,7 +130,7 @@
 %    The backend can contain management commands, so the boolean should
 %    be set to true first.
 %    \begin{macrocode}
-        \bool_gset_true:N \g__pdfmanagement_active_bool
+        \bool_gset_true:N \g_@@_active_bool
         \keys_set_groups:nnn { document / metadata} {init}{ #1 }
         %if no backend has been loaded force it now:
         \str_if_exist:NF \c_sys_backend_str
@@ -148,7 +149,7 @@
 %    and setup the generic driver.
 %    \begin{macrocode}
         \keys_set_filter:nnn  { document / metadata } { init } { lang=en-US, #1 }
-        \bool_if:NT \g__pdfmanagement_active_bool
+        \bool_if:NT \g_@@_active_bool
           {
             \PassOptionsToPackage{customdriver=hgeneric-testphase}{hyperref}
           }
@@ -183,7 +184,7 @@
 %    \begin{macrocode}
 %FMi this doesn't look correct -- testphase code is not loaded if only
 %    in second call --- see test 001
-        \g__pdfmanagement_testphase_tl
+        \g_@@_testphase_tl
         \RequirePackage{pdfmanagement-firstaid}
       }
   }
@@ -196,8 +197,8 @@
 %    \begin{macrocode}
 %FMi defined elsewhere
 %FMi
-%FMi \clist_new:N \g__pdfmanagement_firstaidoff_clist
-%FMi \tl_new:N \g__pdfmanagement_testphase_tl
+%FMi \clist_new:N \g_@@_firstaidoff_clist
+%FMi \tl_new:N \g_@@_testphase_tl
 \keys_define:nn { document / metadata }
   {
     backend .choices:nn =

--- a/required/latex-lab/documentmetadata-support.ins
+++ b/required/latex-lab/documentmetadata-support.ins
@@ -4,24 +4,24 @@
 %% LaTeX or TeX.
 %%
 %% Copyright 2021 LaTeX Project
-%% 
-%% 
-%% This file is part of the documentmetadata-support Bundle for LaTeX.
+%%
+%%
+%% This file is part of the `LaTeX-lab Bundle' for LaTeX.
 %% -------------------------------------------------------------------
-%% 
+%%
 %% It may be distributed and/or modified under the
 %% conditions of the LaTeX Project Public License, either version 1.3c
 %% of this license or (at your option) any later version.
 %% The latest version of this license is in
 %%    http://www.latex-project.org/lppl.txt
-%% and version 1.3c or later is part of all distributions of LaTeX 
+%% and version 1.3c or later is part of all distributions of LaTeX
 %% version 2008 or later.
-%% 
+%%
 %% In particular, NO PERMISSION is granted to modify the contents of this
 %% file since it contains the legal notices that are placed in the files
 %% it generates.
-%% 
-%% 
+%%
+%%
 %%
 %% --------------- start of docstrip commands ------------------
 %%
@@ -29,7 +29,7 @@
 
 \keepsilent
 
-\usedir{tex/latex/contrib/documentmetadata-support}
+\usedir{tex/latex/contrib/latex-lab}
 
 \preamble
 
@@ -37,7 +37,7 @@ This is a generated file.
 
 Copyright 2021 LaTeX Project
 
-This file was generated from file(s) of the LaTeX `documentmetadata-support Bundle'.
+This file was generated from file(s) of the  `LaTeX-lab Bundle'.
 ------------------------------------------------------------------------------------
 
 It may be distributed and/or modified under the
@@ -45,16 +45,16 @@ conditions of the LaTeX Project Public License, either version 1.3c
 of this license or (at your option) any later version.
 The latest version of this license is in
    http://www.latex-project.org/lppl.txt
-and version 1.3c or later is part of all distributions of LaTeX 
+and version 1.3c or later is part of all distributions of LaTeX
 version 2008 or later.
 
 This file may only be distributed together with a copy of the LaTeX
-`documentmetadata-support Bundle'. You may however distribute the `documentmetadata-support Bundle'
+`LaTeX-lab Bundle'. You may however distribute the `LaTeX-lab Bundle'
 without such generated files.
 
 The newest sources can be found below
 
-   https://github.com/latex3/documentmetadata-support/
+   https://github.com/latex3/latex2e/required/latex-lab
 
 where one can also log issues in case there are any.
 
@@ -64,4 +64,5 @@ where one can also log issues in case there are any.
 
 \generate{\file{documentmetadata-support.ltx}{\from{documentmetadata-support.dtx}{code}}}
 
+\generate{\file{tagpdf-latex-lab-testphase.ltx}{\from{latex-lab-testphase.dtx}{tagpdf}}}
 \endbatchfile

--- a/required/latex-lab/latex-lab-testphase.dtx
+++ b/required/latex-lab/latex-lab-testphase.dtx
@@ -1,0 +1,72 @@
+% \iffalse meta-comment
+%
+%% File: latex-lab-testphase.dtx (C) 2021 LaTeX Project
+%
+% It may be distributed and/or modified under the conditions of the
+% LaTeX Project Public License (LPPL), either version 1.3c of this
+% license or (at your option) any later version.  The latest version
+% of this license is in the file
+%
+%    https://www.latex-project.org/lppl.txt
+%
+%
+% The development version of the bundle can be found below
+%
+%    https://github.com/latex3/latex2e/required/latex-lab
+%
+% for those people who are interested or want to report an issue.
+%
+%<*driver>
+\documentclass{l3doc}
+\EnableCrossrefs
+\CodelineIndex
+\begin{document}
+  \DocInput{latex-lab-testphase.dtx}
+\end{document}
+%</driver>
+%
+% \fi
+%
+
+% \title{The \texttt{latex-lab-testphase} code\thanks{}}
+% \author{Ulrike Fischer \LaTeX{} Project}
+%
+% \maketitle
+%
+%
+% \begin{abstract}
+% \end{abstract}
+%
+% \section{Introduction}
+%
+%    This code implements small files which can be loaded with the |testphase|
+%    key of \cs{DocumentMetadata}. Currently it only contains a
+%    wrapper for \pkg{tagpdf}, but this will be extended to allow user to load
+%    well defined parts of the tagged PDF project.
+%
+%
+%
+% \StopEventually{\setlength\IndexMin{200pt}  \PrintIndex  }
+%
+%
+% \section{The Implementation}
+%
+%    \begin{macrocode}
+%<*tagpdf>
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+\RequirePackage{tagpdf}
+\AddToDocumentProperties [document]{testphase/tagpdf}{loaded}
+
+\tagpdfsetup{activate,paratagging,interwordspace}
+\AddToDocumentProperties [document]{tagging}{active}
+\AddToDocumentProperties [document]{tagging/para}{active}
+\AddToDocumentProperties [document]{tagging/interwordspace}{active}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%</tagpdf>
+%    \end{macrocode}
+% \Finale
+%


### PR DESCRIPTION
Add \DocumentMetadata and the needed support files. Compared to \DeclareDocumentMetadata a number of keys have been removed/moved to get a cleaner interface.

# Internal housekeeping

## Status of pull request

- Feedback wanted 
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added (one will have to remove one)
- [X ] Version and date string updated in changed source files (I hope ...)
- [X] Relevant `\changes` entries in source included (no entries)
- [X] Relevant `changes.txt` updated
- [X] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
