### PR TITLE
Install pdfcolfoot

### DIFF
--- a/.github/tl_packages
+++ b/.github/tl_packages
@@ -78,6 +78,7 @@ ly1
 makeindex
 mflogo
 palatino
+pdfcolfoot
 pl
 psnfss
 sauter


### PR DESCRIPTION
which has been split out of the oberdiek bundle since v1.4 2023-01-10
 - CTAN Announcement: https://ctan.org/ctan-ann/id/mailman.3074.1673468195.3715.ctan-ann@ctan.org

This fixes the failed ci running on latest `develop`, see for example https://github.com/muzimuzhi/latex2e/actions/runs/3922308282/jobs/6705166525#step:5:35143.

_Update_: Branch `main` need this change as well.

**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
- Under development
- [x] Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
