### PR TITLE
Set endlinechar earlier in v-type argument parser

### DIFF
--- a/base/ltcmd.dtx
+++ b/base/ltcmd.dtx
@@ -3132,6 +3132,7 @@
     \tl_set:Nn \l_@@_signature_tl {#1}
     \group_begin:
       \tex_escapechar:D = 92 \scan_stop:
+      \tex_endlinechar:D = `\^^M \scan_stop:
       \tl_clear:N \l_@@_v_arg_tl
       \peek_remove_spaces:n
         {
@@ -3295,7 +3296,6 @@
   {
     \cs_set_eq:NN \do \char_set_catcode_other:N
     \dospecials
-    \tex_endlinechar:D = `\^^M \scan_stop:
     \bool_if:NTF \l_@@_long_bool
       { \char_set_catcode_other:n { \tex_endlinechar:D } }
       { \char_set_catcode_parameter:n { \tex_endlinechar:D } }


### PR DESCRIPTION
Originally mentioned in https://github.com/latex3/latex2e/issues/876.

Currently `\command%something%` does not absorb the content between the `%`. Moving the `dospecial` to before in addition will break it. (on the other hand setting endlinechar earlier should not break anything, as far as I can see.

# Internal housekeeping

## Status of pull request

- Feedback wanted (*is this desirable? Before I take a look at the items below*)

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
