### PR TITLE
Fix file names

### DIFF
--- a/base/doc/usrguide.tex
+++ b/base/doc/usrguide.tex
@@ -39,7 +39,7 @@
    \footnote{This file may distributed and/or modified under the
      conditions of the \LaTeX{} Project Public License, either version 1.3c
      of this license or (at your option) any later version. See the source
-    \texttt{usrguide3.tex} for full details.}%
+    \texttt{usrguide.tex} for full details.}%
 }
 
 \date{2022-07-05}
@@ -75,7 +75,7 @@
 \section{Introduction}
 
 \LaTeXe{} was released in 1994 and added a number of then-new concepts to
-\LaTeX{}. These are described in \texttt{usrguide-old}, which has largely remained
+\LaTeX{}. These are described in \texttt{usrguide-historic}, which has largely remained
 unchanged. Since then, the \LaTeX{} team have worked on a number of ideas,
 firstly a programming language for \LaTeX{} (\pkg{expl3}) and then a range of
 tools for document authors which build on that language. Here, we describe


### PR DESCRIPTION
* base/doc/usrguide.tex: Fix the file name in the footnote.
(section{Introduction}): Use the correct name for the old manual.
