### PR TITLE
\calulateheight -> \calculateheight in usrguide

### DIFF
--- a/base/doc/usrguide.tex
+++ b/base/doc/usrguide.tex
@@ -1187,11 +1187,11 @@ therefore shows the same syntax peculiars as discussed
 above. Nevertheless, in practice they are usually sufficient.  For
 example
 \begin{verbatim}
-\newcommand\calulateheight[1]{%
+\newcommand\calculateheight[1]{%
   \setlength\textheight{\dimeval{\topskip+\baselineskip*\inteval{#1-1}}}}
 \end{verbatim}
 sets the \cs{textheight} to the appropriate value if a page should
-hold a specific number of text lines. Thus after |\calulateheight{40}|
+hold a specific number of text lines. Thus after |\calculateheight{40}|
 it is set to \dimeval{\topskip+\baselineskip*\inteval{40-1}}, given
 the values \cs{topskip} (\dimeval{\topskip}) and \cs{baselineskip}
 (\dimeval{\baselineskip}) in the current document.


### PR DESCRIPTION
I assume the intended command name was `\calculateheight`, not `\calulateheight`.

I don't think any of the following needs addressing since it's just a typo fix, but please correct me if I'm wrong.

---

**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
- Under development
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
