### PR TITLE
Use 'mac' instead of 'function'

### DIFF
--- a/base/doc/usrguide.tex
+++ b/base/doc/usrguide.tex
@@ -844,23 +844,23 @@ The argument specifications for document commands and environments are
 available for examination and use.
 
 \begin{decl}
-  |\GetDocumentCommandArgSpec| \arg{function}         \\
+  |\GetDocumentCommandArgSpec| \arg{cmd}         \\
   |\GetDocumentEnvironmentArgSpec| \arg{environment}
 \end{decl}
 These functions transfer the current argument specification for the
-requested \meta{function} or \meta{environment} into the token list
-variable \cs{ArgumentSpecification}. If the \meta{function} or
+requested \meta{cmd} or \meta{environment} into the token list
+variable \cs{ArgumentSpecification}. If the \meta{cmd} or
 \meta{environment} has no known argument specification then an error
 is issued. The assignment to \cs{ArgumentSpecification} is local to
 the current \TeX{} group.
 
 \begin{decl}
-  |\ShowDocumentCommandArgSpec| \arg{function}         \\
+  |\ShowDocumentCommandArgSpec| \arg{cmd}         \\
   |\ShowDocumentEnvironmentArgSpec| \arg{environment}
 \end{decl}
 These functions show the current argument specification for the
-requested \meta{function} or \meta{environment} at the terminal. If
-the \meta{function} or \meta{environment} has no known argument
+requested \meta{cmd} or \meta{environment} at the terminal. If
+the \meta{cmd} or \meta{environment} has no known argument
 specification then an error is issued.
 
 


### PR DESCRIPTION
* base/doc/usrguide.tex (subsection{Access to the argument specification}): Talk about 'mac' instead of 'function' like in the rest of the document.
