### PR TITLE
Gh953 doc: remove verb definitions no longer necessary

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -11,6 +11,14 @@ All changes above are only part of the development branch for the next release.
 ================================================================================
 
 
+2022-11-13  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
+
+	* doc.dtx:
+	Redefinitions of \verb removed as no longer needed (gh/953)
+
+	Redefinitions of \vs{@verbatim} changed to match the kernel
+	definition (gh/953)
+
 2022-11-08  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 
 	* ltshipout.dtx:

--- a/base/changes.txt
+++ b/base/changes.txt
@@ -16,7 +16,7 @@ All changes above are only part of the development branch for the next release.
 	* doc.dtx:
 	Redefinitions of \verb removed as no longer needed (gh/953)
 
-	Redefinitions of \vs{@verbatim} changed to match the kernel
+	Redefinitions of \@verbatim changed to match the kernel
 	definition (gh/953)
 
 2022-11-08  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>

--- a/base/doc.dtx
+++ b/base/doc.dtx
@@ -2695,7 +2695,7 @@
 %    first lines are copied literally from \texttt{latex.tex}.
 % \changes{v1.7i}{1992/07/12}{Added \cs{@@par} to clear possible
 %                             \cs{parshape}.}
-%  \changes{v3.0m}{2022/11/13}{Redefinitions of \vs{@verbatim} changed
+%  \changes{v3.0m}{2022/11/13}{Redefinitions of \cs{@verbatim} changed
 %     to match the kernel definition (gh/953)}
 %    \begin{macrocode}
 \def\@verbatim{\trivlist \item\relax

--- a/base/doc.dtx
+++ b/base/doc.dtx
@@ -45,7 +45,7 @@
 %<+package>
 %<+package>\ProvidesPackage{doc}
 %<+shortvrb>\ProvidesPackage{shortvrb}
-%<+package|shortvrb>  [2022/11/08 v3.0l
+%<+package|shortvrb>  [2022/11/13 v3.0m
 %<+package|shortvrb>   Standard LaTeX documentation package V3 (FMi)]
 %\catcode`\<=12
 %
@@ -82,6 +82,8 @@
 %  \changes{v1.9a}{1993/12/02}{Upgrade for LaTeX2e}
 %  \changes{v1.9d}{1993/12/20}{Protected changes entry.}
 %  \changes{v1.0p}{1994/05/21}{Use new error commands}
+%  \changes{v3.0m}{2022/11/13}{Redefinitions of \vs{verb} removed as
+%     no longer needed (gh/953)}
 %
 %
 % \hyphenation{make-index}
@@ -2693,12 +2695,16 @@
 %    first lines are copied literally from \texttt{latex.tex}.
 % \changes{v1.7i}{1992/07/12}{Added \cs{@@par} to clear possible
 %                             \cs{parshape}.}
+%  \changes{v3.0m}{2022/11/13}{Redefinitions of \vs{@verbatim} changed
+%     to match the kernel definition (gh/953)}
 %    \begin{macrocode}
-\def\@verbatim{\trivlist \item[]\if@minipage\else\vskip\parskip\fi
-      \leftskip\@totalleftmargin\rightskip\z@
-      \parindent\z@\parfillskip\@flushglue\parskip\z@
-      \@@par
-      \@tempswafalse
+\def\@verbatim{\trivlist \item\relax
+  \if@minipage\else\vskip\parskip\fi
+  \leftskip\@totalleftmargin\rightskip\z@
+  \parindent\z@\parfillskip\@flushglue\parskip\z@
+  \language\l@nohyphenation
+  \@@par
+  \@tempswafalse
 %    \end{macrocode}
 %    |\@verbatim| sets |^^M|, the end of line character, to
 %    be equal to |\par|.  This control sequence is redefined
@@ -2706,8 +2712,13 @@
 %    \changes{v1.7c}{1992/03/24}{Added \cs{interlinepenalty} to
 %                             \cs{par} from verbatim.sty}
 %    \begin{macrocode}
- \def\par{\if@tempswa\hbox{}\fi\@tempswatrue\@@par
-          \penalty\interlinepenalty
+  \def\par{%
+    \if@tempswa
+      \leavevmode \null \@@par\penalty\interlinepenalty
+    \else
+      \@tempswatrue
+      \ifhmode\@@par\penalty\interlinepenalty\fi
+    \fi    
 %    \end{macrocode}
 %    We add a control sequence |\check@percent| to the definition
 %    of |\par| whose task it is to check for a percent character.
@@ -2720,9 +2731,10 @@
 % \changes{v1.8b}{1993/09/21}{Changed to conform to new LaTeX verbatim,
 %                           which handles more ligatures.}
 %    \begin{macrocode}
- \obeylines
- \let\do\do@noligs \verbatim@nolig@list
- \let\do\@makeother \dospecials}
+  \let\do\@makeother \dospecials
+  \obeylines \verbatim@font \@noligs
+  \everypar \expandafter{\the\everypar \unpenalty}%
+}
 %    \end{macrocode}
 % \end{macro}
 %
@@ -2751,83 +2763,12 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{imacro}{\verb}
-% \changes{v1.7a}{1992/02/27}{Now warns about newlines (from
-%                           newdoc with `@noligs added).}
-% \changes{v1.8b}{1993/09/21}{Changed to conform to new LaTeX \cs{verb}}
-% We re-define |\verb| to check for newlines in its argument since a
-% missing delimiter is difficult to detect in \DOC{} source.
-% The code is the same as in \texttt{latex.tex} of September 19, 1993.
-% Perhaps there should be a font-changing
-% hook rather than just using |\ttfamily|, but if so it probably should be
-% different from |\MacroFont| since that normally includes |\small|
-% and would look wrong inline.
-% \changes{v1.7a}{1992/02/28}{Added math mode check (from verbatim.sty)}
-%    \begin{macrocode}
-\def\verb{\relax\ifmmode\hbox\else\leavevmode\null\fi
-  \bgroup \let\do\do@noligs \verbatim@nolig@list
-    \ttfamily \verb@eol@error \let\do\@makeother \dospecials
-    \@ifstar{\@sverb}{\@vobeyspaces \frenchspacing \@sverb}}
-%    \end{macrocode}
-% \end{imacro}
 %
-% \begin{macro}{\verb@balance@group}
-% \begin{macro}{\verb@egroup}
-% \begin{macro}{\verb@eol@error}
-% \changes{v1.8b}{1993/09/21}{Renamed \cs{verb@err} to
-%                   \cs{verb@eol@error}, as in new LaTeX verbatim.}
-%    \begin{macrocode}
-\let\verb@balance@group\@empty
-%    \end{macrocode}
-%
-%    \begin{macrocode}
-\def\verb@egroup{\global\let\verb@balance@group\@empty\egroup}
-%    \end{macrocode}
-%
-%    \begin{macrocode}
-\begingroup
-  \obeylines%
-  \gdef\verb@eol@error{\obeylines%
-    \def^^M{\verb@egroup\@latex@error{%
-            \noexpand\verb command ended by end of line}\@ehc}}%
-\endgroup
-%    \end{macrocode}
-% \end{macro}
-% \end{macro}
-% \end{macro}
-%
-% \begin{macro}{\@sverb}
-% \changes{v1.7a}{1992/02/27}{Added for \cs{verb} change.}
-% \changes{v1.7a}{1992/02/28}{Now same as in verbatim.sty.}
-% \changes{v1.8b}{1993/09/21}{Changed to conform to new LaTeX verbatim,
-%                           which has better error trapping.}
-% See \cite{art:verbatim} for commentary.
-%  \changes{v2.1j}{2019/11/03}{Use the kernel definition, no change needed (gh/205)}
-%    \begin{macrocode}
-%\def\@sverb#1{%
-%  \catcode`#1\active  \lccode`\~`#1%
-%  \gdef\verb@balance@group{\verb@egroup
-%     \@latex@error{Illegal use of \noexpand\verb command}\@ehc}%
-%  \aftergroup\verb@balance@group
-%  \lowercase{\let~\verb@egroup}}
-%    \end{macrocode}
-% \end{macro}
-%
-%
-% \begin{macro}{\verbatim@nolig@list}
-% \begin{macro}{\do@noligs}
-%     These macros replace the old |\@noligs| mechanism by an
-%     extensible version to allow more ligatures to be added.
-%    \begin{macrocode}
-\def\verbatim@nolig@list{\do\`\do\<\do\>\do\,\do\'\do\-}
-\def\do@noligs#1{%
-  \catcode`#1\active
-  \begingroup
-     \lccode`\~=`#1\relax
-     \lowercase{\endgroup\def~{\leavevmode\kern\z@\char`#1}}}
-%    \end{macrocode}
-% \end{macro}
-% \end{macro}
+% In the early versions of the package it also redefined \cs{verb}
+% because that didn't include the useful test for \enquote{newline} in
+% the verbatim text. This is nowadays part of \LaTeX{} so we do not
+% redefine it any longer (the original code is still kept in the file
+% after \cs{endinput} to keep the long history intact).
 %
 % \begin{tcounter}{\macro@cnt}
 %    \label{page:macro} The \env{macro} environment is implemented as
@@ -6262,6 +6203,89 @@
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \endinput
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+% \section{Code no longer used}
+%
+% \begin{imacro}{\verb}
+% \changes{v1.7a}{1992/02/27}{Now warns about newlines (from
+%                           newdoc with `@noligs added).}
+% \changes{v1.8b}{1993/09/21}{Changed to conform to new LaTeX \cs{verb}}
+% We re-define |\verb| to check for newlines in its argument since a
+% missing delimiter is difficult to detect in \DOC{} source.
+% The code is the same as in \texttt{latex.tex} of September 19, 1993.
+% Perhaps there should be a font-changing
+% hook rather than just using |\ttfamily|, but if so it probably should be
+% different from |\MacroFont| since that normally includes |\small|
+% and would look wrong inline.
+% \changes{v1.7a}{1992/02/28}{Added math mode check (from verbatim.sty)}
+%    \begin{macrocode}
+%\def\verb{\relax\ifmmode\hbox\else\leavevmode\null\fi
+%  \bgroup \let\do\do@noligs \verbatim@nolig@list
+%    \ttfamily \verb@eol@error \let\do\@makeother \dospecials
+%    \@ifstar{\@sverb}{\@vobeyspaces \frenchspacing \@sverb}}
+%    \end{macrocode}
+% \end{imacro}
+%
+% \begin{macro}{\verb@balance@group}
+% \begin{macro}{\verb@egroup}
+% \begin{macro}{\verb@eol@error}
+% \changes{v1.8b}{1993/09/21}{Renamed \cs{verb@err} to
+%                   \cs{verb@eol@error}, as in new LaTeX verbatim.}
+%    \begin{macrocode}
+%\let\verb@balance@group\@empty
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%\def\verb@egroup{\global\let\verb@balance@group\@empty\egroup}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%\begingroup
+%  \obeylines%
+%  \gdef\verb@eol@error{\obeylines%
+%    \def^^M{\verb@egroup\@latex@error{%
+%            \noexpand\verb command ended by end of line}\@ehc}}%
+%\endgroup
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
+% \end{macro}
+%
+% \begin{macro}{\@sverb}
+% \changes{v1.7a}{1992/02/27}{Added for \cs{verb} change.}
+% \changes{v1.7a}{1992/02/28}{Now same as in verbatim.sty.}
+% \changes{v1.8b}{1993/09/21}{Changed to conform to new LaTeX verbatim,
+%                           which has better error trapping.}
+% See \cite{art:verbatim} for commentary.
+%  \changes{v2.1j}{2019/11/03}{Use the kernel definition, no change needed (gh/205)}
+%    \begin{macrocode}
+%\def\@sverb#1{%
+%  \catcode`#1\active  \lccode`\~`#1%
+%  \gdef\verb@balance@group{\verb@egroup
+%     \@latex@error{Illegal use of \noexpand\verb command}\@ehc}%
+%  \aftergroup\verb@balance@group
+%  \lowercase{\let~\verb@egroup}}
+%    \end{macrocode}
+% \end{macro}
+%
+%
+% \begin{macro}{\verbatim@nolig@list}
+% \begin{macro}{\do@noligs}
+%     These macros replace the old |\@noligs| mechanism by an
+%     extensible version to allow more ligatures to be added.
+%    \begin{macrocode}
+%\def\verbatim@nolig@list{\do\`\do\<\do\>\do\,\do\'\do\-}
+%\def\do@noligs#1{%
+%  \catcode`#1\active
+%  \begingroup
+%     \lccode`\~`#1\relax
+%     \lowercase{\endgroup\def~{\leavevmode\kern\z@\char`#1}}}
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
+
 
 ^^A  Needed for emacs
 ^^A

--- a/base/doc.dtx
+++ b/base/doc.dtx
@@ -82,7 +82,7 @@
 %  \changes{v1.9a}{1993/12/02}{Upgrade for LaTeX2e}
 %  \changes{v1.9d}{1993/12/20}{Protected changes entry.}
 %  \changes{v1.0p}{1994/05/21}{Use new error commands}
-%  \changes{v3.0m}{2022/11/13}{Redefinitions of \vs{verb} removed as
+%  \changes{v3.0m}{2022/11/13}{Redefinitions of \cs{verb} removed as
 %     no longer needed (gh/953)}
 %
 %

--- a/base/doc/ltnews37.tex
+++ b/base/doc/ltnews37.tex
@@ -159,6 +159,41 @@
 \githubissue{943}
 
 
+\subsection{\pkg{doc}: Support the \pkg{upquote} package}
+
+The default quote and backquote characters in typewriter fonts are
+typographical quotes, e.g., the input
+\begin{verbatim}
+   verb*/`prog 'my input'`/
+\end{verbatim}
+ is rendered as \verb*/`prog 'my input'`/ and not as
+%
+\begingroup              % code to mimic upquote.sty
+\catcode`'=\active
+\catcode``=\active
+\makeatletter
+\g@addto@macro\@noligs
+   {\let'\textquotesingle
+    \let`\textasciigrave
+    \ifx\encodingdefault\upquote@OTone
+    \ifx\ttdefault\upquote@cmtt
+    \def'{\char13 }%
+    \def`{\char18 }%
+    \fi\fi}
+\endgroup
+%
+\verb*/`prog 'my input'`/ as preferred by many programmers.
+
+This can be adjusted, for example, with the \pkg{upquote} package,
+which results in the second output. However, for historical reasons
+\pkg{doc} had its own definition of \cs{verb} and \env{verbatim} and
+as a consequence the two packages did not cooperate.  This has now
+been fixed and loading \pkg{upquote} together with \pkg{doc} has the
+desired effect.
+%
+\githubissue{953}
+
+
 \subsection{A further hook for shipping out pages}
 
 Since October 2020 the shipout process offers a number of hooks to

--- a/base/testfiles-doc/github-0205.luatex.tlg
+++ b/base/testfiles-doc/github-0205.luatex.tlg
@@ -98,11 +98,10 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 4.0 minus 5.0
 ...\glue 0.0 plus 1.0
-...\penalty 0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 6.0139
-...\hbox(3.87498+1.11111)x345.0, glue set 314.4389fil, direction TLT
+...\hbox(3.87498+1.11111)x345.0, glue set 314.5503fil, direction TLT
 ....\localpar
 .....\localinterlinepenalty=0
 .....\localbrokenpenalty=0
@@ -114,21 +113,20 @@ Completed box being shipped out [1]
 .....\glue -5.0
 .....\hbox(0.0+0.0)x0.0, direction TLT
 .....\glue 5.0
-....\penalty 0
-....\hbox(2.19444+1.11111)x5.2778, glue set 0.01393fil, direction TLT
+....\hbox(2.19444+1.11111)x5.24995, direction TLT
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\OT1/cmtt/m/n/10  
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(2.19444+1.11111)x5.2778, glue set 0.01393fil, direction TLT
+....\hbox(2.19444+1.11111)x5.24995, direction TLT
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\OT1/cmtt/m/n/10  
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\OT1/cmtt/m/n/9 x
-....\hbox(2.19444+1.11111)x5.2778, glue set 0.01393fil, direction TLT
+....\hbox(2.19444+1.11111)x5.24995, direction TLT
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\OT1/cmtt/m/n/10  
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(2.19444+1.11111)x5.2778, glue set 0.01393fil, direction TLT
+....\hbox(2.19444+1.11111)x5.24995, direction TLT
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\OT1/cmtt/m/n/10  
 .....\glue 0.0 plus 1.0fil minus 1.0fil

--- a/base/testfiles-doc/github-0205.tlg
+++ b/base/testfiles-doc/github-0205.tlg
@@ -23,17 +23,20 @@ Completed box being shipped out [1]
 ...\hbox(6.94444+1.11111)x345.0, glue set 265.22255fil
 ....\hbox(0.0+0.0)x15.0
 ....\hbox(0.0+0.0)x0.0
+....\setlanguage1 (hyphenmin 2,3)
 ....\OT1/cmtt/m/n/10 x
 ....\OT1/cmtt/m/n/10  
 ....\OT1/cmtt/m/n/10  
 ....\OT1/cmtt/m/n/10  
 ....\OT1/cmtt/m/n/10 x
 ....\glue 3.33333 plus 1.66666 minus 1.11111
+....\setlanguage0 (hyphenmin 2,3)
 ....\OT1/cmr/m/n/10 a
 ....\OT1/cmr/m/n/10 n
 ....\OT1/cmr/m/n/10 d
 ....\glue 3.33333 plus 1.66666 minus 1.11111
 ....\hbox(0.0+0.0)x0.0
+....\setlanguage1 (hyphenmin 2,3)
 ....\OT1/cmtt/m/n/10  
 ....\OT1/cmtt/m/n/10  
 ....\OT1/cmtt/m/n/10  
@@ -70,7 +73,6 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 4.0 minus 5.0
 ...\glue 0.0 plus 1.0
-...\penalty 0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 7.12502
@@ -81,7 +83,6 @@ Completed box being shipped out [1]
 .....\glue -5.0
 .....\hbox(0.0+0.0)x0.0
 .....\glue 5.0
-....\penalty 0
 ....\OT1/cmtt/m/n/9  
 ....\OT1/cmtt/m/n/9  
 ....\OT1/cmtt/m/n/9 x

--- a/base/testfiles-doc/github-0205.xetex.tlg
+++ b/base/testfiles-doc/github-0205.xetex.tlg
@@ -23,6 +23,7 @@ Completed box being shipped out [1]
 ...\hbox(6.94444+1.11111)x345.0, glue set 265.22255fil
 ....\hbox(0.0+0.0)x15.0
 ....\hbox(0.0+0.0)x0.0
+....\setlanguage1 (hyphenmin 2,3)
 ....\OT1/cmtt/m/n/10 x
 ....\hbox(2.19444+1.11111)x5.24995
 .....\glue 0.0 plus 1.0fil minus 1.0fil
@@ -38,6 +39,7 @@ Completed box being shipped out [1]
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\OT1/cmtt/m/n/10 x
 ....\glue 3.33333 plus 1.66666 minus 1.11111
+....\setlanguage0 (hyphenmin 2,3)
 ....\OT1/cmr/m/n/10 a
 ....\OT1/cmr/m/n/10 n
 ....\OT1/cmr/m/n/10 d
@@ -88,32 +90,30 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 4.0 minus 5.0
 ...\glue 0.0 plus 1.0
-...\penalty 0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 6.0139
-...\hbox(3.87498+1.11111)x345.0, glue set 314.4389fil
+...\hbox(3.87498+1.11111)x345.0, glue set 314.5503fil
 ....\hbox(0.0+0.0)x0.0
 .....\glue 0.0
 .....\glue 0.0
 .....\glue -5.0
 .....\hbox(0.0+0.0)x0.0
 .....\glue 5.0
-....\penalty 0
-....\hbox(2.19444+1.11111)x5.2778, glue set 0.01393fil
+....\hbox(2.19444+1.11111)x5.24995
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\OT1/cmtt/m/n/10  
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(2.19444+1.11111)x5.2778, glue set 0.01393fil
+....\hbox(2.19444+1.11111)x5.24995
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\OT1/cmtt/m/n/10  
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 ....\OT1/cmtt/m/n/9 x
-....\hbox(2.19444+1.11111)x5.2778, glue set 0.01393fil
+....\hbox(2.19444+1.11111)x5.24995
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\OT1/cmtt/m/n/10  
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-....\hbox(2.19444+1.11111)x5.2778, glue set 0.01393fil
+....\hbox(2.19444+1.11111)x5.24995
 .....\glue 0.0 plus 1.0fil minus 1.0fil
 .....\OT1/cmtt/m/n/10  
 .....\glue 0.0 plus 1.0fil minus 1.0fil

--- a/base/testfiles-doc/tlb-dox004.tlg
+++ b/base/testfiles-doc/tlb-dox004.tlg
@@ -246,6 +246,7 @@ Completed box being shipped out [1]
 .....\OT1/cmr/m/n/10 r
 .....\glue 3.33333 plus 1.66666 minus 1.11111
 .....\hbox(0.0+0.0)x0.0
+.....\setlanguage1 (hyphenmin 2,3)
 .....\OT1/cmtt/m/n/10 \
 .....\OT1/cmtt/m/n/10 m
 .....\OT1/cmtt/m/n/10 y
@@ -255,6 +256,7 @@ Completed box being shipped out [1]
 .....\OT1/cmtt/m/n/10 g
 .....\OT1/cmtt/m/n/10 t
 .....\OT1/cmtt/m/n/10 h
+.....\setlanguage0 (hyphenmin 2,3)
 .....\OT1/cmr/m/n/10 .
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -391,6 +393,7 @@ Completed box being shipped out [2]
 .....\OT1/cmr/m/n/10 t
 .....\glue 3.33333 plus 1.66666 minus 1.11111
 .....\hbox(0.0+0.0)x0.0
+.....\setlanguage1 (hyphenmin 2,3)
 .....\OT1/cmtt/m/n/10 \
 .....\OT1/cmtt/m/n/10 m
 .....\OT1/cmtt/m/n/10 y
@@ -401,6 +404,7 @@ Completed box being shipped out [2]
 .....\OT1/cmtt/m/n/10 t
 .....\OT1/cmtt/m/n/10 h
 .....\glue 3.33333 plus 1.66666 minus 1.11111
+.....\setlanguage0 (hyphenmin 2,3)
 .....\OT1/cmr/m/n/10 w
 .....\OT1/cmr/m/n/10 i
 .....\OT1/cmr/m/n/10 t
@@ -1240,6 +1244,7 @@ Completed box being shipped out [4]
 .......\hbox(7.69997+3.30003)x155.0, glue set 96.95895fill
 ........\hbox(0.0+0.0)x0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 @
 ........\OT1/cmtt/m/n/9 m
@@ -1286,6 +1291,7 @@ Completed box being shipped out [4]
 .......\hbox(7.69997+3.30003)x155.0, glue set 101.6839fill
 ........\hbox(0.0+0.0)x0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 @
 ........\OT1/cmtt/m/n/9 m
@@ -1362,6 +1368,7 @@ Completed box being shipped out [4]
 .......\hbox(7.69997+3.30003)x155.0, glue set 125.30862fill
 ........\hbox(0.0+0.0)x0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 d
 ........\OT1/cmtt/m/n/9 e
@@ -1637,6 +1644,7 @@ Completed box being shipped out [4]
 .......\hbox(7.69997+3.30003)x155.0, glue set 115.85873fill
 ........\hbox(0.0+0.0)x0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 h
 ........\OT1/cmtt/m/n/9 s
@@ -1726,6 +1734,7 @@ Completed box being shipped out [4]
 ........\glue 15.0
 ........\glue 0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 m
 ........\OT1/cmtt/m/n/9 y
@@ -1762,6 +1771,7 @@ Completed box being shipped out [4]
 .........\special{ps:SDict begin H.R end}
 ........\special{ps:SDict begin [/Color [1 0 0]/H /I/Border [0 0 0]BorderArrayPatch/Subtype /Link/Dest (HD.5) cvn H.B /ANN pdfmark end}
 ........\special{color pop}
+........\setlanguage0 (hyphenmin 2,3)
 ........\OT1/cmr/m/n/9 ,
 ........\glue 3.08331 plus 1.92706 minus 0.8222
 ........\mathon
@@ -1896,6 +1906,7 @@ Completed box being shipped out [4]
 .......\hbox(7.69997+3.30003)x155.0, glue set 101.6839fill
 ........\hbox(0.0+0.0)x0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 m
 ........\OT1/cmtt/m/n/9 y
@@ -1941,6 +1952,7 @@ Completed box being shipped out [4]
 .......\hbox(7.69997+3.30003)x155.0, glue set 55.8473fill
 ........\hbox(0.0+0.0)x0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 m
 ........\OT1/cmtt/m/n/9 y
@@ -1951,6 +1963,7 @@ Completed box being shipped out [4]
 ........\OT1/cmtt/m/n/9 t
 ........\OT1/cmtt/m/n/9 h
 ........\glue 3.08331 plus 1.54166 minus 1.02777
+........\setlanguage0 (hyphenmin 2,3)
 ........\OT1/cmr/m/n/9 (
 ........\OT1/cmr/m/n/9 l
 ........\OT1/cmr/m/n/9 e
@@ -2038,6 +2051,7 @@ Completed box being shipped out [4]
 .......\hbox(7.69997+3.30003)x155.0, glue set 73.33423fill
 ........\hbox(0.0+0.0)x0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 n
 ........\OT1/cmtt/m/n/9 e
@@ -2114,6 +2128,7 @@ Completed box being shipped out [4]
 .......\hbox(7.69997+3.30003)x155.0, glue set 115.85873fill
 ........\hbox(0.0+0.0)x0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 r
 ........\OT1/cmtt/m/n/9 e
@@ -2288,9 +2303,11 @@ Completed box being shipped out [5]
 ........\glue 15.0
 ........\glue 0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 f
 ........\OT1/cmtt/m/n/9 o
 ........\OT1/cmtt/m/n/9 o
+........\setlanguage0 (hyphenmin 2,3)
 ........\OT1/cmr/m/n/9 :
 ........\glue 3.08331 plus 1.54166 minus 1.02777
 ........\OT1/cmr/m/n/9 ^^L (ligature fi)
@@ -2357,6 +2374,7 @@ Completed box being shipped out [5]
 ........\glue 15.0
 ........\glue 0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 m
 ........\OT1/cmtt/m/n/9 y
@@ -2366,6 +2384,7 @@ Completed box being shipped out [5]
 ........\OT1/cmtt/m/n/9 g
 ........\OT1/cmtt/m/n/9 t
 ........\OT1/cmtt/m/n/9 h
+........\setlanguage0 (hyphenmin 2,3)
 ........\OT1/cmr/m/n/9 :
 ........\glue 3.08331 plus 1.54166 minus 1.02777
 ........\OT1/cmr/m/n/9 F
@@ -2454,6 +2473,7 @@ Completed box being shipped out [5]
 ........\glue 15.0
 ........\glue 0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 @
 ........\OT1/cmtt/m/n/9 m
@@ -2463,6 +2483,7 @@ Completed box being shipped out [5]
 ........\OT1/cmtt/m/n/9 c
 ........\OT1/cmtt/m/n/9 r
 ........\OT1/cmtt/m/n/9 o
+........\setlanguage0 (hyphenmin 2,3)
 ........\OT1/cmr/m/n/9 :
 ........\glue 3.08331 plus 1.54166 minus 1.02777
 ........\OT1/cmr/m/n/9 n
@@ -2520,6 +2541,7 @@ Completed box being shipped out [5]
 ........\glue 15.0
 ........\glue 0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 m
 ........\OT1/cmtt/m/n/9 y
 ........\OT1/cmtt/m/n/9 e
@@ -2533,6 +2555,7 @@ Completed box being shipped out [5]
 ........\OT1/cmtt/m/n/9 e
 ........\OT1/cmtt/m/n/9 n
 ........\OT1/cmtt/m/n/9 t
+........\setlanguage0 (hyphenmin 2,3)
 ........\OT1/cmr/m/n/9 :
 ........\glue 3.08331 plus 1.54166 minus 1.02777
 ........\OT1/cmr/m/n/9 T

--- a/base/testfiles-doc/tlb-dox004.xetex.tlg
+++ b/base/testfiles-doc/tlb-dox004.xetex.tlg
@@ -230,6 +230,7 @@ Completed box being shipped out [1]
 .....\OT1/cmr/m/n/10 r
 .....\glue 3.33333 plus 1.66666 minus 1.11111
 .....\hbox(0.0+0.0)x0.0
+.....\setlanguage1 (hyphenmin 2,3)
 .....\OT1/cmtt/m/n/10 \
 .....\OT1/cmtt/m/n/10 m
 .....\OT1/cmtt/m/n/10 y
@@ -239,6 +240,7 @@ Completed box being shipped out [1]
 .....\OT1/cmtt/m/n/10 g
 .....\OT1/cmtt/m/n/10 t
 .....\OT1/cmtt/m/n/10 h
+.....\setlanguage0 (hyphenmin 2,3)
 .....\OT1/cmr/m/n/10 .
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -370,6 +372,7 @@ Completed box being shipped out [2]
 .....\OT1/cmr/m/n/10 t
 .....\glue 3.33333 plus 1.66666 minus 1.11111
 .....\hbox(0.0+0.0)x0.0
+.....\setlanguage1 (hyphenmin 2,3)
 .....\OT1/cmtt/m/n/10 \
 .....\OT1/cmtt/m/n/10 m
 .....\OT1/cmtt/m/n/10 y
@@ -380,6 +383,7 @@ Completed box being shipped out [2]
 .....\OT1/cmtt/m/n/10 t
 .....\OT1/cmtt/m/n/10 h
 .....\glue 3.33333 plus 1.66666 minus 1.11111
+.....\setlanguage0 (hyphenmin 2,3)
 .....\OT1/cmr/m/n/10 w
 .....\OT1/cmr/m/n/10 i
 .....\OT1/cmr/m/n/10 t
@@ -1198,6 +1202,7 @@ Completed box being shipped out [4]
 .......\hbox(7.69997+3.30003)x155.0, glue set 96.95895fill
 ........\hbox(0.0+0.0)x0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 @
 ........\OT1/cmtt/m/n/9 m
@@ -1227,6 +1232,7 @@ Completed box being shipped out [4]
 ........\glue 3.08331 plus 1.54166 minus 1.02777
 ........\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/GoTo/D(page.3)>>>>}
 ........\special{color push rgb 1 0 0}
+........\setlanguage0 (hyphenmin 2,3)
 ........\OT1/cmr/m/n/9 3
 ........\special{color pop}
 ........\special{pdf:eann}
@@ -1239,6 +1245,7 @@ Completed box being shipped out [4]
 .......\hbox(7.69997+3.30003)x155.0, glue set 101.6839fill
 ........\hbox(0.0+0.0)x0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 @
 ........\OT1/cmtt/m/n/9 m
@@ -1306,6 +1313,7 @@ Completed box being shipped out [4]
 .......\hbox(7.69997+3.30003)x155.0, glue set 125.30862fill
 ........\hbox(0.0+0.0)x0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 d
 ........\OT1/cmtt/m/n/9 e
@@ -1329,6 +1337,7 @@ Completed box being shipped out [4]
 ........\glue 3.08331 plus 1.54166 minus 1.02777
 ........\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/GoTo/D(page.3)>>>>}
 ........\special{color push rgb 1 0 0}
+........\setlanguage0 (hyphenmin 2,3)
 ........\OT1/cmr/m/n/9 3
 ........\special{color pop}
 ........\special{pdf:eann}
@@ -1544,6 +1553,7 @@ Completed box being shipped out [4]
 .......\hbox(7.69997+3.30003)x155.0, glue set 115.85873fill
 ........\hbox(0.0+0.0)x0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 h
 ........\OT1/cmtt/m/n/9 s
@@ -1569,6 +1579,7 @@ Completed box being shipped out [4]
 ........\glue 3.08331 plus 1.54166 minus 1.02777
 ........\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/GoTo/D(page.3)>>>>}
 ........\special{color push rgb 1 0 0}
+........\setlanguage0 (hyphenmin 2,3)
 ........\OT1/cmr/m/n/9 3
 ........\special{color pop}
 ........\special{pdf:eann}
@@ -1624,6 +1635,7 @@ Completed box being shipped out [4]
 ........\glue 15.0
 ........\glue 0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 m
 ........\OT1/cmtt/m/n/9 y
@@ -1652,6 +1664,7 @@ Completed box being shipped out [4]
 ........\glue 3.08331 plus 1.54166 minus 1.02777
 ........\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/GoTo/D(HD.5)>>>>}
 ........\special{color push rgb 1 0 0}
+........\setlanguage0 (hyphenmin 2,3)
 ........\OT1/cmr/m/it/9 1
 ........\special{color pop}
 ........\special{pdf:eann}
@@ -1770,6 +1783,7 @@ Completed box being shipped out [4]
 .......\hbox(7.69997+3.30003)x155.0, glue set 101.6839fill
 ........\hbox(0.0+0.0)x0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 m
 ........\OT1/cmtt/m/n/9 y
@@ -1798,6 +1812,7 @@ Completed box being shipped out [4]
 ........\glue 3.08331 plus 1.54166 minus 1.02777
 ........\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/GoTo/D(page.3)>>>>}
 ........\special{color push rgb 1 0 0}
