### PR TITLE
Gh982: Add full release date to ltnews

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,13 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 ================================================================================
 
+2023-01-16 Yukai Chou <muzimuzhi@gmail.com>
+
+	* ltnews.cls:
+	Added full release date yyyy-mm-dd to _all_ ltnews issues.
+	Added \publicationday{<day>} to specify day in a month in ltnews<n>.tex.
+	<day> defaults to 01.
+
 ================================================================================
 All changes above are only part of the development branch for the next release.
 ================================================================================

--- a/base/doc/ltnews.tex
+++ b/base/doc/ltnews.tex
@@ -113,22 +113,11 @@
    \renewcommand{\@evenfoot}{\@indiciafont\@indicia\hfill --\thepage}%
 }
 
-\newcommand*{\MonthJanuary}{01}
-\newcommand*{\MonthFebruary}{02}
-\newcommand*{\MonthMarch}{03}
-\newcommand*{\MonthApril}{04}
-\newcommand*{\MonthMay}{05}
-\newcommand*{\MonthJune}{06}
-\newcommand*{\MonthJuly}{07}
-\newcommand*{\MonthAugust}{08}
-\newcommand*{\MonthSeptember}{09}
-\newcommand*{\MonthOctober}{10}
-\newcommand*{\MonthNovember}{11}
-\newcommand*{\MonthDecember}{12}
 \newcommand*{\printissue}{%
   Issue %
   \texorpdfstring{\number\value{issue}}{\theissue}, %
-  \texorpdfstring{\@month\space\@year}{\@year/\@nameuse{Month\@month}}%
+  \texorpdfstring{\@month\space\@year\space(\publicationdate)}
+    {\@year/\@julianmonthtonum{\@month}}%
 }
 \let\l@part\l@section
 \let\l@section\l@subsection
@@ -303,6 +292,7 @@
   \loop
   \ifnum\value{issue}<\lastissue
     \stepcounter{issue}%
+    \publicationday{01}%
     \input{ltnews\theissue}%
   \repeat
   \stepcounter{issue}%

--- a/base/doc/ltnews19.tex
+++ b/base/doc/ltnews19.tex
@@ -36,6 +36,7 @@
 
 \usepackage{lmodern,url}
 
+\publicationday{24}
 \publicationmonth{September}
 \publicationyear{2009}
 

--- a/base/doc/ltnews20.tex
+++ b/base/doc/ltnews20.tex
@@ -36,6 +36,7 @@
 
 \usepackage{lmodern,url}
 
+\publicationday{27}
 \publicationmonth{June}
 \publicationyear{2011}
 

--- a/base/doc/ltnews27.tex
+++ b/base/doc/ltnews27.tex
@@ -35,6 +35,7 @@
 
 \usepackage{lmodern,url,hologo}
 
+\publicationday{15}
 \publicationmonth{April}
 \publicationyear{2017}
 

--- a/base/doc/ltnews31.tex
+++ b/base/doc/ltnews31.tex
@@ -119,6 +119,7 @@
 \fi
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+\publicationday{02}
 \publicationmonth{February}
 \publicationyear{2020}
 

--- a/base/doc/ltnews34.tex
+++ b/base/doc/ltnews34.tex
@@ -116,6 +116,7 @@
 \providecommand\tubcommand[1]{}
 \tubcommand{\input{tubltmac}}
 
+\publicationday{15}
 \publicationmonth{November}
 \publicationyear{2021}
 

--- a/base/doc/ltnews37.tex
+++ b/base/doc/ltnews37.tex
@@ -122,6 +122,7 @@
 \providecommand\tubcommand[1]{}
 \tubcommand{\input{tubltmac}}
 
+% \publicationday{01} % change this if it's not released on 1st of a month
 \publicationmonth{June}
 \publicationyear{2023  --- DRAFT version for upcoming release}
 

--- a/base/ltnews.cls
+++ b/base/ltnews.cls
@@ -429,6 +429,30 @@
 \newcommand{\@year}{\ClassError{ltnews}
    {No \protect\publicationyear~given}\@eha}
 
+\newcommand{\publicationday}{\renewcommand{\@day}}
+\newcommand{\@day}{01} % most releases happen on 1st of a month
+
+\newcommand{\publicationdate}{%
+  % support draft ltnews, \publicationyear{2023 --- DRAFT ...}
+  \expandafter\@gobblenonyear\@year\@nil
+  -\@julianmonthtonum\@month-\two@digits\@day}
+
+\newcommand{\@julianmonthtonum}[1]{\@nameuse{@juliantonum#1}}
+\def\@juliantonumJanuary  {01}
+\def\@juliantonumFebruary {02}
+\def\@juliantonumMarch    {03}
+\def\@juliantonumApril    {04}
+\def\@juliantonumMay      {05}
+\def\@juliantonumJune     {06}
+\def\@juliantonumJuly     {07}
+\def\@juliantonumAugust   {08}
+\def\@juliantonumSeptember{09}
+\def\@juliantonumOctober  {10}
+\def\@juliantonumNovember {11}
+\def\@juliantonumDecember {12}
+
+\long\def\@gobblenonyear#1#2#3#4#5\@nil{#1#2#3#4}
+
 \newcommand{\publicationissue}{\renewcommand{\@issue}}
 \newcommand{\@issue}{\ClassError{ltnews}
    {No \protect\publicationissue~given}\@eha}
@@ -449,7 +473,8 @@
    \twocolumn[{%
       \parbox[t][7\baselineskip]{\textwidth}{%
          \@titlefont\@title\\[\medskipamount]
-         \normalfont\normalsize\issuename~\@issue, \@month~\@year
+         \normalfont\normalsize\issuename~\@issue,
+         \@month~\@year~(\publicationdate)%
       }%
    }]%
    \thispagestyle{titlepage}


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

Since most of the releases happen on 1st of a month, `\publicationday{01}` is set in `ltnews.cls`. This also avoids modifying every existing `ltnews<n>.tex`.

```bash
grep -rhe '# [^ ]* Release' changes.txt | grep -ve '[/-]01 '
# 2021-11-15 Release
# 2020-02-02 Release
# 2017-04-15 Release
# 2011/06/27 Release
# 2009/09/24 Release
```

implements #982

**Previews**
![image](https://user-images.githubusercontent.com/6376638/212569269-b0fc21b7-172b-45ca-9254-b9733cebaffd.png)
![image](https://user-images.githubusercontent.com/6376638/212569286-36c57bec-7b47-4b44-992f-270ff664dd25.png)
![image](https://user-images.githubusercontent.com/6376638/212570236-1c6df71c-8f13-43f2-a5b0-36bcbb04da8a.png)
![image](https://user-images.githubusercontent.com/6376638/212570254-52d44c78-50c0-4c47-b4dc-d5a22051f379.png)
![image](https://user-images.githubusercontent.com/6376638/212570270-b35ddc42-9694-4a41-b63d-bc3b87303e06.png)

**Discussion**
- Full release date is also added to the toc entry, is it acceptable?
- PDF bookmark titles are not modified.
   ![image](https://user-images.githubusercontent.com/6376638/212570379-c045ad2e-43e8-4f7a-8ce0-e10426fed594.png)

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- [x] Feedback wanted 
- Under development
- [x] Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
