### PR TITLE
Only remove key name from \@unusedoptionlist

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -10,6 +10,11 @@ are not part of the distribution.
 All changes above are only part of the development branch for the next release.
 ================================================================================
 
+2022-06-16  Joseph Wright <Joseph.Wright@latex-proejct.org>
+
+	* ltkeys.dtx (subsection{Main mechanism})
+	Remove key name but avoid touching key value in \@unusedoptionlist
+
 2022-06-15  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 
 	* lthooks.dtx (subsubsection{Disabling and providing hooks}):

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltkeys.dtx}
-             [2022/02/21 v1.0f LaTeX Kernel (Kevyal options)]
+             [2022/06/16 v1.0g LaTeX Kernel (Kevyal options)]
 % \iffalse
 \documentclass{l3doc}
 \GetFileInfo{ltkeys.dtx}
@@ -277,6 +277,9 @@
 % \end{macro}
 %
 % \begin{macro}{\@@_options_class:n}
+% \changes{v1.0g}{2022/06/16}{Better handling of option removal}
+% \begin{macro}{\@@_options_remove:nnn}
+% \changes{v1.0g}{2022/06/16}{New function}
 %   For classes, each option (stripped of any content after |=|)
 %   is checked for existence as a key. If found, the option is added to
 %   the combined list for processing. On the other hand, unused options
@@ -296,18 +299,26 @@
           {
             \clist_map_inline:cn { opt@ \@currname . \@currext }
               {
-                \keys_if_exist:neTF
-                  {#1} { \@@_remove_equals:n {##1} }
-                  { \clist_put_right:Nn \l_@@_options_clist {##1} }
-                  { \clist_put_right:Nn \@unusedoptionlist {##1} }
+                \@@_options_remove:xnn
+                  { \@@_remove_equals:n {##1} }
+                  {##1} {#1}
               }
           }
       }
   }
+\cs_new_protected:Npn \@@_options_remove:nnn #1#2#3
+  {
+    \keys_if_exist:nnTF {#3} {#1}
+      { \clist_put_right:Nn \l_@@_latexe_options_clist {#2} }
+      { \clist_put_right:Nn \@unusedoptionlist {#1} }
+  }
+\cs_generate_variant:Nn \@@_options_remove:nnn { x }
 %    \end{macrocode}
+% \end{macro}
 % \end{macro}
 %
 % \begin{macro}{\@@_options_package:n}
+% \changes{v1.0g}{2022/06/16}{Better handling of option removal}
 %   For global options when processing a package, the tasks are slightly
 %   different from those for a class. The check is the same, but here
 %   there is nothing to do if the option is not applicable. Each valid
@@ -317,11 +328,9 @@
   {
     \clist_map_inline:Nn \@classoptionslist
       {
-        \keys_if_exist:neT {#1} { \@@_remove_equals:n {##1} }
-          {
-            \clist_put_right:Nn \l_@@_options_clist {##1}
-            \clist_remove_all:Nn \@unusedoptionlist {##1}
-          }
+        \@@_options_remove:xnn
+          { \@@_remove_equals:n {##1} }
+          {##1} {#1}
       }
   }
 %    \end{macrocode}

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -309,7 +309,7 @@
 \cs_new_protected:Npn \@@_options_remove:nnn #1#2#3
   {
     \keys_if_exist:nnTF {#3} {#1}
-      { \clist_put_right:Nn \l_@@_latexe_options_clist {#2} }
+      { \clist_put_right:Nn \l_@@_options_clist {#2} }
       { \clist_put_right:Nn \@unusedoptionlist {#1} }
   }
 \cs_generate_variant:Nn \@@_options_remove:nnn { x }

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -299,7 +299,7 @@
           {
             \clist_map_inline:cn { opt@ \@currname . \@currext }
               {
-                \@@_options_remove:xnn
+                \@@_options_remove:enn
                   { \@@_remove_equals:n {##1} }
                   {##1} {#1}
               }
@@ -312,7 +312,7 @@
       { \clist_put_right:Nn \l_@@_options_clist {#2} }
       { \clist_put_right:Nn \@unusedoptionlist {#1} }
   }
-\cs_generate_variant:Nn \@@_options_remove:nnn { x }
+\cs_generate_variant:Nn \@@_options_remove:nnn { e }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}
@@ -328,7 +328,7 @@
   {
     \clist_map_inline:Nn \@classoptionslist
       {
-        \@@_options_remove:xnn
+        \@@_options_remove:enn
           { \@@_remove_equals:n {##1} }
           {##1} {#1}
       }


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
- Under development
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [X] Version and date string updated in changed source files
- [X] Relevant `\changes` entries in source included
- [X] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
