### PR TITLE
missing substitution for #1037

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,7 +6,11 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 ================================================================================
 
-2022-08-18  Phelype Oleinik  <phelype.oleinik@latex-project.org>
+2023-04-13  David Carlisle  <David.Carlisle@latex-project.org>
+
+	* cmfonts.fdd: add missing substitution for U/cmtt/bx/sl gh/1037
+
+2023-04-13  Phelype Oleinik  <phelype.oleinik@latex-project.org>
 
 	* ltcmd.dtx (subsection{Grabbing arguments}):
 	Set \tex_endlinechar:D earlier to correct parsing of newlines in

--- a/base/cmfonts.fdd
+++ b/base/cmfonts.fdd
@@ -67,7 +67,7 @@
 %<*driver,  >
              \ProvidesFile{cmfonts.drv}
 %</driver,  >
-        [2022/07/10 v2.5l Standard LaTeX font definitions]
+        [2022/04/13 v2.5m Standard LaTeX font definitions]
 %
 %<*driver>
 \documentclass{ltxdoc}
@@ -1048,8 +1048,10 @@
 %    \end{macrocode}
 %
 % \changes{v2.5j}{2019/12/16}{Provide substitutions for cmtt/bx/sl}
+% \changes{v2.5m}{2023/04/13}{Add missing substitution for U/cmtt/bx/sl}
 %    \begin{macrocode}
 %<+OT1cmtt>\DeclareFontShape{OT1}{cmtt}{bx}{sl}
+%<+Ucmtt>\DeclareFontShape{U}{cmtt}{bx}{sl}
 %<-nowarn>  {<->sub*cmtt/m/n}{}
 %<+nowarn>  {<->ssub*cmtt/m/n}{}
 %<+OT1cmtt>\DeclareFontShape{OT1}{cmtt}{bx}{ui}

--- a/base/cmfonts.fdd
+++ b/base/cmfonts.fdd
@@ -67,7 +67,7 @@
 %<*driver,  >
              \ProvidesFile{cmfonts.drv}
 %</driver,  >
-        [2022/04/13 v2.5m Standard LaTeX font definitions]
+        [2023/04/13 v2.5m Standard LaTeX font definitions]
 %
 %<*driver>
 \documentclass{ltxdoc}

--- a/base/testfiles/github-1037.lvt
+++ b/base/testfiles/github-1037.lvt
@@ -1,0 +1,14 @@
+\documentclass{article}
+\input{test2e}
+\begin{document}
+
+\START
+\sbox0{%
+\usefont{U}{cmtt}{m}{n}%
+\usefont{U}{cmr}{m}{n}%
+\usefont{U}{cmss}{m}{n}%
+\usefont{U}{lasy}{m}{n}%
+}
+% this should be empty
+\showbox0
+\END

--- a/base/testfiles/github-1037.tlg
+++ b/base/testfiles/github-1037.tlg
@@ -1,0 +1,9 @@
+This is a generated file for the LaTeX2e validation system.
+Don't change this file in any respect.
+LaTeX Font Info:    Trying to load font information for U+cmtt on input line ....
+LaTeX Font Info:    Trying to load font information for U+cmss on input line ....
+LaTeX Font Info:    Trying to load font information for U+lasy on input line ....
+> \box...=
+\hbox(0.0+0.0)x0.0
+! OK.
+l. ...\showbox0


### PR DESCRIPTION


# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [X] Test file(s) added
- [X] Version and date string updated in changed source files
- [X] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
