### PR TITLE
Gh1078 [ltcmdhooks] Avoid token-by-token processing when possible

### DIFF
--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -4424,6 +4424,7 @@
 % \end{macro}
 %
 % \begin{macro}{\@@_cs_gput_right:nnn}
+% \begin{macro}{\@@_cs_gput_right_fast:nnn,\@@_cs_gput_right_slow:nnn}
 % \begin{macro}{\@@_code_gset_auxi:nnnn,\@@_code_gset_auxi:eeen}
 %   This macro is used to append code to the \verb|toplevel| and
 %   \verb|next| token lists, trating them correctly depending on their
@@ -4435,7 +4436,27 @@
 %    \begin{macrocode}
 %<latexrelease>\IncludeInRelease{2023/06/01}{\@@_cs_gput_right:nnn}
 %<latexrelease>                 {Hooks~with~args}
-\cs_new_protected:Npn \@@_cs_gput_right:nnn #1 #2 #3
+%    \end{macrocode}
+%
+%   Check if the current hook is declared and takes no arguments.  In
+%   this case, we short-circuit and use the simpler and much faster
+%   approach that doesn't require hash-doubling.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_cs_gput_right:nnn #1 #2
+  {
+    \if:w T
+        \@@_if_declared:nF {#2} { F }
+        \tl_if_empty:cF { c_@@_#2_parameter_tl } { F }
+          T
+      \exp_after:wN \@@_cs_gput_right_fast:nnn
+    \else:
+      \exp_after:wN \@@_cs_gput_right_slow:nnn
+    \fi:
+        {#1} {#2}
+  }
+\cs_new_protected:Npn \@@_cs_gput_right_fast:nnn #1 #2 #3
+  { \cs_gset:cpx { @@#1~#2 } { \exp_not:v { @@#1~#2 } \exp_not:n {#3} } }
+\cs_new_protected:Npn \@@_cs_gput_right_slow:nnn #1 #2 #3
   {
 %    \end{macrocode}
 %   The auxiliary \cs{@@_code_gset_auxi:eeen} just does the assignment
@@ -4498,9 +4519,12 @@
 %<latexrelease>\IncludeInRelease{2020/10/01}{\@@_cs_gput_right:nnn}
 %<latexrelease>                 {Hooks~with~args}
 %<latexrelease>\cs_undefine:N \@@_cs_gput_right:nnn
+%<latexrelease>\cs_undefine:N \@@_cs_gput_right_fast:nnn
+%<latexrelease>\cs_undefine:N \@@_cs_gput_right_slow:nnn
 %<latexrelease>\cs_undefine:N \@@_code_gset_auxi:nnnn
 %<latexrelease>\EndIncludeInRelease
 %    \end{macrocode}
+% \end{macro}
 % \end{macro}
 % \end{macro}
 %

--- a/base/testfiles-lthooks/github-1078.lvt
+++ b/base/testfiles-lthooks/github-1078.lvt
@@ -1,0 +1,50 @@
+
+\input{regression-test}
+
+\START
+
+\ExplSyntaxOn
+\tex_resettimer:D
+\int_step_inline:nn{15}
+  {
+    \AddToHook{begindocument}
+      {
+        \def\blub
+          {
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+          }
+      }
+  }
+% On my machine, with LaTeX 2022-11-01, this prints around 320
+% \typeout { Elapsed~time = \the \tex_elapsedtime:D }
+% With LaTeX 2023-06-01, it goes past 360000
+% So 10000 seems like a good theshold to make the test pass or fail,
+% regardless of which machine it's running on.  This can be tweaked
+% though:
+\int_compare:nNnTF { \tex_elapsedtime:D } > { 10000 }
+  { \iow_term:n { ERROR!~Too~slow. } }
+  { \iow_term:n { Looks~okay. } }
+
+\OMIT
+\makeatletter
+\typeout { Elapsed~time = \strip@pt \dimexpr \tex_elapsedtime:D sp ~ s }
+\TIMO
+
+\ExplSyntaxOff
+
+\END

--- a/base/testfiles-lthooks/github-1078.tlg
+++ b/base/testfiles-lthooks/github-1078.tlg
@@ -1,0 +1,3 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+Looks okay.


### PR DESCRIPTION
When a hook is declared and takes no argument, the roundtrip of doubling hashes is unnecessary, so skip it.

Partially fixes #1078

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [x] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [N/A] `ltnewsX.tex` (and/or `latexchanges.tex`) updated&mdash;unneeded
