### PR TITLE
Gh955 fix broken rollback

### DIFF
--- a/base/README.md
+++ b/base/README.md
@@ -1,7 +1,7 @@
 The LaTeX kernel
 ================
 
-Release 2023-05-01 pre-release 0
+Release 2023-06-01 pre-release 0
 
 Overview
 --------

--- a/base/changes.txt
+++ b/base/changes.txt
@@ -11,6 +11,11 @@ All changes above are only part of the development branch for the next release.
 ================================================================================
 
 
+2022-11-14  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
+
+	* latexrelease.dtx (subsection{Ignoring \texttt{\string_new} errors when rolling back}):
+	Silence \cs{NewMarkClass} in rollback (gh/955)
+
 2022-11-13  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 
 	* doc.dtx:

--- a/base/latexrelease.dtx
+++ b/base/latexrelease.dtx
@@ -40,7 +40,7 @@
 %<*latexrelease>
 % \fi
 %         \ProvidesFile{latexrelease.dtx}
-          [2022/02/28 v1.0o LaTeX release emulation and tests
+          [2022/11/14 v1.0p LaTeX release emulation and tests
               (including releases up to \latexreleaseversion)]
 % \iffalse
 %</latexrelease>
@@ -746,8 +746,12 @@ of this package available from CTAN}
 %
 % Finally, redirect the error thrown by \cs{NewHook} to nowhere so it
 % can be safely reused (the hook isn't redeclared if it already exists).
+% The same happens for \cs{NewMarkClass}.  
+% \changes{v1.0p}{2022/11/14}
+%         {Silence \cs{NewMarkClass} in rollback (gh/955)}
 %    \begin{macrocode}
 \msg_redirect_name:nnn { hooks } { exists } { none }
+\msg_redirect_name:nnn { mark } { class-already-defined }{ none } 
 %    \end{macrocode}
 %
 % Now a one-off for |ltcmd.dtx|: we need to make \cs{NewDocumentCommand}

--- a/base/ltvers.dtx
+++ b/base/ltvers.dtx
@@ -112,7 +112,7 @@
 %</2ekernel>
 %<latexrelease>\edef\latexreleaseversion
 %<*2ekernel|latexrelease>
-   {2023-05-01}
+   {2023-06-01}
 %</2ekernel|latexrelease>
 %<*2ekernel>
 \def\patch@level{-0}

--- a/base/testfiles/tlb-latexrelease-rollback-2022-06-01.luatex.tlg
+++ b/base/testfiles/tlb-latexrelease-rollback-2022-06-01.luatex.tlg
@@ -722,33 +722,6 @@ Already applied: [....-..-..] NFSS version1 commands on input line ....
 Applying: [....-..-..] Extended Allocation on input line ....
 Already applied: [....-..-..] Extended Allocation on input line ....
 Applying: [....-..-..] Delayed legacy marks on input line ....
-! LaTeX mark Error: Mark class '2e-left' already defined
-For immediate help type H <return>.
- ...                                              
-l. ...\NewMarkClass {2e-left}
-This is a coding error.
-LaTeX was asked to define a new mark class called '2e-left': this mark class
-already exists.
-Try typing <return> to proceed.
-If that doesn't work, type X <return> to quit.
-! LaTeX mark Error: Mark class '2e-right' already defined
-For immediate help type H <return>.
- ...                                              
-l. ...\NewMarkClass {2e-right}
-This is a coding error.
-LaTeX was asked to define a new mark class called '2e-right': this mark class
-already exists.
-Try typing <return> to proceed.
-If that doesn't work, type X <return> to quit.
-! LaTeX mark Error: Mark class '2e-right-nonempty' already defined
-For immediate help type H <return>.
- ...                                              
-l. ...\NewMarkClass {2e-right-nonempty}
-This is a coding error.
-LaTeX was asked to define a new mark class called '2e-right-nonempty': this
-mark class already exists.
-Try typing <return> to proceed.
-If that doesn't work, type X <return> to quit.
 Already applied: [....-..-..] Delayed legacy marks on input line ....
 Applying: [....-..-..] Extended Allocation on input line ....
 Already applied: [....-..-..] Extended Allocation on input line ....

--- a/base/testfiles/tlb-latexrelease-rollback-2022-06-01.tlg
+++ b/base/testfiles/tlb-latexrelease-rollback-2022-06-01.tlg
@@ -710,33 +710,6 @@ Already applied: [....-..-..] NFSS version1 commands on input line ....
 Applying: [....-..-..] Extended Allocation on input line ....
 Already applied: [....-..-..] Extended Allocation on input line ....
 Applying: [....-..-..] Delayed legacy marks on input line ....
-! LaTeX mark Error: Mark class '2e-left' already defined
-For immediate help type H <return>.
- ...                                              
-l. ...\NewMarkClass {2e-left}
-This is a coding error.
-LaTeX was asked to define a new mark class called '2e-left': this mark class
-already exists.
-Try typing <return> to proceed.
-If that doesn't work, type X <return> to quit.
-! LaTeX mark Error: Mark class '2e-right' already defined
-For immediate help type H <return>.
- ...                                              
-l. ...\NewMarkClass {2e-right}
-This is a coding error.
-LaTeX was asked to define a new mark class called '2e-right': this mark class
-already exists.
-Try typing <return> to proceed.
-If that doesn't work, type X <return> to quit.
-! LaTeX mark Error: Mark class '2e-right-nonempty' already defined
-For immediate help type H <return>.
- ...                                              
-l. ...\NewMarkClass {2e-right-nonempty}
-This is a coding error.
-LaTeX was asked to define a new mark class called '2e-right-nonempty': this
-mark class already exists.
-Try typing <return> to proceed.
-If that doesn't work, type X <return> to quit.
 Already applied: [....-..-..] Delayed legacy marks on input line ....
 Applying: [....-..-..] Extended Allocation on input line ....
 Already applied: [....-..-..] Extended Allocation on input line ....

--- a/base/testfiles/tlb-latexrelease-rollback-2022-06-01.xetex.tlg
+++ b/base/testfiles/tlb-latexrelease-rollback-2022-06-01.xetex.tlg
@@ -711,33 +711,6 @@ Already applied: [....-..-..] NFSS version1 commands on input line ....
 Applying: [....-..-..] Extended Allocation on input line ....
 Already applied: [....-..-..] Extended Allocation on input line ....
 Applying: [....-..-..] Delayed legacy marks on input line ....
-! LaTeX mark Error: Mark class '2e-left' already defined
-For immediate help type H <return>.
- ...                                              
-l. ...\NewMarkClass {2e-left}
-This is a coding error.
-LaTeX was asked to define a new mark class called '2e-left': this mark class
-already exists.
-Try typing <return> to proceed.
-If that doesn't work, type X <return> to quit.
-! LaTeX mark Error: Mark class '2e-right' already defined
-For immediate help type H <return>.
- ...                                              
-l. ...\NewMarkClass {2e-right}
-This is a coding error.
-LaTeX was asked to define a new mark class called '2e-right': this mark class
-already exists.
-Try typing <return> to proceed.
-If that doesn't work, type X <return> to quit.
-! LaTeX mark Error: Mark class '2e-right-nonempty' already defined
-For immediate help type H <return>.
- ...                                              
-l. ...\NewMarkClass {2e-right-nonempty}
-This is a coding error.
-LaTeX was asked to define a new mark class called '2e-right-nonempty': this
-mark class already exists.
-Try typing <return> to proceed.
-If that doesn't work, type X <return> to quit.
 Already applied: [....-..-..] Delayed legacy marks on input line ....
 Applying: [....-..-..] Extended Allocation on input line ....
 Already applied: [....-..-..] Extended Allocation on input line ....

--- a/base/testfiles/tlb-latexrelease-rollback-2022-11-01.luatex.tlg
+++ b/base/testfiles/tlb-latexrelease-rollback-2022-11-01.luatex.tlg
@@ -722,33 +722,6 @@ Already applied: [....-..-..] NFSS version1 commands on input line ....
 Applying: [....-..-..] Extended Allocation on input line ....
 Already applied: [....-..-..] Extended Allocation on input line ....
 Applying: [....-..-..] Delayed legacy marks on input line ....
-! LaTeX mark Error: Mark class '2e-left' already defined
-For immediate help type H <return>.
- ...                                              
-l. ...\NewMarkClass {2e-left}
-This is a coding error.
-LaTeX was asked to define a new mark class called '2e-left': this mark class
-already exists.
-Try typing <return> to proceed.
-If that doesn't work, type X <return> to quit.
-! LaTeX mark Error: Mark class '2e-right' already defined
-For immediate help type H <return>.
- ...                                              
-l. ...\NewMarkClass {2e-right}
-This is a coding error.
-LaTeX was asked to define a new mark class called '2e-right': this mark class
-already exists.
-Try typing <return> to proceed.
-If that doesn't work, type X <return> to quit.
-! LaTeX mark Error: Mark class '2e-right-nonempty' already defined
-For immediate help type H <return>.
- ...                                              
-l. ...\NewMarkClass {2e-right-nonempty}
-This is a coding error.
-LaTeX was asked to define a new mark class called '2e-right-nonempty': this
-mark class already exists.
-Try typing <return> to proceed.
-If that doesn't work, type X <return> to quit.
 Already applied: [....-..-..] Delayed legacy marks on input line ....
 Applying: [....-..-..] Extended Allocation on input line ....
 Already applied: [....-..-..] Extended Allocation on input line ....

--- a/base/testfiles/tlb-latexrelease-rollback-2022-11-01.tlg
+++ b/base/testfiles/tlb-latexrelease-rollback-2022-11-01.tlg
@@ -710,33 +710,6 @@ Already applied: [....-..-..] NFSS version1 commands on input line ....
 Applying: [....-..-..] Extended Allocation on input line ....
 Already applied: [....-..-..] Extended Allocation on input line ....
 Applying: [....-..-..] Delayed legacy marks on input line ....
-! LaTeX mark Error: Mark class '2e-left' already defined
-For immediate help type H <return>.
- ...                                              
-l. ...\NewMarkClass {2e-left}
-This is a coding error.
-LaTeX was asked to define a new mark class called '2e-left': this mark class
-already exists.
-Try typing <return> to proceed.
-If that doesn't work, type X <return> to quit.
-! LaTeX mark Error: Mark class '2e-right' already defined
-For immediate help type H <return>.
- ...                                              
-l. ...\NewMarkClass {2e-right}
-This is a coding error.
-LaTeX was asked to define a new mark class called '2e-right': this mark class
-already exists.
-Try typing <return> to proceed.
-If that doesn't work, type X <return> to quit.
-! LaTeX mark Error: Mark class '2e-right-nonempty' already defined
-For immediate help type H <return>.
- ...                                              
-l. ...\NewMarkClass {2e-right-nonempty}
-This is a coding error.
-LaTeX was asked to define a new mark class called '2e-right-nonempty': this
-mark class already exists.
-Try typing <return> to proceed.
-If that doesn't work, type X <return> to quit.
 Already applied: [....-..-..] Delayed legacy marks on input line ....
 Applying: [....-..-..] Extended Allocation on input line ....
 Already applied: [....-..-..] Extended Allocation on input line ....

--- a/base/testfiles/tlb-latexrelease-rollback-2022-11-01.xetex.tlg
+++ b/base/testfiles/tlb-latexrelease-rollback-2022-11-01.xetex.tlg
@@ -711,33 +711,6 @@ Already applied: [....-..-..] NFSS version1 commands on input line ....
 Applying: [....-..-..] Extended Allocation on input line ....
 Already applied: [....-..-..] Extended Allocation on input line ....
 Applying: [....-..-..] Delayed legacy marks on input line ....
-! LaTeX mark Error: Mark class '2e-left' already defined
-For immediate help type H <return>.
- ...                                              
-l. ...\NewMarkClass {2e-left}
-This is a coding error.
-LaTeX was asked to define a new mark class called '2e-left': this mark class
-already exists.
-Try typing <return> to proceed.
-If that doesn't work, type X <return> to quit.
-! LaTeX mark Error: Mark class '2e-right' already defined
-For immediate help type H <return>.
- ...                                              
-l. ...\NewMarkClass {2e-right}
-This is a coding error.
-LaTeX was asked to define a new mark class called '2e-right': this mark class
-already exists.
-Try typing <return> to proceed.
-If that doesn't work, type X <return> to quit.
-! LaTeX mark Error: Mark class '2e-right-nonempty' already defined
-For immediate help type H <return>.
- ...                                              
-l. ...\NewMarkClass {2e-right-nonempty}
-This is a coding error.
-LaTeX was asked to define a new mark class called '2e-right-nonempty': this
-mark class already exists.
-Try typing <return> to proceed.
-If that doesn't work, type X <return> to quit.
 Already applied: [....-..-..] Delayed legacy marks on input line ....
 Applying: [....-..-..] Extended Allocation on input line ....
 Already applied: [....-..-..] Extended Allocation on input line ....

--- a/base/testfiles/tlb-latexrelease-rollback-2023-06-01.lvt
+++ b/base/testfiles/tlb-latexrelease-rollback-2023-06-01.lvt
@@ -1,0 +1,12 @@
+%
+% Rolling back to a previous release without hitting errors
+% There should be one test for every earlier main release
+%
+\input{test2e}
+
+\START
+
+\RequirePackage[2023/06/01]{latexrelease}
+
+\END
+

--- a/base/testfiles/tlb-latexrelease-rollback-2023-06-01.tlg
+++ b/base/testfiles/tlb-latexrelease-rollback-2023-06-01.tlg
@@ -1,0 +1,7 @@
+This is a generated file for the LaTeX2e validation system.
+Don't change this file in any respect.
+(latexrelease.sty
+LaTeX Info: Redefining \IfTargetDateBefore on input line ....
+Package: latexrelease ....-..-.. v... LaTeX release emulation and tests (including releases up to ....-..-..)
+Package latexrelease Warning: Current format date selected, no patches applied.
+)

--- a/base/update-rollback-tests.sh
+++ b/base/update-rollback-tests.sh
@@ -4,6 +4,7 @@ l3build save -eetex,xetex,luatex \
 	tlb-latexrelease-rollback-2021-11-15 \
 	tlb-latexrelease-rollback-2022-06-01 \
 	tlb-latexrelease-rollback-2022-11-01 \
+	tlb-latexrelease-rollback-2023-06-01 \
 	tlb-latexrelease-rollback-003-often \
 	tlb-rollback-004-often \
 	tlb-rollback-005 \


### PR DESCRIPTION
# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [n/a] Test file(s) added -- already existing :-(
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [n/a] `ltnewsX.tex` (and/or `latexchanges.tex`) updated

I also changed the release date to 6/1 and also added a dummy rollback test for the upcoming release