+........\setlanguage0 (hyphenmin 2,3)
 ........\OT1/cmr/m/n/9 3
 ........\special{color pop}
 ........\special{pdf:eann}
@@ -1810,6 +1825,7 @@ Completed box being shipped out [4]
 .......\hbox(7.69997+3.30003)x155.0, glue set 55.8473fill
 ........\hbox(0.0+0.0)x0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 m
 ........\OT1/cmtt/m/n/9 y
@@ -1820,6 +1836,7 @@ Completed box being shipped out [4]
 ........\OT1/cmtt/m/n/9 t
 ........\OT1/cmtt/m/n/9 h
 ........\glue 3.08331 plus 1.54166 minus 1.02777
+........\setlanguage0 (hyphenmin 2,3)
 ........\OT1/cmr/m/n/9 (
 ........\OT1/cmr/m/n/9 l
 ........\OT1/cmr/m/n/9 e
@@ -1893,6 +1910,7 @@ Completed box being shipped out [4]
 .......\hbox(7.69997+3.30003)x155.0, glue set 73.33423fill
 ........\hbox(0.0+0.0)x0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 n
 ........\OT1/cmtt/m/n/9 e
@@ -1927,6 +1945,7 @@ Completed box being shipped out [4]
 ........\glue 3.08331 plus 1.54166 minus 1.02777
 ........\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/GoTo/D(page.3)>>>>}
 ........\special{color push rgb 1 0 0}
