### PR TITLE
remove firstaid for gh 591, unneeded and breaks fix for gh 989

### DIFF
--- a/required/firstaid/changes.txt
+++ b/required/firstaid/changes.txt
@@ -1,3 +1,9 @@
+2023-05-20  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
+
+	* latex2e-first-aid-for-external-files.dtx: removed temporary fix for 
+      GitHub issue 591, unneeded now and it breaks for luatex the fix for gh 989
+      (minipage/list spacing) 
+
 2022-12-06  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
 
 	* latex2e-first-aid-for-external-files.dtx (subsection{the crop package first aid}):

--- a/required/firstaid/latex2e-first-aid-for-external-files.dtx
+++ b/required/firstaid/latex2e-first-aid-for-external-files.dtx
@@ -675,63 +675,6 @@
 %    \end{macrocode}
 %
 %
-% \subsection[Temporary fixes for the kernel (until the next
-%             patch-level release)]
-%    {Temporary fixes for the kernel \\
-%     (until the next patch-level release)}
-%
-% This fixes GitHub issue 591. It is only needed in Lua\TeX\ and replaces just one
-% instance of \cs{tex\_par:D} with the following version which removes
-% other nodes in the current list first.
-%    \begin{macrocode}
-\ExplSyntaxOn
-\sys_if_engine_luatex:T
-  {
-    \newluafunction \g__para_end_empty_par_id_int
-    \exp_args:Nx \everyjob {
-      \exp_not:V \everyjob
-      \exp_not:N \lua_now:n {
-        local~texnest, flush_list, par_token = tex.nest, node.flush_list, token.create'tex_par:D'~
-        lua.get_functions_table()[\int_use:N \g__para_end_empty_par_id_int] = function()
-          local~nest_level = texnest.top~
-          local~cur_head = nest_level.head~
-          flush_list(cur_head.next)
-          nest_level.tail, cur_head.next = cur_head, nil~
-          token.put_next(par_token)
-        end
-      }
-    }
-    \protected \luadef \__para_end_empty_par: \g__para_end_empty_par_id_int
-    \group_begin:
-    \cs_set:Npn \__para_extract_everypar:w #1 \the \toks #2 \s_stop
-      {
-        \tl_gset:Nn \g__para_standard_everypar_tl {
-          \box_gset_to_last:N \g_para_indent_box
-          \group_begin:
-            \__para_end_empty_par:
-          \group_end:
-          \tex_everypar:D { \msg_error:nnnn { hooks }{ para-mode }{before}{vertical} }
-          \@kernel@before@para@before
-          \hook_use:n {para/before}
-          \group_begin:
-            \tex_everypar:D {}
-            \skip_zero:N \tex_parskip:D
-            \tex_noindent:D
-          \group_end:
-          \tex_everypar:D{\g__para_standard_everypar_tl}
-          \@kernel@before@para@begin
-          \hook_use:n {para/begin}
-          \if_mode_horizontal: \else:
-            \msg_error:nnnn { hooks }{ para-mode }{begin}{vertical} \fi:
-          \__para_handle_indent:
-          \the \toks #2
-        }
-      }
-    \exp_last_unbraced:No \__para_extract_everypar:w \g__para_standard_everypar_tl \s_stop
-    \group_end:
-  }
-\ExplSyntaxOff
-%    \end{macrocode}
 %
 %
 %    \begin{macrocode}

--- a/required/firstaid/latex2e-first-aid-for-external-files.dtx
+++ b/required/firstaid/latex2e-first-aid-for-external-files.dtx
@@ -1,6 +1,6 @@
 % \iffalse meta-comment
 %
-%% File: latex2e-first-aid-for-external-files.dtx (C) Copyright 2020-2022
+%% File: latex2e-first-aid-for-external-files.dtx (C) Copyright 2020-2023
 %%
 %% The LaTeX Project and any individual authors listed elsewhere
 %% in this file.
@@ -111,8 +111,8 @@
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\def\LaTeXFirstAidDate{2022/12/06}
-\def\LaTeXFirstAidVersion{v1.0x}
+\def\LaTeXFirstAidDate{2023/05/20}
+\def\LaTeXFirstAidVersion{v1.0z}
 %    \end{macrocode}
 %
 %    \begin{macrocode}


### PR DESCRIPTION
This removes a first aid which has been added as temporary in 2021. If is should stay anyway it must be updated as it overwrites a fix for gh 989.

 
# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

 Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ X ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ X] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated (only internal)
