### PR TITLE
Fix typo, add missing "be" in license footnotes

### DIFF
--- a/base/doc/cfgguide.tex
+++ b/base/doc/cfgguide.tex
@@ -41,7 +41,7 @@
 
 \author{\copyright~Copyright 1998, 2001, 2003 \LaTeX\ Project Team.\\
    All rights reserved.%
-   \footnote{This file may distributed and/or modified under the
+   \footnote{This file may be distributed and/or modified under the
      conditions of the \LaTeX{} Project Public License, either version 1.3c
      of this license or (at your option) any later version. See the source
     \texttt{cfgguide.tex} for full details.}%

--- a/base/doc/clsguide.tex
+++ b/base/doc/clsguide.tex
@@ -36,7 +36,7 @@
 
 \author{Copyright \copyright~1995--2006 The \LaTeX\ Project\\
    All rights reserved.%
-   \footnote{This file may distributed and/or modified under the
+   \footnote{This file may be distributed and/or modified under the
      conditions of the \LaTeX{} Project Public License, either version 1.3c
      of this license or (at your option) any later version. See the source
     \texttt{clsguide.tex} for full details.}%

--- a/base/doc/cyrguide.tex
+++ b/base/doc/cyrguide.tex
@@ -34,7 +34,7 @@
 
 \author{\copyright~Copyright 1998--1999,\\ Vladimir Volovich,
         Werner Lemberg and \LaTeX\ Project Team.\\ All rights reserved.%
-        \footnote{This file may distributed and/or modified under the
+        \footnote{This file may be distributed and/or modified under the
           conditions of the \LaTeX{} Project Public License, either version 1.3c
           of this license or (at your option) any later version. See the source
          \texttt{cyrguide.tex} for full details.}%

--- a/base/doc/fntguide.tex
+++ b/base/doc/fntguide.tex
@@ -46,7 +46,7 @@
   Team.\thanks{Thanks to Arash Esbati for documenting the
     newer NFSS features of 2020}\\
   All rights reserved.%
-  \footnote{This file may distributed and/or modified under the
+  \footnote{This file may be distributed and/or modified under the
     conditions of the \LaTeX{} Project Public License, either version 1.3c
     of this license or (at your option) any later version. See the source
    \texttt{fntguide.tex} for full details.}%

--- a/base/doc/modguide.tex
+++ b/base/doc/modguide.tex
@@ -42,7 +42,7 @@
 
 \author{\copyright~Copyright 1995, \LaTeX\ Project Team.\\
    All rights reserved.%
-   \footnote{This file may distributed and/or modified under the
+   \footnote{This file may be distributed and/or modified under the
      conditions of the \LaTeX{} Project Public License, either version 1.3c
      of this license or (at your option) any later version. See the source
      texttt{modguide.tex} for full details.}%

--- a/base/doc/usrguide-historic.tex
+++ b/base/doc/usrguide-historic.tex
@@ -36,7 +36,7 @@
 
 \author{\copyright~Copyright 1995--2022, \LaTeX\ Project Team.\\
    All rights reserved.%
-   \footnote{This file may distributed and/or modified under the
+   \footnote{This file may be distributed and/or modified under the
      conditions of the \LaTeX{} Project Public License, either version 1.3c
      of this license or (at your option) any later version. See the source
     \texttt{usrguide.tex} for full details.}%

--- a/base/doc/usrguide.tex
+++ b/base/doc/usrguide.tex
@@ -36,7 +36,7 @@
 \title{\LaTeX\ for authors --- current version}
 \author{\copyright~Copyright 2020-2022, \LaTeX\ Project Team.\\
    All rights reserved.%
-   \footnote{This file may distributed and/or modified under the
+   \footnote{This file may be distributed and/or modified under the
      conditions of the \LaTeX{} Project Public License, either version 1.3c
      of this license or (at your option) any later version. See the source
     \texttt{usrguide.tex} for full details.}%

--- a/base/dropped-documentation/latexchanges.tex
+++ b/base/dropped-documentation/latexchanges.tex
@@ -40,7 +40,7 @@
 
 \author{\copyright~Copyright 2015--2021, \LaTeX\ Project Team.\\
    All rights reserved.%
-   \footnote{This file may distributed and/or modified under the
+   \footnote{This file may be distributed and/or modified under the
      conditions of the \LaTeX{} Project Public License, either version 1.3c
      of this license or (at your option) any later version. See the source
     \texttt{latexchanges.tex} for full details.}%


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

I'm neither a native speaker nor a grammar police, just it seems to me "may be distributed" is more commonly used than "may distributed". For example the [latest LPPL](https://www.latex-project.org/lppl.txt) reads

```
How to Use This License
-----------------------

[...]

Here is an example of such a notice and statement:

  %% pig.dtx
  %% Copyright 2005 M. Y. Name
  %
  % This work may be distributed and/or modified under the
  % conditions of the LaTeX Project Public License, either version 1.3
  % of this license or (at your option) any later version.
```

The modified lines were added in commit 3633a90. Since that commit didn't change version and date strings, current PR keeps them intact as well.

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- [x] Feedback wanted 
- Under development
- [x] Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
