### PR TITLE
reset frozen mathversion for #1028

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,11 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 ================================================================================
 
+2023-04-01  David Carlisle  <David.Carlisle@latex-project.org>
+
+	* ltfssbas.dtx: locally reset frozen mathversions when the math
+	version changes. (gh/1028)
+
 2023-03-28  Joseph Wright  <Joseph.Wright@latex-project.org>
 
 	* ltclass.dtx:

--- a/base/doc/ltnews37.tex
+++ b/base/doc/ltnews37.tex
@@ -389,7 +389,6 @@ the terminal.
 \githubissue{958}
 
 
-
 \subsection{A further hook for shipping out pages}
 
 Since October 2020 the shipout process offers a number of hooks to
@@ -506,6 +505,13 @@ expandable ones.
 This is fixed in the present \LaTeX{} release.
 %
 \githubissue{1009}
+
+\subsection{Corrections for switching math version}
+Some internal code improvements improve support for switching math version
+when nested within an outer math expression.
+This will improve \cs{boldsymbol} and \cs{bm} and similar commands.
+%
+\githubissue{1028}
 
 
 \section{Changes to packages in the \pkg{amsmath} category}

--- a/base/ltfssbas.dtx
+++ b/base/ltfssbas.dtx
@@ -35,7 +35,7 @@
 %
 %
 \ProvidesFile{ltfssbas.dtx}
-             [2022/07/04 v3.2k LaTeX Kernel (NFSS Basic Macros)]
+             [2023/04/01 v3.2l LaTeX Kernel (NFSS Basic Macros)]
 % \iffalse
 \documentclass{ltxdoc}
 \begin{document}
@@ -1050,11 +1050,22 @@
 %      {\cs{def} $\to$ \cs{edef} for \cs{math@version}.}
 % \changes{v1.2g}{1990/02/16}{\cs{@nomath} added.}
 % \changes{v2.1a}{1994/01/17}{New math font setup}