+........\setlanguage0 (hyphenmin 2,3)
 ........\OT1/cmr/m/n/9 3
 ........\special{color pop}
 ........\special{pdf:eann}
@@ -1960,6 +1979,7 @@ Completed box being shipped out [4]
 .......\hbox(7.69997+3.30003)x155.0, glue set 115.85873fill
 ........\hbox(0.0+0.0)x0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 r
 ........\OT1/cmtt/m/n/9 e
@@ -1985,6 +2005,7 @@ Completed box being shipped out [4]
 ........\glue 3.08331 plus 1.54166 minus 1.02777
 ........\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 0]/H/I/C[1 0 0]/A<</S/GoTo/D(page.3)>>>>}
 ........\special{color push rgb 1 0 0}
+........\setlanguage0 (hyphenmin 2,3)
 ........\OT1/cmr/m/n/9 3
 ........\special{color pop}
 ........\special{pdf:eann}
@@ -2121,9 +2142,11 @@ Completed box being shipped out [5]
 ........\glue 15.0
 ........\glue 0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 f
 ........\OT1/cmtt/m/n/9 o
 ........\OT1/cmtt/m/n/9 o
+........\setlanguage0 (hyphenmin 2,3)
 ........\OT1/cmr/m/n/9 :
 ........\glue 3.08331 plus 1.54166 minus 1.02777
 ........\OT1/cmr/m/n/9 ^^L (ligature fi)
