### PR TITLE
Generate simpler variant for \cs_generate_from_arg_count:NNnn

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,12 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 ================================================================================
 
+2023-05-26  Yukai Chou <muzimuzhi@gmail.com>
+
+    * ltcmd.dtx (subsection{Structure of \pkg{xparse} commands}):
+    Use simpler 'NNno' variant instead of 'NNVo' for
+    \cs_generate_from_arg_count:NNnn
+
 2023-05-22  Joseph Wright  <Joseph.Wright@latex-project.org>
 
 	* usrguide.tex

--- a/base/ltcmd.dtx
+++ b/base/ltcmd.dtx
@@ -34,8 +34,8 @@
 %%% From File: ltcmd.dtx
 %
 %    \begin{macrocode}
-\def\ltcmdversion{v1.1d}
-\def\ltcmddate{2023-05-25}
+\def\ltcmdversion{v1.1e}
+\def\ltcmddate{2023-05-26}
 %    \end{macrocode}
 %
 %<*driver>
@@ -725,6 +725,9 @@
       { \@@_environment_or_command: }
   }
 %    \end{macrocode}
+%
+% \changes{v1.1e}{2023/05/26}
+%         {Use simpler variant \cs{cs_generate_from_arg_count:NNno}}
 %   To construct \cs{@@_tmp:w}, first go through the arguments
 %   found and the corresponding defaults, building a token list with
 %   |{#|\meta{arg number}|}| for arguments found in the input (whose

--- a/base/ltcmd.dtx
+++ b/base/ltcmd.dtx
@@ -738,10 +738,10 @@
     \int_zero:N \l_@@_current_arg_int
     \@@_tl_mapthread_function:NNN \l_@@_args_tl \l_@@_defaults_tl
       \@@_defaults_def:nn
-    \cs_generate_from_arg_count:NNVo \@@_tmp:w \cs_set:Npn
+    \cs_generate_from_arg_count:NNno \@@_tmp:w \cs_set:Npn
       \l_@@_current_arg_int \l_@@_tmpa_tl
   }
-\cs_generate_variant:Nn \cs_generate_from_arg_count:NNnn { NNVo }
+\cs_generate_variant:Nn \cs_generate_from_arg_count:NNnn { NNno }
 \cs_new_protected:Npn \@@_defaults_def:nn
   {
     \int_incr:N \l_@@_current_arg_int

--- a/base/ltcmd.dtx
+++ b/base/ltcmd.dtx
@@ -35,7 +35,7 @@
 %
 %    \begin{macrocode}
 \def\ltcmdversion{v1.1d}
-\def\ltcmddate{2023-04-13}
+\def\ltcmddate{2023-05-25}
 %    \end{macrocode}
 %
 %<*driver>


### PR DESCRIPTION
It's first n-arg already accepts an `<int expr>`.

Only date string is updated, not sure if it's enough.

**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