+% \changes{v3.2l}{2023/04/01}{Reset frozen mathversion gh/1028}
 %    \begin{macrocode}
 \DeclareRobustCommand\mathversion[1]
          {\@nomath\mathversion
           \expandafter\ifx\csname mv@#1\endcsname\relax
           \@latex@error{Math version `#1' is not defined}\@eha\else
+%    \end{macrocodpe}
+%  If there has been a frozen math version reset locally. See GH 1028.
+%    \begin{macrocode}
+          \ifcsname mv@\math@version @frozen\endcsname
+            \expandafter\let
+            \csname mv@\math@version @frozen\expandafter\endcsname
+            \csname mv@\math@version\endcsname
+          \fi
+%    \end{macrocode}
+%    \begin{macrocode}
           \edef\math@version{#1}%
 %    \end{macrocode}
 %    We need to force a math font setup both now and at the point

--- a/base/ltfssbas.dtx
+++ b/base/ltfssbas.dtx
@@ -1056,7 +1056,7 @@
          {\@nomath\mathversion
           \expandafter\ifx\csname mv@#1\endcsname\relax
           \@latex@error{Math version `#1' is not defined}\@eha\else
-%    \end{macrocodpe}
+%    \end{macrocode}
 %  If there has been a frozen math version reset locally. See GH 1028.
 %    \begin{macrocode}
           \ifcsname mv@\math@version @frozen\endcsname

--- a/base/testfiles/github-1028.luatex.tlg
+++ b/base/testfiles/github-1028.luatex.tlg
@@ -1,0 +1,91 @@
+This is a generated file for the LaTeX2e validation system.
+Don't change this file in any respect.
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <7> on input line ....
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <5> on input line ....
+Completed box being shipped out [1]
+\vbox(633.0+0.0)x407.0, direction TLT
+.\glue 16.0
+.\vbox(617.0+0.0)x345.0, shifted 62.0, direction TLT
+..\vbox(12.0+0.0)x345.0, glue set 12.0fil, direction TLT
+...\glue 0.0 plus 1.0fil
+...\hbox(0.0+0.0)x345.0, direction TLT
+....\hbox(0.0+0.0)x345.0, direction TLT
+..\glue 25.0
+..\glue(\lineskip) 0.0
+..\vbox(550.0+0.0)x345.0, glue set 515.94489fil, direction TLT
+...\write-{}
+...\glue(\topskip) 3.05556
+...\hbox(6.94444+1.25)x345.0, glue set 317.63885fil, direction TLT
+....\localpar
+.....\localinterlinepenalty=0
+.....\localbrokenpenalty=0
+.....\localleftbox=null
+.....\localrightbox=null
+....\hbox(0.0+0.0)x15.0, direction TLT
+....\mathon
+....\hbox(6.94444+1.25)x12.36113, direction TLT
+.....\OT1/cmss/m/n/10 Q
+.....\OT1/cmss/m/n/10 1
+....\mathoff
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 3.80556
+...\hbox(6.94444+1.25)x345.0, glue set 291.97223fil, direction TLT
+....\localpar
+.....\localinterlinepenalty=0
+.....\localbrokenpenalty=0
+.....\localleftbox=null
+.....\localrightbox=null
+....\hbox(0.0+0.0)x15.0, direction TLT
+....\mathon
+....\hbox(6.94444+1.25)x12.36113, direction TLT
+.....\OT1/cmss/m/n/10 Q
+.....\OT1/cmss/m/n/10 2
+....\glue(\medmuskip) 2.22217 plus 1.11108 minus 2.22217
+....\OT1/cmr/m/n/10 +
+....\penalty 700
+....\glue(\medmuskip) 2.22217 plus 1.11108 minus 2.22217
+....\hbox(6.94444+1.05554)x13.44452, direction TLT
+.....\mathon
+.....\hbox(6.94444+1.05554)x13.44452, direction TLT
+......\OT1/cmss/bx/n/10 Q
+......\OT1/cmss/bx/n/10 3
+.....\mathoff
+....\mathoff
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 3.80556
+...\hbox(6.94444+1.25)x345.0, glue set 317.63885fil, direction TLT
+....\localpar
+.....\localinterlinepenalty=0
+.....\localbrokenpenalty=0
+.....\localleftbox=null
+.....\localrightbox=null
+....\hbox(0.0+0.0)x15.0, direction TLT
+....\mathon
+....\hbox(6.94444+1.25)x12.36113, direction TLT
+.....\OT1/cmss/m/n/10 Q
+.....\OT1/cmss/m/n/10 4
+....\mathoff
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue -1.25
+...\glue 0.0 plus 1.0fil
+...\glue 0.0
+...\glue 0.0 plus 0.0001fil
+..\glue(\baselineskip) 23.55556
+..\hbox(6.44444+0.0)x345.0, direction TLT
+...\hbox(6.44444+0.0)x345.0, glue set 170.0fil, direction TLT
+....\glue 0.0 plus 1.0fil
+....\OT1/cmr/m/n/10 1
+....\glue 0.0 plus 1.0fil
+(github-1028.aux)

--- a/base/testfiles/github-1028.lvt
+++ b/base/testfiles/github-1028.lvt
@@ -1,0 +1,42 @@
+
+\documentclass{article}
+
+\input{test2e}
+
+\DeclareSymbolFont{symbols1}     {OMS}{cmsy}{m}{n}
+\DeclareSymbolFont{symbols2}     {OMS}{cmsy}{m}{n}
+\DeclareSymbolFont{symbols3}     {OMS}{cmsy}{m}{n}
+\DeclareSymbolFont{symbols4}     {OMS}{cmsy}{m}{n}
+\DeclareSymbolFont{symbols5}     {OMS}{cmsy}{m}{n}
+\DeclareSymbolFont{symbols6}     {OMS}{cmsy}{m}{n}
+\DeclareSymbolFont{symbols7}     {OMS}{cmsy}{m}{n}
+\DeclareSymbolFont{symbols8}     {OMS}{cmsy}{m}{n}
+\DeclareSymbolFont{symbols9}     {OMS}{cmsy}{m}{n}
+\DeclareSymbolFont{symbols10}     {OMS}{cmsy}{m}{n}
+\DeclareSymbolFont{symbols11}     {OMS}{cmsy}{m}{n}
+
+
+
+%\setcounter{localmathalphabets}{0}
+
+
+\begin{document}
+
+
+\showoutput
+
+\START
+
+$\mathsf{Q1}$
+
+% Q2 should not be bold
+$
+\mathsf{Q2}+
+\mbox{%
+\boldmath
+$\mathsf{Q3}$}
+$
+
+$\mathsf{Q4}$
+
+\end{document}

--- a/base/testfiles/github-1028.tlg
+++ b/base/testfiles/github-1028.tlg
@@ -1,0 +1,87 @@
+This is a generated file for the LaTeX2e validation system.
+Don't change this file in any respect.
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <7> on input line ....
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <5> on input line ....
+LaTeX Font Info:    Freeze math alphabet allocation in version normal.
+(Font)              Allocated math groups: 15 (local: 2) on input line ....
+LaTeX Font Info:    Undo math alphabet allocation in version normal on input line ....
+LaTeX Font Info:    Freeze math alphabet allocation in version bold.
+(Font)              Allocated math groups: 15 (local: 2) on input line ....
+LaTeX Font Info:    Undo math alphabet allocation in version normal on input line ....
+LaTeX Font Info:    Undo math alphabet allocation in version bold on input line ....
+LaTeX Font Info:    No math alphabet change to frozen version normal on input line ....
+LaTeX Font Info:    No math alphabet change to frozen version bold on input line ....
+LaTeX Font Info:    No math alphabet change to frozen version normal on input line ....
+LaTeX Font Info:    No math alphabet change to frozen version bold on input line ....
+Completed box being shipped out [1]
+\vbox(633.0+0.0)x407.0
+.\glue 16.0
+.\vbox(617.0+0.0)x345.0, shifted 62.0
+..\vbox(12.0+0.0)x345.0, glue set 12.0fil
+...\glue 0.0 plus 1.0fil
+...\hbox(0.0+0.0)x345.0
+....\hbox(0.0+0.0)x345.0
+..\glue 25.0
+..\glue(\lineskip) 0.0
+..\vbox(550.0+0.0)x345.0, glue set 515.94489fil
+...\write-{}
+...\glue(\topskip) 3.05556
+...\hbox(6.94444+1.25)x345.0, glue set 317.63887fil
+....\hbox(0.0+0.0)x15.0
+....\mathon
+....\hbox(6.94444+1.25)x12.36113
+.....\OT1/cmss/m/n/10 Q
+.....\OT1/cmss/m/n/10 1
+....\mathoff
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 3.80556
+...\hbox(6.94444+1.25)x345.0, glue set 291.97221fil
+....\hbox(0.0+0.0)x15.0
+....\mathon
+....\hbox(6.94444+1.25)x12.36113
+.....\OT1/cmss/m/n/10 Q
+.....\OT1/cmss/m/n/10 2
+....\glue(\medmuskip) 2.22217 plus 1.11108 minus 2.22217
+....\OT1/cmr/m/n/10 +
+....\penalty 700
+....\glue(\medmuskip) 2.22217 plus 1.11108 minus 2.22217
+....\hbox(6.94444+1.05554)x13.44452
+.....\mathon
+.....\hbox(6.94444+1.05554)x13.44452
+......\OT1/cmss/bx/n/10 Q
+......\OT1/cmss/bx/n/10 3
+.....\mathoff
+....\mathoff
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 3.80556
+...\hbox(6.94444+1.25)x345.0, glue set 317.63887fil
+....\hbox(0.0+0.0)x15.0
+....\mathon
+....\hbox(6.94444+1.25)x12.36113
+.....\OT1/cmss/m/n/10 Q
+.....\OT1/cmss/m/n/10 4
+....\mathoff
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue -1.25
+...\glue 0.0 plus 1.0fil
+...\glue 0.0
+...\glue 0.0 plus 0.0001fil
+..\glue(\baselineskip) 23.55556
+..\hbox(6.44444+0.0)x345.0
+...\hbox(6.44444+0.0)x345.0, glue set 170.0fil
+....\glue 0.0 plus 1.0fil
+....\OT1/cmr/m/n/10 1
+....\glue 0.0 plus 1.0fil
+(github-1028.aux)

--- a/base/testfiles/github-1028.xetex.tlg
+++ b/base/testfiles/github-1028.xetex.tlg
@@ -1,0 +1,76 @@
+This is a generated file for the LaTeX2e validation system.
+Don't change this file in any respect.
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <7> on input line ....
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <5> on input line ....
+Completed box being shipped out [1]
+\vbox(633.0+0.0)x407.0
+.\glue 16.0
+.\vbox(617.0+0.0)x345.0, shifted 62.0
+..\vbox(12.0+0.0)x345.0, glue set 12.0fil
+...\glue 0.0 plus 1.0fil
+...\hbox(0.0+0.0)x345.0
+....\hbox(0.0+0.0)x345.0
+..\glue 25.0
+..\glue(\lineskip) 0.0
+..\vbox(550.0+0.0)x345.0, glue set 515.94489fil
+...\write-{}
+...\glue(\topskip) 3.05556
+...\hbox(6.94444+1.25)x345.0, glue set 317.63887fil
+....\hbox(0.0+0.0)x15.0
+....\mathon
+....\hbox(6.94444+1.25)x12.36113
+.....\OT1/cmss/m/n/10 Q
+.....\OT1/cmss/m/n/10 1
+....\mathoff
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 3.80556
+...\hbox(6.94444+1.25)x345.0, glue set 291.97221fil
+....\hbox(0.0+0.0)x15.0
+....\mathon
+....\hbox(6.94444+1.25)x12.36113
+.....\OT1/cmss/m/n/10 Q
+.....\OT1/cmss/m/n/10 2
+....\glue(\medmuskip) 2.22217 plus 1.11108 minus 2.22217
+....\OT1/cmr/m/n/10 +
+....\penalty 700
+....\glue(\medmuskip) 2.22217 plus 1.11108 minus 2.22217
+....\hbox(6.94444+1.05554)x13.44452
+.....\mathon
+.....\hbox(6.94444+1.05554)x13.44452
+......\OT1/cmss/bx/n/10 Q
+......\OT1/cmss/bx/n/10 3
+.....\mathoff
+....\mathoff
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 3.80556
+...\hbox(6.94444+1.25)x345.0, glue set 317.63887fil
+....\hbox(0.0+0.0)x15.0
+....\mathon
+....\hbox(6.94444+1.25)x12.36113
+.....\OT1/cmss/m/n/10 Q
+.....\OT1/cmss/m/n/10 4
+....\mathoff
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue -1.25
+...\glue 0.0 plus 1.0fil
+...\glue 0.0
+...\glue 0.0 plus 0.0001fil
+..\glue(\baselineskip) 23.55556
+..\hbox(6.44444+0.0)x345.0
+...\hbox(6.44444+0.0)x345.0, glue set 170.0fil
+....\glue 0.0 plus 1.0fil
+....\OT1/cmr/m/n/10 1
+....\glue 0.0 plus 1.0fil
+(github-1028.aux)


### PR DESCRIPTION

Possible fix for #1028

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
I didn't add rollback, if it is needed I guess it should have the original from 0000/00/00 and this from 2022/11/01 (when freeze mechanism added)  but this version should work with old formats anyway so no rollback seems ok?

## Checklist of required changes before merge will be approved
- [X] Test file(s) added
- [X] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [x] `ltnewsX.tex` (and/or `latexchanges.tex`) updated