@@ -2185,6 +2208,7 @@ Completed box being shipped out [5]
 ........\glue 15.0
 ........\glue 0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 m
 ........\OT1/cmtt/m/n/9 y
@@ -2194,6 +2218,7 @@ Completed box being shipped out [5]
 ........\OT1/cmtt/m/n/9 g
 ........\OT1/cmtt/m/n/9 t
 ........\OT1/cmtt/m/n/9 h
+........\setlanguage0 (hyphenmin 2,3)
 ........\OT1/cmr/m/n/9 :
 ........\glue 3.08331 plus 1.54166 minus 1.02777
 ........\OT1/cmr/m/n/9 F
@@ -2277,6 +2302,7 @@ Completed box being shipped out [5]
 ........\glue 15.0
 ........\glue 0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 \
 ........\OT1/cmtt/m/n/9 @
 ........\OT1/cmtt/m/n/9 m
@@ -2286,6 +2312,7 @@ Completed box being shipped out [5]
 ........\OT1/cmtt/m/n/9 c
 ........\OT1/cmtt/m/n/9 r
 ........\OT1/cmtt/m/n/9 o
+........\setlanguage0 (hyphenmin 2,3)
 ........\OT1/cmr/m/n/9 :
 ........\glue 3.08331 plus 1.54166 minus 1.02777
 ........\OT1/cmr/m/n/9 n
