### PR TITLE
Fix broken GitHub issue links in ltnews35.tex

### DIFF
--- a/base/doc/ltnews35.tex
+++ b/base/doc/ltnews35.tex
@@ -505,7 +505,7 @@ changes are displayed with
 as the heading (instead of just \meta{version}), when using
 \cs{PrintChanges}.
 %
-\githubissue{gh/531}
+\githubissue{531}
 
 
 
@@ -530,7 +530,7 @@ The document class \class{proc}, which is a small variation on the
 \class{article} class, now supports the \option{twoside} option
 displaying different data in the footer line on recto and verso pages.
 %
-\githubissue{gh/704}
+\githubissue{704}
 
 
 \subsection{Croatian character support}
@@ -539,7 +539,7 @@ The default \pkg{inputenc} support has been extended to support the 9 characters
 D\v Z, D\v z, d\v z, LJ, Lj, lj, NJ, Nj, nj, input as single UTF-8 code points
 in the range U+01C4 to U+01CC.
 %
-\githubissue{gh/723}
+\githubissue{723}
 
 
 \subsection{Cleanup of the Unicode declaration interface}


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

---

Three of the links to GitHub issues are broken in the draft `ltnews35.tex`. I've read the disclaimer above, but this is just a simple typo in some prerelease docs so I think that this PR should be okay, but I totally understand if you have to reject it.