### PR TITLE
Gh1052 [lthooks] Initialise hook structure when adding 'next' code

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,11 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 ================================================================================
 
+2023-04-19  Phelype Oleinik  <phelype.oleinik@latex-project.org>
+
+	* lthooks.dtx (subsection{Specifying code for next invocation}):
+	Initialise hook structure when adding 'next' code (gh/1052)
+
 2023-04-16  Phelype Oleinik  <phelype.oleinik@latex-project.org>
 
 	* lthooks.dtx (subsubsection{Setting hooks up}):

--- a/base/doc/ltnews37.tex
+++ b/base/doc/ltnews37.tex
@@ -579,6 +579,15 @@ translated to ``\verb|the character ^^M|''.
 %
 \githubissue{876}
 
+\subsection{Correct handling of hooks with only `next' code}
+When \cs{AddToHookNext} was used on a not-yet-declared hook, that hook
+would be incorrectly identified as empty by \cs{ShowHook}.  Also, if
+that hook was later declared, that `next' code would not be executed.
+This has been fixed by correctly initializing the hook structure when
+\cs{AddToHookNext} is used.
+%
+\githubissue{1052}
+
 \section{Documentation improvements}
 
 When \LaTeXe{} was released, the team provided documentation for both document

--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -6316,6 +6316,7 @@
 %<latexrelease>                 {Hooks~with~args}
 \cs_new_protected:Npn \@@_gput_next_do:nn #1
   {
+    \@@_init_structure:n {#1}
     \@@_chk_args_allowed:nn {#1} { AddToHookNext }
     \@@_cs_if_empty:cT { @@~#1 }
       { \@@_update_hook_code:n {#1} }

--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -6784,19 +6784,17 @@
 %<latexrelease>                 {Hooks~with~args}
 \prg_new_conditional:Npnn \hook_if_empty:n #1 { p , T , F , TF }
   {
-    \@@_if_structure_exist:nTF {#1}
-      {
-        \bool_lazy_and:nnTF
-            { \prop_if_empty_p:c { g_@@_#1_code_prop } }
-            {
-              \bool_lazy_and_p:nn
-                { \@@_cs_if_empty_p:c { @@_toplevel~#1 } }
-                { \@@_cs_if_empty_p:c { @@_next~#1 } }
-            }
-          { \prg_return_true: }
-          { \prg_return_false: }
-      }
-      { \prg_return_true: }
+    \if:w
+        T
+        \prop_if_exist:cT { g_@@_#1_code_prop }
+          { \prop_if_empty:cF { g_@@_#1_code_prop } { F } }
+        \@@_cs_if_empty:cF { @@_toplevel~#1 } { F }
+        \@@_cs_if_empty:cF { @@_next~#1 } { F }
+        T
+      \prg_return_true:
+    \else:
+      \prg_return_false:
+    \fi:
   }
 %<latexrelease>\EndIncludeInRelease
 %    \end{macrocode}

--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -31,8 +31,8 @@
 %%% From File: lthooks.dtx
 %
 %    \begin{macrocode}
-\def\lthooksversion{v1.1b}
-\def\lthooksdate{2023/04/16}
+\def\lthooksversion{v1.1c}
+\def\lthooksdate{2023/04/19}
 %    \end{macrocode}
 %
 %<*driver>
@@ -6311,6 +6311,8 @@
 %   execution token list.
 % \changes{v1.1a}{2023/04/06}
 %         {Changes to add hook arguments (hook-args).}
+% \changes{v1.1c}{2023/04/19}
+%         {Initialise hook structure when adding 'next' code (gh/1052).}
 %    \begin{macrocode}
 %<latexrelease>\IncludeInRelease{2023/06/01}{\@@_gput_next_do:nn}
 %<latexrelease>                 {Hooks~with~args}
@@ -6779,6 +6781,8 @@
 %   \cs{@@_next\textvisiblespace\meta{hook}} are empty.
 % \changes{v1.1a}{2023/04/06}
 %         {Changes to add hook arguments (hook-args).}
+% \changes{v1.1c}{2023/04/19}
+%         {Simpler and faster version (gh/1052).}
 %    \begin{macrocode}
 %<latexrelease>\IncludeInRelease{2023/06/01}{\hook_if_empty:n}
 %<latexrelease>                 {Hooks~with~args}

--- a/base/testfiles-lthooks/github-1052.lvt
+++ b/base/testfiles-lthooks/github-1052.lvt
@@ -1,0 +1,39 @@
+\input{regression-test}
+
+\documentclass{minimal}
+
+\begin{document}
+
+\START
+
+\ExplSyntaxOn
+\hook_gput_code:nnn { env/foo/before } { label } { \typeout{env/foo/before} }
+\hook_show:n { env/foo/before }
+\hook_use:n { env/foo/before }
+
+\hook_gput_code:nnn { envfoobefore } { label } { \typeout{envfoobefore} }
+\hook_show:n { envfoobefore }
+\hook_new:n { envfoobefore }
+\hook_use:n { envfoobefore }
+
+\hook_gput_next_code:nn { env/foo/after } { \typeout{env/foo/after} }
+\hook_show:n { env/foo/after }
+\hook_use:n { env/foo/after }
+
+\hook_gput_next_code:nn { envfooafter } { \typeout{envfooafter} }
+\hook_show:n { envfooafter }
+\hook_new:n { envfooafter }
+\hook_use:n { envfooafter }
+
+\hook_gput_code:nnn { env/foo/begin } { top-level } { \typeout{env/foo/begin} }
+\hook_show:n { env/foo/begin }
+\hook_use:n { env/foo/begin }
+
+\hook_gput_code:nnn { envfoobegin } { top-level } { \typeout{envfoobegin} }
+\hook_show:n { envfoobegin }
+\hook_new:n { envfoobegin }
+\hook_use:n { envfoobegin }
+
+\ExplSyntaxOff
+
+\END

--- a/base/testfiles-lthooks/github-1052.tlg
+++ b/base/testfiles-lthooks/github-1052.tlg
@@ -46,6 +46,7 @@ env/foo/after
 -> The hook 'envfooafter':
 > The hook is not declared.
 > Code chunks:
+>     ---
 > Document-level (top-level) code:
 >     ---
 > Extra code for next invocation:
@@ -56,6 +57,7 @@ env/foo/after
 >     Not set because the hook is undeclared.
 <recently read> }
 l. ...\hook_show:n { envfooafter }
+envfooafter
 -> The generic hook 'env/foo/begin':
 > Code chunks:
 >     ---

--- a/base/testfiles-lthooks/github-1052.tlg
+++ b/base/testfiles-lthooks/github-1052.tlg
@@ -1,0 +1,87 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+-> The generic hook 'env/foo/before':
+> Code chunks:
+>     label -> \typeout {env/foo/before}
+> Document-level (top-level) code (executed last):
+>     ---
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     label.
+<recently read> }
+l. ...\hook_show:n { env/foo/before }
+env/foo/before
+-> The hook 'envfoobefore':
+> The hook is not declared.
+> Code chunks:
+>     label -> \typeout {envfoobefore}
+> Document-level (top-level) code:
+>     ---
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...\hook_show:n { envfoobefore }
+envfoobefore
+-> The generic hook 'env/foo/after':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed first):
+>     ---
+> Extra code for next invocation:
+>     -> \typeout {env/foo/after}
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     ---.
+<recently read> }
+l. ...\hook_show:n { env/foo/after }
+env/foo/after
+-> The hook 'envfooafter':
+> The hook is not declared.
+> Code chunks:
+> Document-level (top-level) code:
+>     ---
+> Extra code for next invocation:
+>     -> \typeout {envfooafter}
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...\hook_show:n { envfooafter }
+-> The generic hook 'env/foo/begin':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \typeout {env/foo/begin}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...\hook_show:n { env/foo/begin }
+env/foo/begin
+-> The hook 'envfoobegin':
+> The hook is not declared.
+> Code chunks:
+>     ---
+> Document-level (top-level) code:
+>     -> \typeout {envfoobegin}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...\hook_show:n { envfoobegin }
+envfoobegin


### PR DESCRIPTION
# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [x] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [x] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
