### PR TITLE
protected@edef in option handler

### DIFF
--- a/base/ltclass.dtx
+++ b/base/ltclass.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltclass.dtx}
-             [2022/06/20 v1.5c LaTeX Kernel (Class & Package Interface)]
+             [2022/10/10 v1.5d LaTeX Kernel (Class & Package Interface)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltclass.dtx}
@@ -1302,7 +1302,10 @@
     {\@expl@@@filehook@resolve@file@subst@@w #3.#1\@nil}%
       \reserved@a\reserved@b
   \@expl@@@filehook@clear@replacement@flag@@
-  \expandafter\xdef\csname opt@\reserved@a\endcsname{%
+%    \end{macrocode}
+% \changes{v1.5d}{2022/010/10}{Use \cs{\protected@xdef}.}
+%    \begin{macrocode}
+  \expandafter\protected@xdef\csname opt@\reserved@a\endcsname{%
     \@ifundefined{opt@\reserved@a}\@empty
       {\csname opt@\reserved@a\endcsname,}%
     \zap@space#2 \@empty}%
@@ -1476,10 +1479,12 @@
 %         {Star form added.}
 % \changes{v0.2c}{1993/11/17}
 %         {restoring \cs{@fileswith@pti@ns} added.}
+% \changes{v1.5d}{2022/010/10}
+%         {Use \cs{\protected@edef}.}
 %    \begin{macrocode}
 \def\ProcessOptions{%
   \let\ds@\@empty
-  \edef\@curroptions{\@ptionlist{\@currname.\@currext}}%
+  \protected@edef\@curroptions{\@ptionlist{\@currname.\@currext}}%
   \@ifstar\@xprocess@ptions\@process@ptions}
 \@onlypreamble\ProcessOptions
 %    \end{macrocode}
@@ -2186,7 +2191,10 @@
       \@ifundefined{opt@fam@\@currname.\@currext}
         {\@onefilewithoptions@clashchk{#2}}
         {%
-          \expandafter\edef\csname opt@\@currname.\@currext\endcsname
+%    \end{macrocode}
+% \changes{v1.5d}{2022/010/10}{Use \cs{\protected@edef}.}
+%    \begin{macrocode}
+          \expandafter\protected@edef\csname opt@\@currname.\@currext\endcsname
             {\zap@space#2 \@empty}%
           \@namedef{@raw@opt@\@currname.\@currext}{#2}%
           \expandafter\expandafter\expandafter\ProcessKeyOptions
@@ -2693,10 +2701,11 @@
 % \changes{v0.2v}{1994/01/29}
 %         {Macro added.}
 % \changes{v1.0t}{1995/11/14}{Allow empty option}
+% \changes{v1.5d}{2022/010/10}{Use \cs{\protected@edef}.}
 %    \begin{macrocode}
 \def\@@unprocessedoptions{%
   \ifx\@currext\@pkgextension
-    \edef\@curroptions{\@ptionlist{\@currname.\@currext}}%
+    \protected@edef\@curroptions{\@ptionlist{\@currname.\@currext}}%
     \@for\CurrentOption:=\@curroptions\do{%
         \ifx\CurrentOption\@empty\else\@unknownoptionerror\fi}%
   \fi}

--- a/base/testfiles/github-0932.lvt
+++ b/base/testfiles/github-0932.lvt
@@ -1,0 +1,24 @@
+\begin{filecontents}{0932.sty}
+
+\ProvidesPackage{0932}
+
+\def\mainfont{\reset@font}
+
+\DeclareKeys{
+font .store = \mainfont
+}
+
+\ProcessKeyOptions
+\end{filecontents}
+
+\documentclass{article}
+
+\input{test2e}
+
+\START
+% this should not error
+\usepackage[font=\bfseries]{0932}
+
+\show\mainfont
+
+\END

--- a/base/testfiles/github-0932.tlg
+++ b/base/testfiles/github-0932.tlg
@@ -1,0 +1,8 @@
+This is a generated file for the LaTeX2e validation system.
+Don't change this file in any respect.
+(0932.sty
+Package: 0932 
+)
+> \mainfont=macro:
+->\bfseries .
+l. ...\show\mainfont


### PR DESCRIPTION


## Status of pull request


- [X] Feedback wanted 
  
  I have not added rollback which is tricky as parts of the option handler are pre-included
  in latexrelease, it could be considered  a bug-fix change which could have been done when
  raw option lists added, so I'm not sure rollig back just this part is worth the complication
  But rollback could be added if needed (I think:-)


- Ready to merge
 other than the above, and adding changes.txt and news.

## Checklist of required changes before merge will be approved
- [X] Test file(s) added
- [X] Version and date string updated in changed source files
- [X] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
