### PR TITLE
do not reset \operator@font when loading amsopn (see #734)

### DIFF
--- a/base/doc/ltnews35.tex
+++ b/base/doc/ltnews35.tex
@@ -472,6 +472,28 @@ is now fixed.
 
 \section{Changes to packages in the \pkg{amsmath} category}
 
+
+\subsection{\pkg{amsopn} Do not reset \cs{operator@font}}
+
+The package \pkg{amsopn} used to define \cs{operator@font} but this
+command is already provided by the \LaTeX{} format (for at least 14
+years). As a result the definition in \pkg{amsopn} is equivalent to a
+reset to the kernel definition, which is unnecessary and suprising if
+you alter the math setup (e.g., by loading a package) and at a later
+stage add \pkg{amsmath}, which then undoes part of your setup. For
+this reason the definition was taken out and
+\pkg{amsmath}/\pkg{amsopn} now relies on the format definition.
+
+In the unlikely event that you want the resetting to happen, use
+\begin{verbatim}
+  \makeatletter 
+   \def\operator@font{\mathgroup\symoperators} 
+  \makeatother
+\end{verbatim}
+after loading the package.
+%
+\githubissue{734}
+
 \subsection{???}
 %
 \githubissue{???}

--- a/required/amsmath/amsopn.dtx
+++ b/required/amsmath/amsopn.dtx
@@ -58,7 +58,7 @@ Bug reports can be opened (category \texttt{#1}) at\\%
 %    \begin{macrocode}
 \NeedsTeXFormat{LaTeX2e}% LaTeX 2.09 can't be used (nor non-LaTeX)
 [1994/12/01]% LaTeX date must December 1994 or later
-\ProvidesPackage{amsopn}[2021/08/26 v2.02 operator names]
+\ProvidesPackage{amsopn}[2022/01/20 v2.03 operator names]
 %    \end{macrocode}
 %
 %    What \cs{nolimits@} does is keep a \cn{limits} typed by the user
@@ -198,8 +198,16 @@ Bug reports can be opened (category \texttt{#1}) at\\%
 %    more accessible so that users can call this font for use in special
 %    constructs that are not ordinary operator names but conceptually
 %    related.
+%
+%    \cs{operator@font} is also declared by the \LaTeX{} kernel (for
+%    at least 14 years), thus defining it here effectively means
+%    ``resetting it'' to the kernel value, which is counterproductive
+%    in situations where the user (or a class) has altered its
+%    definition and at a later point \pkg{amsopn} got added.
+% \changes{v2.03}{2022/01/20}{Do not reset \cs{operator@font} it is
+%    already defined in the LaTeX kernel (gh/734)}
 %    \begin{macrocode}
-\def\operator@font{\mathgroup\symoperators}
+%\def\operator@font{\mathgroup\symoperators} % commented out in 2.03
 \def\operatorfont{\operator@font}
 %    \end{macrocode}
 % \end{macro}

--- a/required/amsmath/changes.txt
+++ b/required/amsmath/changes.txt
@@ -1,3 +1,9 @@
+2022-01-20  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
+
+	* amsopn.dtx:
+	Do not define/reset \operator@font; it is already defined in
+	the LaTeX kernel (gh/734)
+
 2021-11-18  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 
 	* All *.dtx: Replaced \StopEventually by \MaybeStop

--- a/required/amsmath/testfiles/github-0734.lvt
+++ b/required/amsmath/testfiles/github-0734.lvt
@@ -1,0 +1,17 @@
+\documentclass{article}
+
+\input{test2e}
+
+\makeatletter
+\def\operator@font{XXX}   % doesn't matter what it is defined to
+\makeatother
+
+\usepackage{amsopn}
+
+\START
+
+\makeatletter
+\show\operator@font
+\makeatother
+
+\END

--- a/required/amsmath/testfiles/github-0734.tlg
+++ b/required/amsmath/testfiles/github-0734.tlg
@@ -1,0 +1,5 @@
+This is a generated file for the LaTeX2e validation system.
+Don't change this file in any respect.
+> \operator@font=macro:
+->XXX.
+l. ...\show\operator@font


### PR DESCRIPTION
# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [x] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [x] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