@@ -2338,6 +2365,7 @@ Completed box being shipped out [5]
 ........\glue 15.0
 ........\glue 0.0
 ........\hbox(0.0+0.0)x0.0
+........\setlanguage1 (hyphenmin 2,3)
 ........\OT1/cmtt/m/n/9 m
 ........\OT1/cmtt/m/n/9 y
 ........\OT1/cmtt/m/n/9 e
@@ -2351,6 +2379,7 @@ Completed box being shipped out [5]
 ........\OT1/cmtt/m/n/9 e
 ........\OT1/cmtt/m/n/9 n
 ........\OT1/cmtt/m/n/9 t
+........\setlanguage0 (hyphenmin 2,3)
 ........\OT1/cmr/m/n/9 :
 ........\glue 3.08331 plus 1.54166 minus 1.02777
 ........\OT1/cmr/m/n/9 T

--- a/base/testfiles-doc/tlb-dox005.tlg
+++ b/base/testfiles-doc/tlb-dox005.tlg
@@ -178,6 +178,7 @@ Completed box being shipped out [1]
 ....\OT1/cmr/m/n/10 r
 ....\glue 3.33333 plus 1.66666 minus 1.11111
 ....\hbox(0.0+0.0)x0.0
+....\setlanguage1 (hyphenmin 2,3)
 ....\OT1/cmtt/m/n/10 \
 ....\OT1/cmtt/m/n/10 m
 ....\OT1/cmtt/m/n/10 y
