### PR TITLE
add key to start support for pdf/A-4

### DIFF
--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -1,3 +1,8 @@
+2022-14-04 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
+
+	* documentmeta-support.dtx:
+	add key A-4 for first steps to support pdf/A-4
+
 2022-03-08 Joseph Wright <Joseph.Wright@latex-project.org>
 
 	* latex-lab-prototype.dtx

--- a/required/latex-lab/documentmetadata-support.dtx
+++ b/required/latex-lab/documentmetadata-support.dtx
@@ -18,8 +18,8 @@
 % for those people who are interested or want to report an issue.
 %
 %    \begin{macrocode}
-\def\documentmetadatasupportversion{1.0a}
-\def\documentmetadatasupportdate{2022-01-12}
+\def\documentmetadatasupportversion{1.0b}
+\def\documentmetadatasupportdate{2022-14-04}
 %    \end{macrocode}
 %
 %
@@ -108,13 +108,14 @@
 %     e.g., \texttt{lang=de-DE}. If not given the default value used is |en-US|.
 %
 %    \item[\texttt{pdfstandard}] Choice key to set the pdf standard.
-%      Currently |A-1b|, |A-2a|, |A-2b|, |A-2u|, |A-3a|, |A-3b| and |A-3u| are accepted as
+%      Currently |A-1b|, |A-2a|, |A-2b|, |A-2u|, |A-3a|, |A-3b|, |A-3u| and |A-4| are accepted as
 %      values. The casing is irrelevant, |a-1b| works too.
 %      The underlying code to ensure the requirements (as far as they
 %      can be ensured) is still incomplete, but a color profile is included and the
 %      \texttt{/OutputIntent} is set. The |u| variants for example do not force unicode,
 %      but they will pass the information to hyperref and hyperxmp. The |a| variants
-%      do \emph{not} enforce (or even test) a tagged pdf yet.
+%      do \emph{not} enforce (or even test) a tagged pdf yet. The |A-4| support is
+%      currently incomplete.
 %      More information can be found in the documentation
 %      of \pkg{l3pdfmeta}.
 %
@@ -304,7 +305,7 @@
         \keys_set:nn {document / metadata} {_pdfstandard=\str_uppercase:n{#1}}
       }
     ,_pdfstandard .choices:nn =
-      {A-1B,A-2A,A-2B,A-2U,A-3A,A-3B,A-3U}
+      {A-1B,A-2A,A-2B,A-2U,A-3A,A-3B,A-3U,A-4}
       {
         \prop_if_exist:cT { g__pdfmeta_standard_pdf/#1_prop }
           {


### PR DESCRIPTION
# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [n/a] Test file(s) added (not needed)
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated

This only add the key for the standard pdf/A-4 so that support can be started in the pdfresources. 