### PR TITLE
keyval.dtx: Fix a typo

### DIFF
--- a/required/graphics/keyval.dtx
+++ b/required/graphics/keyval.dtx
@@ -20,7 +20,7 @@
 %<driver>        \ProvidesFile{keyval.drv}
 % \fi
 %                \ProvidesFile{keyval.dtx}
-                 [2014/10/28 v1.15 key=value parser (DPC)]
+                 [2022/05/29 v1.15 key=value parser (DPC)]
 %
 % \iffalse
 %</!plain>
@@ -177,7 +177,7 @@
 % \section{The Internal Interface}
 % A declaration of the form:\\
 % |\define@key{family}{key}{...}|\\
-% Defines a macro |\KV@prefix@key| with one argument. When used in a
+% Defines a macro |\KV@family@key| with one argument. When used in a
 % keyval list, the macro receives the value as its argument.
 %
 % A declaration of the form:\\


### PR DESCRIPTION
* required/graphics/keyval.dtx (section{The Internal Interface}):
Fix a typo in the macro defined by \define@key.