@@ -187,6 +188,7 @@ Completed box being shipped out [1]
 ....\OT1/cmtt/m/n/10 g
 ....\OT1/cmtt/m/n/10 t
 ....\OT1/cmtt/m/n/10 h
+....\setlanguage0 (hyphenmin 2,3)
 ....\OT1/cmr/m/n/10 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -294,6 +296,7 @@ Completed box being shipped out [2]
 ....\OT1/cmr/m/n/10 t
 ....\glue 3.33333 plus 1.66666 minus 1.11111
 ....\hbox(0.0+0.0)x0.0
+....\setlanguage1 (hyphenmin 2,3)
 ....\OT1/cmtt/m/n/10 \
 ....\OT1/cmtt/m/n/10 m
 ....\OT1/cmtt/m/n/10 y
@@ -304,6 +307,7 @@ Completed box being shipped out [2]
 ....\OT1/cmtt/m/n/10 t
 ....\OT1/cmtt/m/n/10 h
 ....\glue 3.33333 plus 1.66666 minus 1.11111
+....\setlanguage0 (hyphenmin 2,3)
 ....\OT1/cmr/m/n/10 w
 ....\OT1/cmr/m/n/10 i
 ....\OT1/cmr/m/n/10 t
@@ -1056,6 +1060,7 @@ Completed box being shipped out [3]
 .....\hbox(7.69997+3.30003)x108.33333, glue set 50.29228fill
 ......\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 @
 ......\OT1/cmtt/m/n/9 m
@@ -1083,6 +1088,7 @@ Completed box being shipped out [3]
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ......\penalty 10000
 ......\glue 3.08331 plus 1.54166 minus 1.02777
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 3
 ......\penalty 10000
 ......\glue(\parfillskip) -15.0
@@ -1093,6 +1099,7 @@ Completed box being shipped out [3]
 .....\hbox(7.69997+3.30003)x108.33333, glue set 55.01723fill
 ......\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 @
 ......\OT1/cmtt/m/n/9 m
@@ -1149,6 +1156,7 @@ Completed box being shipped out [3]
 .....\hbox(7.69997+3.30003)x108.33333, glue set 78.64195fill
 ......\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 d
 ......\OT1/cmtt/m/n/9 e
@@ -1170,6 +1178,7 @@ Completed box being shipped out [3]
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ......\penalty 10000
 ......\glue 3.08331 plus 1.54166 minus 1.02777
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 3
 ......\penalty 10000
 ......\glue(\parfillskip) -15.0
