### PR TITLE
fix fntguide typos

### DIFF
--- a/base/doc/fntguide.tex
+++ b/base/doc/fntguide.tex
@@ -323,7 +323,7 @@ A less common value for font shape is:
   \end{minipage}
 \end{center}
 and there is also |ui| for upright italic, i.e., an italic shape but
-artifically turned upright. This is sometimes useful and available in
+artificially turned upright. This is sometimes useful and available in
 some fonts.
 
 
@@ -1377,7 +1377,7 @@ the `cmr' family).
 from this subsection.
 
 \NEWdescription{2019/07/10}
-As an exception it may also contain a |\DeclareFontsubstitution|
+As an exception it may also contain a |\DeclareFontSubstitution|
 declaration (described in \ref{sec:encoding-defaults}) to specify how
 font substitution for this encoding should be handled.  In that case it
 is important that the values used point to a font that is guaranteed to


### PR DESCRIPTION
Small typo fixes in fntguide.tex :

- artifically -> artificially
- |\DeclareFontsubstitution| -> |\DeclareFontSubstitution|