### PR TITLE
Set mathdefaultsmode for LuaLaTeX

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -5,6 +5,10 @@ It is provided for convenience only.  It therefore makes no claims to
 completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 ================================================================================
+2022-05-08  Marcel Krüger  <Marcel.Krueger@latex-project.org>
+
+	* ltmath.dtx: Use more consistent default math styles on LuaLaTeX
+
 2022-04-13  Ulrike Fischer <Ulrike.Fischer@latex-project.org>
 
 	* ltxref.dtx:

--- a/base/doc/ltnews35.tex
+++ b/base/doc/ltnews35.tex
@@ -708,6 +708,27 @@ been fixed in the latest release.
 \sxissue{q/637565}
 
 
+
+\subsection{More consistent use of cramped math styles in \LuaTeX}
+
+Using \LuaTeX's \cs{Udelimiterover} to place a horizontally extensible glyph
+on top of a mathematical expression now causes the expression to be set in cramped
+style as used in similar situations by traditional \TeX\ math rendering.
+Similarly cramped style is now used for expressions set under such a delimiter
+using \cs{Uunderdelimiter} but no longer used when setting an expression on top
+of such extensible glyphs using \cs{Uoverdelimiter}.
+This new behavior follows \TeX's rule that cramped style is used whenever something
+else appears above the expression.
+Additionally the math style of these constructs can now be detected using \cs{mathstyle}.
+
+The old behavior can be restored by adding
+\begin{verbatim}
+   \mathdefaultsmode=0
+\end{verbatim}
+to a document.
+
+
+
 \section{Changes to packages in the \pkg{amsmath} category}
 
 

--- a/base/ltmath.dtx
+++ b/base/ltmath.dtx
@@ -38,7 +38,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltmath.dtx}
-              [2022/04/08 v1.2k LaTeX Kernel (Math Setup)]
+              [2022/05/08 v1.2l LaTeX Kernel (Math Setup)]
 % \iffalse
 %</driver>
 %
@@ -1089,6 +1089,18 @@
 \long\def\@ensuredmath#1{$\relax#1$}
 %    \end{macrocode}
 % \end{macro}
+%
+% \changes{v1.2l}{2022/05/08}{Use consistent math styles under \LuaTeX}
+% \LuaTeX\ contains new math primitives to place expression over or under
+% horizontally extensible glyphs. Before \LuaTeX\ 1.14 these did not work
+% correctly with the |\mathstyle| primitive and sometimes did not use
+% cramped style in consistent ways. For newer version, we opt into the
+% corrected behavior.
+%    \begin{macrocode}
+\ifx\mathdefaultsmode\@undefined\else
+  \mathdefaultsmode=1
+\fi
+%    \end{macrocode}
 %
 %    \begin{macrocode}
 %</2ekernel>


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

Fix which of the `\Udelimiterover` and friends commands in LuaTeX trigger clamped mode and how this is reported by `\mathstyle`. See the LuaTeX manual, "7.9.3 Math options with \mathdefaultsmode" or [the related thread on dev-luatex](https://www.mail-archive.com/dev-luatex@ntg.nl/msg04711.html) for details. Technically a breaking change but I couldn't find any current use of these commands in LaTeX packages in TeX Live.

Depends on LuaTeX 1.14.

# Internal housekeeping

## Status of pull request

- Feedback wanted 
<!-- - Under development -->
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [x] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