@@ -1349,6 +1358,7 @@ Completed box being shipped out [3]
 .....\hbox(7.69997+3.30003)x108.33333, glue set 69.19206fill
 ......\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 h
 ......\OT1/cmtt/m/n/9 s
@@ -1372,6 +1382,7 @@ Completed box being shipped out [3]
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ......\penalty 10000
 ......\glue 3.08331 plus 1.54166 minus 1.02777
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 3
 ......\penalty 10000
 ......\glue(\parfillskip) -15.0
@@ -1418,6 +1429,7 @@ Completed box being shipped out [3]
 ......\glue 15.0
 ......\glue 0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 m
 ......\OT1/cmtt/m/n/9 y
@@ -1444,6 +1456,7 @@ Completed box being shipped out [3]
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ......\penalty 10000
 ......\glue 3.08331 plus 1.54166 minus 1.02777
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/it/9 1
 ......\OT1/cmr/m/n/9 ,
 ......\glue 3.08331 plus 1.92706 minus 0.8222
@@ -1553,6 +1566,7 @@ Completed box being shipped out [3]
 .....\hbox(7.69997+3.30003)x108.33333, glue set 55.01723fill
 ......\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 m
 ......\OT1/cmtt/m/n/9 y
@@ -1579,6 +1593,7 @@ Completed box being shipped out [3]
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ......\penalty 10000
 ......\glue 3.08331 plus 1.54166 minus 1.02777
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 3
 ......\penalty 10000
 ......\glue(\parfillskip) -15.0
@@ -1589,6 +1604,7 @@ Completed box being shipped out [3]
 .....\hbox(7.69997+3.30003)x108.33333, glue set 9.18063fill
 ......\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 m
 ......\OT1/cmtt/m/n/9 y
@@ -1599,6 +1615,7 @@ Completed box being shipped out [3]
 ......\OT1/cmtt/m/n/9 t
 ......\OT1/cmtt/m/n/9 h
 ......\glue 3.08331 plus 1.54166 minus 1.02777
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 (
 ......\OT1/cmr/m/n/9 l
 ......\OT1/cmr/m/n/9 e
@@ -1657,6 +1674,7 @@ Completed box being shipped out [3]
 .....\hbox(7.69997+3.30003)x108.33333, glue set 26.66756fill
 ......\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 n
 ......\OT1/cmtt/m/n/9 e
@@ -1689,6 +1707,7 @@ Completed box being shipped out [3]
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ......\penalty 10000
 ......\glue 3.08331 plus 1.54166 minus 1.02777
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 3
 ......\penalty 10000
 ......\glue(\parfillskip) -15.0
@@ -1713,6 +1732,7 @@ Completed box being shipped out [3]
 .....\hbox(7.69997+3.30003)x108.33333, glue set 69.19206fill
 ......\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 r
 ......\OT1/cmtt/m/n/9 e
@@ -1736,6 +1756,7 @@ Completed box being shipped out [3]
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ......\penalty 10000
 ......\glue 3.08331 plus 1.54166 minus 1.02777
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 3
 ......\penalty 10000
 ......\glue(\parfillskip) -15.0
@@ -1814,9 +1835,11 @@ Completed box being shipped out [3]
 ......\glue 15.0
 ......\glue 0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 f
 ......\OT1/cmtt/m/n/9 o
 ......\OT1/cmtt/m/n/9 o
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 :
 ......\glue 3.08331 plus 1.54166 minus 1.02777
 ......\OT1/cmr/m/n/9 ^^L (ligature fi)
@@ -1874,6 +1897,7 @@ Completed box being shipped out [3]
 ......\glue 15.0
 ......\glue 0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 m
 ......\OT1/cmtt/m/n/9 y
@@ -1883,6 +1907,7 @@ Completed box being shipped out [3]
 ......\OT1/cmtt/m/n/9 g
 ......\OT1/cmtt/m/n/9 t
 ......\OT1/cmtt/m/n/9 h
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 :
 ......\glue 3.08331 plus 1.54166 minus 1.02777
 ......\OT1/cmr/m/n/9 F
@@ -1969,6 +1994,7 @@ Completed box being shipped out [3]
 ......\glue 15.0
 ......\glue 0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 @
 ......\OT1/cmtt/m/n/9 m
@@ -1978,6 +2004,7 @@ Completed box being shipped out [3]
 ......\OT1/cmtt/m/n/9 c
 ......\OT1/cmtt/m/n/9 r
 ......\OT1/cmtt/m/n/9 o
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 :
 ......\glue 3.08331 plus 1.54166 minus 1.02777
 ......\OT1/cmr/m/n/9 n
@@ -2026,6 +2053,7 @@ Completed box being shipped out [3]
 ......\glue 15.0
 ......\glue 0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 m
 ......\OT1/cmtt/m/n/9 y
 ......\OT1/cmtt/m/n/9 e
@@ -2039,6 +2067,7 @@ Completed box being shipped out [3]
 ......\OT1/cmtt/m/n/9 e
 ......\OT1/cmtt/m/n/9 n
 ......\OT1/cmtt/m/n/9 t
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 :
 ......\glue 3.08331 plus 1.54166 minus 1.02777
 ......\OT1/cmr/m/n/9 T

--- a/base/testfiles-doc/tlb-dox005.xetex.tlg
+++ b/base/testfiles-doc/tlb-dox005.xetex.tlg
@@ -177,6 +177,7 @@ Completed box being shipped out [1]
 ....\OT1/cmr/m/n/10 r
 ....\glue 3.33333 plus 1.66666 minus 1.11111
 ....\hbox(0.0+0.0)x0.0
+....\setlanguage1 (hyphenmin 2,3)
 ....\OT1/cmtt/m/n/10 \
 ....\OT1/cmtt/m/n/10 m
 ....\OT1/cmtt/m/n/10 y
@@ -186,6 +187,7 @@ Completed box being shipped out [1]
 ....\OT1/cmtt/m/n/10 g
 ....\OT1/cmtt/m/n/10 t
 ....\OT1/cmtt/m/n/10 h
+....\setlanguage0 (hyphenmin 2,3)
 ....\OT1/cmr/m/n/10 .
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
@@ -292,6 +294,7 @@ Completed box being shipped out [2]
 ....\OT1/cmr/m/n/10 t
 ....\glue 3.33333 plus 1.66666 minus 1.11111
 ....\hbox(0.0+0.0)x0.0
+....\setlanguage1 (hyphenmin 2,3)
 ....\OT1/cmtt/m/n/10 \
 ....\OT1/cmtt/m/n/10 m
 ....\OT1/cmtt/m/n/10 y
@@ -302,6 +305,7 @@ Completed box being shipped out [2]
 ....\OT1/cmtt/m/n/10 t
 ....\OT1/cmtt/m/n/10 h
 ....\glue 3.33333 plus 1.66666 minus 1.11111
+....\setlanguage0 (hyphenmin 2,3)
 ....\OT1/cmr/m/n/10 w
 ....\OT1/cmr/m/n/10 i
 ....\OT1/cmr/m/n/10 t
@@ -1054,6 +1058,7 @@ Completed box being shipped out [3]
 .....\hbox(7.69997+3.30003)x108.33333, glue set 50.29228fill
 ......\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 @
 ......\OT1/cmtt/m/n/9 m
@@ -1081,6 +1086,7 @@ Completed box being shipped out [3]
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ......\penalty 10000
 ......\glue 3.08331 plus 1.54166 minus 1.02777
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 3
 ......\penalty 10000
 ......\glue(\parfillskip) -15.0
@@ -1091,6 +1097,7 @@ Completed box being shipped out [3]
 .....\hbox(7.69997+3.30003)x108.33333, glue set 55.01723fill
 ......\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 @
 ......\OT1/cmtt/m/n/9 m
@@ -1147,6 +1154,7 @@ Completed box being shipped out [3]
 .....\hbox(7.69997+3.30003)x108.33333, glue set 78.64195fill
 ......\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 d
 ......\OT1/cmtt/m/n/9 e
@@ -1168,6 +1176,7 @@ Completed box being shipped out [3]
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ......\penalty 10000
 ......\glue 3.08331 plus 1.54166 minus 1.02777
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 3
 ......\penalty 10000
 ......\glue(\parfillskip) -15.0
@@ -1347,6 +1356,7 @@ Completed box being shipped out [3]
 .....\hbox(7.69997+3.30003)x108.33333, glue set 69.19206fill
 ......\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 h
 ......\OT1/cmtt/m/n/9 s
@@ -1370,6 +1380,7 @@ Completed box being shipped out [3]
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ......\penalty 10000
 ......\glue 3.08331 plus 1.54166 minus 1.02777
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 3
 ......\penalty 10000
 ......\glue(\parfillskip) -15.0
@@ -1416,6 +1427,7 @@ Completed box being shipped out [3]
 ......\glue 15.0
 ......\glue 0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 m
 ......\OT1/cmtt/m/n/9 y
@@ -1442,6 +1454,7 @@ Completed box being shipped out [3]
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ......\penalty 10000
 ......\glue 3.08331 plus 1.54166 minus 1.02777
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/it/9 1
 ......\OT1/cmr/m/n/9 ,
 ......\glue 3.08331 plus 1.92706 minus 0.8222
@@ -1551,6 +1564,7 @@ Completed box being shipped out [3]
 .....\hbox(7.69997+3.30003)x108.33333, glue set 55.01723fill
 ......\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 m
 ......\OT1/cmtt/m/n/9 y
@@ -1577,6 +1591,7 @@ Completed box being shipped out [3]
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ......\penalty 10000
 ......\glue 3.08331 plus 1.54166 minus 1.02777
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 3
 ......\penalty 10000
 ......\glue(\parfillskip) -15.0
@@ -1587,6 +1602,7 @@ Completed box being shipped out [3]
 .....\hbox(7.69997+3.30003)x108.33333, glue set 9.18063fill
 ......\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 m
 ......\OT1/cmtt/m/n/9 y
@@ -1597,6 +1613,7 @@ Completed box being shipped out [3]
 ......\OT1/cmtt/m/n/9 t
 ......\OT1/cmtt/m/n/9 h
 ......\glue 3.08331 plus 1.54166 minus 1.02777
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 (
 ......\OT1/cmr/m/n/9 l
 ......\OT1/cmr/m/n/9 e
@@ -1655,6 +1672,7 @@ Completed box being shipped out [3]
 .....\hbox(7.69997+3.30003)x108.33333, glue set 26.66756fill
 ......\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 n
 ......\OT1/cmtt/m/n/9 e
@@ -1687,6 +1705,7 @@ Completed box being shipped out [3]
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ......\penalty 10000
 ......\glue 3.08331 plus 1.54166 minus 1.02777
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 3
 ......\penalty 10000
 ......\glue(\parfillskip) -15.0
@@ -1711,6 +1730,7 @@ Completed box being shipped out [3]
 .....\hbox(7.69997+3.30003)x108.33333, glue set 69.19206fill
 ......\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 r
 ......\OT1/cmtt/m/n/9 e
@@ -1734,6 +1754,7 @@ Completed box being shipped out [3]
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 ......\penalty 10000
 ......\glue 3.08331 plus 1.54166 minus 1.02777
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 3
 ......\penalty 10000
 ......\glue(\parfillskip) -15.0
@@ -1812,9 +1833,11 @@ Completed box being shipped out [3]
 ......\glue 15.0
 ......\glue 0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 f
 ......\OT1/cmtt/m/n/9 o
 ......\OT1/cmtt/m/n/9 o
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 :
 ......\glue 3.08331 plus 1.54166 minus 1.02777
 ......\OT1/cmr/m/n/9 ^^L (ligature fi)
@@ -1872,6 +1895,7 @@ Completed box being shipped out [3]
 ......\glue 15.0
 ......\glue 0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 m
 ......\OT1/cmtt/m/n/9 y
@@ -1881,6 +1905,7 @@ Completed box being shipped out [3]
 ......\OT1/cmtt/m/n/9 g
 ......\OT1/cmtt/m/n/9 t
 ......\OT1/cmtt/m/n/9 h
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 :
 ......\glue 3.08331 plus 1.54166 minus 1.02777
 ......\OT1/cmr/m/n/9 F
@@ -1967,6 +1992,7 @@ Completed box being shipped out [3]
 ......\glue 15.0
 ......\glue 0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 \
 ......\OT1/cmtt/m/n/9 @
 ......\OT1/cmtt/m/n/9 m
@@ -1976,6 +2002,7 @@ Completed box being shipped out [3]
 ......\OT1/cmtt/m/n/9 c
 ......\OT1/cmtt/m/n/9 r
 ......\OT1/cmtt/m/n/9 o
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 :
 ......\glue 3.08331 plus 1.54166 minus 1.02777
 ......\OT1/cmr/m/n/9 n
@@ -2024,6 +2051,7 @@ Completed box being shipped out [3]
 ......\glue 15.0
 ......\glue 0.0
 ......\hbox(0.0+0.0)x0.0
+......\setlanguage1 (hyphenmin 2,3)
 ......\OT1/cmtt/m/n/9 m
 ......\OT1/cmtt/m/n/9 y
 ......\OT1/cmtt/m/n/9 e
@@ -2037,6 +2065,7 @@ Completed box being shipped out [3]
 ......\OT1/cmtt/m/n/9 e
 ......\OT1/cmtt/m/n/9 n
 ......\OT1/cmtt/m/n/9 t
+......\setlanguage0 (hyphenmin 2,3)
 ......\OT1/cmr/m/n/9 :
 ......\glue 3.08331 plus 1.54166 minus 1.02777
 ......\OT1/cmr/m/n/9 T


### PR DESCRIPTION
# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [n/a] Test file(s) added -- tested by existing tests 
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [x] `ltnewsX.tex` (and/or `latexchanges.tex`) updated

review mainly for documentation needed I guess