### PR TITLE
Fix mistakes

### DIFF
--- a/required/tools/afterpage.dtx
+++ b/required/tools/afterpage.dtx
@@ -25,7 +25,7 @@
 %
 %<package>\NeedsTeXFormat{LaTeX2e}
 %<package>\ProvidesPackage{afterpage}
-%<package>         [2014/10/28 v1.08 After-Page Package (DPC)]
+%<package>         [2023/07/04 v1.08 After-Page Package (DPC)]
 %
 %<*driver>
 \documentclass{ltxdoc}
@@ -199,7 +199,7 @@
          \global\setbox\@ne\lastbox}%
 %    \end{macrocode}
 % If the text that is saved in |\AP@partial| had footnotes, we'd
-% better grab them as well otherwise they may come out on a page
+% better grab them as well, otherwise they may come out on a page
 % with the `afterpage' text, before the page that has the
 % footnote mark! (Added at v1.08.)
 %    \begin{macrocode}
@@ -218,7 +218,7 @@
 %    \end{macrocode}
 %
 % Restore the |\everydisplay| register. |\ignorespaces| prevents a space
-% or newline after |$$| creating rogue a indentation or paragraph.
+% or newline after |$$| creating a rogue indentation or paragraph.
 %    \begin{macrocode}
 \def\AP@ed{\everydisplay\expandafter{\the\toks@}\ignorespaces}
 %    \end{macrocode}
@@ -264,7 +264,7 @@
 % `afterpage' commands, so just add the new commands to the end of the
 % list. Otherwise save the commands in |\AP@|. (within a local group),
 % and switch the output routine. (The new output routine just calls the
-% old one if it is invoked by a \LaTeX{} float.
+% old one if it is invoked by a \LaTeX{} float.)
 %    \begin{macrocode}
 \long\def\afterpage#1{%
   \ifx\AP@\relax
@@ -291,7 +291,7 @@
     \global\output\expandafter{\the\AP@output}%
     \AP@clearpage
 %    \end{macrocode}
-% At this point (since v1.08) Need to clear |\AP@| \emph{before}
+% At this point (since v1.08) need to clear |\AP@| \emph{before}
 % using its expansion, as otherwise hit an infinite loop. Sigh.
 %    \begin{macrocode}
     \global\expandafter\let\expandafter\AP@\expandafter\relax
@@ -350,7 +350,7 @@
 %    \end{macrocode}
 % Subtract the new height of |#1| from |\skip@|, and add back on
 % |\splittopskip|, so |\skip@| is now the height of the first row of
-% |#1| This may still be 0pt if (eg) a mark or whatsit is between the
+% |#1|. This may still be 0pt if (eg) a mark or whatsit is between the
 % top glue and the first box. Save (this height${}-{}$|\splittopskip|)
 % in |\skip\tw@|.
 %    \begin{macrocode}

--- a/required/tools/bm.dtx
+++ b/required/tools/bm.dtx
@@ -36,7 +36,7 @@
 %<driver>\ProvidesFile{bm.drv}
 % \fi
 %         \ProvidesFile{bm.dtx}
-          [2022/01/05 v1.2f Bold Symbol Support (DPC/FMi)]
+          [2023/07/08 v1.2f Bold Symbol Support (DPC/FMi)]
 %
 % \iffalse
 %<*driver>
@@ -97,7 +97,7 @@
 %
 % If there is a `heavy' math version defined (usually accessed by a
 % user-command |\heavymath|) then a similar command |\hm|
-% is defined which access these `ultra bold' fonts. Currently this is
+% is defined which accesses these `ultra bold' fonts. Currently this is
 % probably only useful with the `mathtime plus' font collection.
 % Definitions of commands that use these fonts may be made by
 % specifying the optional argument `heavy' to |\DeclareBoldMathCommand|.
@@ -140,7 +140,7 @@
 % your font set.
 %
 % \section{Features}
-% In most cases this package should work in a fairly self explanatory
+% In most cases this package should work in a fairly self-explanatory
 % way, but there are some things that might not be obvious.
 %
 % \subsection{Interaction with Math Alphabet Commands}
@@ -209,7 +209,7 @@
 % Normally if a command takes arguments the full command, including
 % any arguments, should be included in |\bm|.
 %
-% So |\bm{\overbrace{abc}}| (producing \smash{$\bm{\overbrace{abc}}$})
+% So |\bm{\overbrace{abc}}| (producing \smash{$\bm{\overbrace{abc}}$}),
 % not
 % |\bm{\overbrace}{abc}|. If you do not include all the arguments you
 % will typically get the error message:\\
@@ -245,7 +245,7 @@
 % allocations.
 %
 % If no bold font appears to be available for a particular symbol,
-% |\bm| will use `poor man's bold' that is, overprinting the same
+% |\bm| will use `poor man's bold', which will overprint the same
 % character in slightly offset
 % positions to give an appearance of boldness.
 %
@@ -255,8 +255,8 @@
 % font set there are suitable fonts for bold and heavy math setting,
 % and so |\bm| and |\hm| work well. Similarly in the basic Lucida
 % New Math font set there are no bold math fonts, so |\bm| will
-% use `poor man's bold. However if the Lucida Expert set is used,
-% Then |\bm| will detect, and use the bold math fonts that are
+% use `poor man's bold'. However, if the Lucida Expert set is used,
+% then |\bm| will detect, and use, the bold math fonts that are
 % available.
 %
 % As discussed above, one may set |\bmmax| higher or lower than its
@@ -310,7 +310,7 @@
 % ``poor man's bold''. That is, over-printing the character with slight offsets.
 % Since version 1.2e, the package now warns if a font is set up to use this over-printing and
 % the package option |nopbm|  is available which prevents its use in which case |\bm| will
-% use the non-bold for characters from the affected font,
+% use the non-bold for characters from the affected font.
 %
 % \MaybeStop{}
 %
@@ -339,7 +339,7 @@
 %
 % \changes{v1.2e}{2021/04/25}
 %      {Package options gh/71}
-% Options to use or not use poor mans bold (over-printing)
+% Options to use or not use poor man's bold (over-printing)
 % and level of warning messages.
 %    \begin{macrocode}
 %<*package>
@@ -399,7 +399,7 @@
 % code, which is temporarily defined to |\bm|, to save wasting a csname.
 % Similarly |\bm@pmb|\ldots\ (which will be defined later) are used
 % as scratch macros.
-% (This csname saving no longer used, setup command is |\bm@setup| not |\bm|).
+% (This csname saving no longer used, setup command is |\bm@setup|, not |\bm|.)
 %
 % The general plan. Run through the fonts allocated to the normal math
 % version. Ignore \meta{math alphabet} allocations\footnote{For now?}
@@ -505,11 +505,11 @@
                \ifx\bm@pmb@\@firstofone\else, using \string\pmb\fi}%
     \else
 %    \end{macrocode}
-% Else make a new name by adjoining |#1| to the name of the symbol font
+% Else make a new name by adjoining |#1| to the name of the symbol font,
 % eg, |\symboldsymbols| to match |\symsymbols|. If that font has already
 % been allocated, or if |\@tempcnta| is positive so we can allocate a
 % new slot for this font, then the table will be
-% set with the offset between the two fonts. otherwise set the offset to
+% set with the offset between the two fonts. Otherwise set the offset to
 % zero (so |\boldmath| will be used to access the font).
 %    \begin{macrocode}
       \edef\@tempa{sym#1\expandafter\@gobblefour\string##1}%
@@ -673,8 +673,8 @@
 \fi
 %    \end{macrocode}
 %
-% If there is no bold math version, It is very easy to set up
-% the table, no need to use all the tricky code above.
+% If there is no bold math version, it is very easy to set up
+% the table since there is no need to use all the tricky code above.
 % Also, at the end of the package redefine the internal macro
 % that |\bm| uses to call |\boldmath|, to use poor man's bold
 % instead.
@@ -711,7 +711,7 @@
 %
 % \begin{macro}{\hmmax}
 %
-% Same for heavy (but default to three this time (enough for mathtime
+% Same for heavy, but default to three this time (enough for mathtime
 % plus, as no heavy operators font).
 %    \begin{macrocode}
 \ifx\hmmax\@undefined
@@ -777,7 +777,7 @@
     \let\protect\@empty
     \let\@typeset@protect\@empty
 %    \end{macrocode}
-% Set up either bold or heavy
+% Set up either bold or heavy.
 %    \begin{macrocode}
     \def\bm@mathchoice{\bm@m@thchoice#1}%
     \def\bm@group{\bm@gr@up#1}%
@@ -848,9 +848,9 @@
     \let\next@\copy
     \global\let\bm@first\@empty
 %    \end{macrocode}
-%   For AMS version of |\sqrt|: don't expand just wrap in brace group
-%   so that it can be made bold in a safe but slow way. Do the same for
-%   internal accent command
+%   For AMS version of |\sqrt|: don't expand, just wrap it in a brace
+%   group so that it can be made bold in a safe but slow way. Do the same
+%   for internal accent command.
 % \changes{v1.1b}{2003/10/05}{AMS \cs{sqrt} not working}
 %
 % \changes{v1.1c}{2004/02/26}{\cs{accentV} made safe (pr/3625)}
@@ -886,7 +886,7 @@
 %    |\mv@bold| or |\mv@heavy| and we execute that after redefining
 %    |\install@mathalphabet| and |\getanddefine@fonts| suitably.
 %    The definitions are reverted back to their original the moment
-%    the scanning is done
+%    the scanning is done.
 % \changes{v1.0h}{2002/11/22}{Get math alphabets right (pr/3476)}
 %    \begin{macrocode}
      \let\install@mathalphabet\def
@@ -972,7 +972,7 @@
 % |\bm| is empty within the definition, so that either\\
 % |\bmdefine\balpha{\bm\alpha}| or  |\bmdefine\balpha{\alpha}| \\
 % may be used. (The former just for compatibility with the original
-% version for plain \TeX).
+% version for plain \TeX.)
 %    \begin{macrocode}
 \def\bmdefine{\DeclareBoldMathCommand[bold]}
 %    \end{macrocode}
@@ -1092,8 +1092,8 @@
 % \begin{macro}{\bm@gr@up}
 % \changes{v1.0c}{1997/10/09}
 %      {Extra brace around argument for \cs{over}}
-% If faced with a group,
-% If we are in math mode, stick it in a |\boldsymbol| like construct
+% If faced with a group
+% when we are in math mode, put it in a |\boldsymbol|-like construct
 % and then recurse on |\bm@expand|.
 % Otherwise just use |\bfseries\boldmath|.
 % The actual test is deferred till `run time'.
@@ -1131,7 +1131,7 @@
 % Other things just copy straight over to the command being built.
 % (Anything inside a |\mathop| or similar will end up being made bold
 % as the |\mathop| will be copied over, but its argument will be made
-% bold by the group code above.
+% bold by the group code above.)
 %    \begin{macrocode}
 \def\bm@test@token#1{%
   \let\bm@next\@empty
@@ -1139,7 +1139,7 @@
 %
 % Stop here. Note that it is vital that the terminating token
 % is non-expandable and defined, rather than the usual \LaTeX\
-% terminators |\@nil| or |\@@|. (Worse still would be a `quark'
+% terminators |\@nil| and |\@@|. (Worse still would be a `quark'
 % like |docstrip|'s |\qStop|.)
 %    \begin{macrocode}
   \ifx#1\@@end
@@ -1166,7 +1166,7 @@
     \afterassignment\bm@radical\count@
 %    \end{macrocode}
 %
-% Need to trap spaces otherwise digits will get turned to bold
+% Need to trap spaces, otherwise digits will get turned to bold
 % mathchars.
 % \changes{v1.1a}{2003/09/01}{Forgotten to check for \cs{hskip} (pr/3572)}
 %    \begin{macrocode}
@@ -1451,7 +1451,7 @@
 % \begin{macro}{\bm@pmb@}
 % \changes{v0.10}{1997/01/04}
 %      {Macro added}
-% |\pmb| variant. (See \TeX{}Book, or AMS \textsf{amsbsy} package).
+% |\pmb| variant. (See \TeX{}book, or AMS \textsf{amsbsy} package.)
 % This one takes a bit more care to use smaller offsets in subscripts.
 %    \begin{macrocode}
 \ifx\bm@pmb@\@firstofone\else
@@ -1544,7 +1544,7 @@
 \def\bm@mathaccent{%
  \bm@changefam{}%
 %    \end{macrocode}
-% The next four lines were added a v1.0e. Without them |\bm{\hat{A}}|
+% The next four lines were added in v1.0e. Without them |\bm{\hat{A}}|
 % makes the accent bold using |\bm| but the group |{A}| is made bold
 % via a |\mathchoice| construction as for any other group, as |\bm|
 % does not attempt to parse inside brace groups. While that produces
@@ -1674,9 +1674,10 @@
 % \begin{macro}{\bm@changefam}
 % \changes{v0.10}{1997/01/04}
 %      {Rewrite for new \cs{bm@table} system}
-% Pull out one specified hex digit and passes
-% it to |\bm@modify| to change. argument is empty normally but |000| to
-% access the second math group in a delimiter code.
+% Pull out one specified hex digit and pass
+% it to |\bm@modify| to change. Its one argument is normally empty,
+% but it will be |000| when necessary to access the second math group
+% in a delimiter code.
 %    \begin{macrocode}
 \def\bm@changefam#1{%
   \@tempcnta\count@

--- a/required/tools/calc.dtx
+++ b/required/tools/calc.dtx
@@ -40,7 +40,7 @@
 %<driver> \ProvidesFile{calc.drv}
 % \fi
 %         \ProvidesFile{calc.dtx}
-          [2017/05/25 v4.3 Infix arithmetic (KKT,FJ)]
+          [2023/07/08 v4.3 Infix arithmetic (KKT,FJ)]
 %
 % \iffalse
 %<*driver>
@@ -102,7 +102,7 @@
 % Arithmetic in \TeX\ is done using low-level operations such as
 % |\advance| and |\multiply|.  This may be acceptable when developing
 % a macro package, but it is not an acceptable interface for the
-% end-user.
+% end user.
 %
 % This package introduces proper infix notation arithmetic which is
 % much more familiar to most people.  The infix notation is more
@@ -271,7 +271,7 @@
 % or at the end of the expression being evaluated.
 %
 % When \TeX\ performs arithmetic on integers, any fractional part of
-% the results are discarded.  For example,
+% the result is discarded.  For example,
 %\begin{verbatim}
 %    \setcounter{x}{7/2}
 %    \setcounter{y}{3*\real{1.6}}
@@ -318,7 +318,7 @@
 %  \setlength{\parindent}{%
 %    \minof{3pt}{\parskip}*\real{1.5}*\maxof{2*\real{1.6}}{2-1}}
 %\end{verbatim}
-% will assign $\min(13.5\textrm{pt},4.5\cs{parskip})$ to \cs{parindent}
+% will assign $\min(13.5\textrm{pt},4.5\cs{parskip})$ to \cs{parindent}.
 %
 %
 %
@@ -453,7 +453,7 @@
 % or a parenthesized expression~$(E')$.
 %
 % Since the \TeX\ engine can only execute arithmetic operations in a
-% machine-code like manner, we have to find a way to translate the
+% machine-code-like manner, we have to find a way to translate the
 % infix notation into this `instruction set'.
 %
 % Our goal is to design a translation scheme that translates~$X$ (an
@@ -565,9 +565,9 @@
 % When an \<integer factor> is expected, we must change $A$ and~$B$ to
 % refer to integer type registers.  We can accomplish this by
 % including instructions to change the type of $A$ and~$B$ to integer
-% type as part of the replacement code for~`$*$; if we append such
+% type as part of the replacement code for~`$*$'; if we append such
 % instructions to the replacement code described above, we also ensure
-% that the type-change is local (provided that the type-changing
+% that the type change is local (provided that the type-changing
 % instructions only have local effect).  However, note that the
 % instance of~$A$ referred to in $\savecode{B\lassign B*A}$ is the
 % integer instance of~$A$.
@@ -933,7 +933,7 @@
 % \begin{macro}{\calc@addAtoB}
 % \begin{macro}{\calc@subtractAfromB}
 % The replacement code for the binary operators `\texttt{+}' and
-% `\texttt{-}' follow a common pattern; the only difference is the
+% `\texttt{-}' follows a common pattern; the only difference is the
 % token that is stored away by |\aftergroup|.  After this replacement
 % code, control is transferred to |\calc@pre@scan|.
 %    \begin{macrocode}
@@ -1063,7 +1063,7 @@
 % \begin{macro}{\calc@ratio@multiply}
 % \begin{macro}{\calc@ratio@divide}
 % When |\calc@post@scan| encounters a |\ratio| control sequence, it hands
-% control to one of the macros |\calc@ratio@multiply| or |\calc@ratio@divide|,
+% control to one of the macros |\calc@ratio@multiply| and |\calc@ratio@divide|,
 % depending on the preceding character. Those macros both forward the
 % control to the macro |\calc@ratio@evaluate|, which performs two steps: (1) it
 % calculates the ratio, which is saved in the global macro token
@@ -1109,7 +1109,7 @@
 % Here we calculate the ratio.  First, we check for negative numerator
 % and/or denominator; note that \TeX\ interprets two minus signs the
 % same as a plus sign.  Then, we calculate the integer part.
-% The minus sign(s), the integer part, and a decimal point, form the
+% The minus sign(s), the integer part, and a decimal point form the
 % initial expansion of the |\calc@the@ratio| macro.
 %    \begin{macrocode}
       \gdef\calc@the@ratio{}%
@@ -1305,8 +1305,8 @@
 %    {Use \cs{PackageError} for error messages (DPC)}
 % \changes{v4.0e}{1997/11/11}
 %    {typo fixed}
-% If |\calc@post@scan| reads a character that is not one of `\texttt{+}',
-% `\texttt{-}', `\texttt{*}', `\texttt{/}', or `\texttt{)}', an error
+% If |\calc@post@scan| reads a character that is neither `\texttt{+}',
+% `\texttt{-}', `\texttt{*}', `\texttt{/}', nor `\texttt{)}', an error
 % has occurred, and this is reported to the user.  Violations in the
 % syntax of \<numeric>s will be detected and reported by \TeX.
 % \changes{v4.1a}{1998/06/07}
@@ -1327,7 +1327,7 @@
 % \changes{v4.2}{2005/08/06}
 %    {Added macro}
 % The kernel macro \cs{@settodim} is changed so that it runs through a list
-% containing \cs{ht}, \cs{wd}, and \cs{dp} and than advance the length
+% containing \cs{ht}, \cs{wd}, and \cs{dp} and then advances the length
 % one step at a time. We just have to use a scratch register in case the
 % user decides to put in a \cs{global} prefix on the length register.
 % A search on the internet confirmed that some people do that kind of thing.

--- a/required/tools/dcolumn.dtx
+++ b/required/tools/dcolumn.dtx
@@ -31,7 +31,7 @@
 %<driver>\ProvidesFile{dcolumn.drv}
 % \fi
 %         \ProvidesFile{dcolumn.dtx}
-          [2014/10/28 v1.06 decimal alignment package (DPC)]
+          [2023/07/08 v1.06 decimal alignment package (DPC)]
 %
 % \iffalse
 %<*driver>
@@ -117,7 +117,7 @@
 %
 % \noindent"\newcolumntype{,}{D{,}{,}{2}}"
 %
-% {\tt ,} specifies takes a column of entries with at most two decimal
+% {\tt ,} specifies a column of entries with at most two decimal
 % places after a~$,$.
 %
 % \newcolumntype{d}[1]{D{.}{\cdot}{#1}}
@@ -138,7 +138,7 @@
 % \end{center}
 %
 % Note that the first column, which had a negative \meta{decimal places}
-% argument is wider than the second column, so that the decimal point
+% argument, is wider than the second column, so that the decimal point
 % appears in the middle of the column.
 % Also note that this package deals correctly with entries with no
 % decimal part, no integer part, and blank entries.
@@ -200,7 +200,7 @@
 %<*package>
 %    \end{macrocode}
 %
-% First we load {\tt array.sty} if it not already loaded.
+% First we load {\tt array.sty} if it is not already loaded.
 %    \begin{macrocode}
 \RequirePackage{array}
 %    \end{macrocode}
@@ -243,10 +243,10 @@
 % \begin{macro}{\DC@x}
 % \changes{v1.03}{1996/02/28}{Macro added}
 % If "\count@" is negative, centre on the decimal point. If it is
-% positive either "#1" will be empty in which case bad out decimal
+% positive either "#1" will be empty in which case pad out decimal
 % part to the number of digits specified by "\count@" or (new feature
 % in v1.03) it is none empty in which case "\count@" contains the
-% number of digits to the left of the point, and "#1" contains a junk
+% number of digits to the left of the point and "#1" contains a junk
 % token (probably ".") followed by the number of digits to the right
 % of the point. In either of these latter cases, "\DC@right" is used.
 %    \begin{macrocode}
@@ -261,7 +261,7 @@
 % \end{macro}
 %
 % \begin{macro}{\DC@centre}
-% If centering on the decimal point, just need to box up the two halves.
+% If centering on the decimal point, just need to box up the two halves:
 %    \begin{macrocode}
 \def\DC@centre#1#2#3{%
   \let\DC@end\DC@endcentre
@@ -293,16 +293,16 @@
   \ifx\relax#3\relax
 %    \end{macrocode}
 % If "#3" is empty, add "\hfill" to right align the column, and
-% Just set "\DC@rl" to begin a group, so nothing fancy is done with
+% just set "\DC@rl" to begin a group, so that nothing fancy is done with
 % the whole number part.
 %    \begin{macrocode}
     \hfill
     \let\DC@rl\bgroup
   \else
 %    \end{macrocode}
-% Otherwise  set "\DC@rl" so that the whole number part is put in a
+% Otherwise set "\DC@rl" so that the whole number part is put in a
 % box "\count@" times as wide as a digit.
-% In order to share code with the other branch, then move "#3" (the
+% In order to share code with the other branch, move "#3" (the
 % number of decimal places) into "\count@" throwing away the `.' from
 % the user syntax.
 % \changes{v1.04}{1996/09/23}{Add \cs{hfill} so integer part
@@ -318,7 +318,7 @@
 %    \end{macrocode}
 % Box 2 contains the decimal part, set to "\dimen@" which is
 % calculated below to be "\count@" times the width of a digit, plus
-% the with of the `decimal point'.
+% the width of the `decimal point'.
 %    \begin{macrocode}
   \uppercase{\def~}{$\egroup\setbox\tw@\hbox to\dimen@\bgroup${#2}}%
    \setbox\z@\hbox{$1$}\dimen@ii\wd\z@

--- a/required/tools/enumerate.dtx
+++ b/required/tools/enumerate.dtx
@@ -31,7 +31,7 @@
 %<driver> \ProvidesFile{enumerate.drv}
 % \fi
 %         \ProvidesFile{enumerate.dtx}
-          [2015/07/23 v3.00 enumerate extensions (DPC)]
+          [2023/07/04 v3.00 enumerate extensions (DPC)]
 %
 % \iffalse
 %<*driver>
@@ -66,7 +66,7 @@
 % This package gives the enumerate environment an optional argument
 % which determines the style in which the counter is printed.
 %
-% An occurrence of one of the tokens |A a I i| or |1| produces the value
+% An occurrence of one of the tokens |A a I i 1| produces the value
 % of the counter printed with (respectively) |\Alph \alph \Roman \roman|
 % or |\arabic|.
 %
@@ -233,7 +233,7 @@
 %
 % To enable a new counter type based on a letter, you just need
 % to add a new |\ifx| clause by analogy with the code above.
-% So for example to make |*| trigger footnote symbol counting.
+% So for example to make |*| trigger footnote symbol counting,
 % a package should do the following.
 %
 % Initialise the hook, in case the package is loaded before
@@ -255,7 +255,7 @@
 % in this way.
 %
 % At this point we just need initialise the hook, taking care not
-% to over write any definitions another package may already have added.
+% to overwrite any definitions another package may already have added.
 %    \begin{macrocode}
 \providecommand\@enhook{}
 %    \end{macrocode}
@@ -276,7 +276,7 @@
 % \end{macro}
 %
 % \begin{macro}{\@@enum@}
-% Handle the optional argument..
+% Handle the optional argument.
 %    \begin{macrocode}
 \def\@@enum@[#1]{%
 %    \end{macrocode}

--- a/required/tools/ftnright.dtx
+++ b/required/tools/ftnright.dtx
@@ -26,7 +26,7 @@
 %% Copyright (C) 1989-2004 Frank Mittelbach, all rights reserved.
 %<+package>\NeedsTeXFormat{LaTeX2e}[1995/06/01]
 %<+package>\ProvidesPackage{ftnright}
-%<+package>         [2014/10/28 v1.1f footnote layout package (FMi)]
+%<+package>         [2023/07/08 v1.1f footnote layout package (FMi)]
 %
 % \fi
 %%
@@ -171,7 +171,7 @@
 %
 % I also upgraded the documentation to conform to the \LaTeXe{}
 % terminology, e.g., this is a package since document classes will not
-% know about it. However it is very likely that i have missed some
+% know about it. However it is very likely that I have missed some
 % necessary corrections.
 %
 % \section{Introduction}
@@ -220,7 +220,7 @@
 %
 % The result of this effort is presented in this paper and the reader
 % can judge for himself whether it was successful or
-% not.\footnote{Please note, that this option only changed the
+% not.\footnote{Please note that this option changed only the
 % placement of footnotes. Since this article also makes use of the
 % {\tt doc} package \cite{bk:GMS94}, that assigns tiny numbers to
 % code lines sprinkled throughout the text, the resulting design is
@@ -235,7 +235,7 @@
 % footnote separator rule which is used in most publications prepared
 % with \TeX{}.\footnote{People who prefer the rule can add it by
 % redefining the command {\tt\bslash footnoterule}
-% \cite[p.~156]{book:LLa86}. Please, note, that this command should
+% \cite[p.~156]{book:LLa86}. Please note that this command should
 % occupy no space, so that a negative space should be used to
 % compensate for the width of the rule used.} Furthermore, I decided
 % to place the footnote markers\footnote{\label{thisftn}The tiny
@@ -572,7 +572,7 @@
 %    are only partly typeset on the preceding page are not resolved.
 %    They are held over until \LaTeX{} starts a page (or column)
 %    containing text besides floats again. For our current layout,
-%    this would mean, that if \LaTeX{} decided to make the right
+%    this would mean that if \LaTeX{} decided to make the right
 %    column of a page a float column, footnotes from the left column
 %    would appear on a later page. A real cure for this problem would
 %    be to rewrite two-thirds of \LaTeX{}'s output routine, so I am
@@ -615,8 +615,8 @@
 %    footnotes from the left column. So we have to change the output
 %    routine at least in the part that contributes floats to the next
 %    column. The macro involved is called |\@startcolumn|. The first
-%    thing we do is to check and see whether any deferred floats
-%    exists.
+%    thing we do is to check and see whether there are any deferred
+%    floats.
 %    \begin{macrocode}
 \def\@startcolumn{%
  \ifx\@deferlist\@empty
@@ -764,7 +764,7 @@
 %    and output the footnotes on a separate page in an
 %    emergency.\footnote{Otherwise, the footnotes are held over for
 %    ever, preventing \TeX{} from finishing the document successfully.
-%    Instead, \TeX{} will produce infinity many empty pages at the end
+%    Instead, \TeX{} will produce infinitely many empty pages at the end
 %    of the document, trying in vain to output the held over
 %    footnotes.  This problem was found by Rainer Sch\"opf when we
 %    prepared the paper for the Cork conference.}
@@ -790,7 +790,7 @@
 %    moment we simply detect it here, perhaps some better scheme can be
 %    implemented. One way to avoid this is to allow more than |\textheight| of
 %    footnotes in |\preparefootins|. However, that isn't such a good idea
-%    either as that means that a footnote from column one, might end up
+%    either since it means that a footnote from column one might end up
 %    completely on a later page.
 % \changes{v1.1f}{2010/02/25}{Check for split footnotes (pr/4099)}
 %    \begin{macrocode}

--- a/required/tools/indentfirst.dtx
+++ b/required/tools/indentfirst.dtx
@@ -25,7 +25,7 @@
 %
 %<package>\NeedsTeXFormat{LaTeX2e}
 %<package>\ProvidesPackage{indentfirst}
-%<package>         [1995/11/23 v1.03 Indent first paragraph (DPC)]
+%<package>         [2023/07/02 v1.03 Indent first paragraph (DPC)]
 %
 %<*driver>
 \documentclass{ltxdoc}
@@ -52,7 +52,7 @@
 % \changes{v1.03}{1995/11/23}{Typo fixes in documentation}
 %
 % \begin{abstract}
-% Make the first line of all sections etc., be indented by the usual
+% Make the first line of all sections etc. be indented by the usual
 % paragraph indentation. This should work with all the standard document
 % classes.
 % \end{abstract}

--- a/required/tools/layout.dtx
+++ b/required/tools/layout.dtx
@@ -30,7 +30,7 @@
 %<+package>\ProvidesPackage{layout}
 %<+driver>\ProvidesFile{layout.drv}
 %\ProvidesFile{layout.dtx}
-                [2021-03-10 v1.2e Show layout parameters]
+                [2023-08-20 v1.2e Show layout parameters]
 %
 %    A short driver is provided that can be extracted if necessary by
 %    the \textsf{DocStrip} program provided with \LaTeXe.
@@ -409,7 +409,7 @@
 %
 % \begin{macro}{\cnt@paperwidth}
 % \begin{macro}{\cnt@paperheight}
-%    The dimensions of the paper
+%    The dimensions of the paper,
 %    \begin{macrocode}
 \newcount\cnt@paperwidth
 \newcount\cnt@paperheight
@@ -514,7 +514,7 @@
 \newcount\ref@hoffset
 \newcount\ref@voffset
 %    \end{macrocode}
-%    The |\hoffset| and |\voffset| values are added to the default
+%    the |\hoffset| and |\voffset| values are added to the default
 %    offset of one inch.
 %    \begin{macrocode}
 \ref@hoffset=\cnt@hoffset  \advance\cnt@hoffset by \oneinch
@@ -531,7 +531,7 @@
 % \end{macro}
 %
 % \begin{macro}{\ref@head}
-%    and the text areas, running heads,
+%    And the text areas, running heads,
 %    \begin{macrocode}
 \newcount\ref@head
 %    \end{macrocode}
@@ -566,7 +566,7 @@
 % \end{macro}
 %
 %    The following are a number of scratch registers, used in the
-%    positioning of the various pices of the picture.
+%    positioning of the various pieces of the picture.
 %    \begin{macrocode}
 \newcount\Interval
 \newcount\ExtraYPos
@@ -639,7 +639,7 @@
     \ifodd\count\z@
 %    \end{macrocode}
 %
-%    Here we deal with an odd page in the twosided case.
+%    Here we deal with an odd page in the two-sided case.
 %
 %    \begin{macrocode}
       \typeout{Two-sided document style, odd page.}
@@ -667,7 +667,7 @@
     \else
 %    \end{macrocode}
 %
-%    Here we deal with an even page in the twosided case.
+%    Here we deal with an even page in the two-sided case.
 %
 %    \begin{macrocode}
   \typeout{Two-sided document style, even page.}
@@ -696,7 +696,7 @@
   \else
 %    \end{macrocode}
 %
-%    Finally we the case for single sided printing.
+%    Finally we deal with the case for single-sided printing.
 %
 % \changes{v1.1}{1994/02/23}{Added check for reversemargin}
 %    \begin{macrocode}
@@ -718,7 +718,7 @@
 %
 %
 %  Now we begin the picture environment; dividing all the lengths by
-%  two is done by setting |\unitlength| to \texttt{0.5pt}
+%  two is done by setting |\unitlength| to \texttt{0.5pt}.
 %    \begin{macrocode}
   \setlength{\unitlength}{.5pt}
   \begin{picture}(\cnt@paperwidth,\cnt@paperheight)
@@ -790,7 +790,7 @@
     \InsideHArrow\cnt@textwidth
 %    \end{macrocode}
 %
-%    Now the |\textheight|
+%    Now the |\textheight|.
 %    \begin{macrocode}
     \SetToHalf\PositionY\cnt@textheight
     \advance\PositionY by \ref@body
@@ -812,7 +812,7 @@
 %    \end{macrocode}
 %
 %
-%    The |\hoffset|,
+%    The |\hoffset|.
 % \changes{v1.2}{1998/04/13}{\cs{PositionY} for label 1 is
 %    fixed at 50}
 %    \begin{macrocode}
@@ -840,12 +840,12 @@
     \Identify{3}
 %    \end{macrocode}
 %
-%    the |\marginparwidth|,
+%    The |\marginparwidth|.
 %    \begin{macrocode}
     \SetToQuart\PositionY\cnt@textheight
     \advance\PositionY by \ref@body
 %    \end{macrocode}
-%    This arrow has to be bit below the one for the |\oddsidemargin|
+%    This arrow has to be a bit below the one for the |\oddsidemargin|
 %    or\\ |\evensidemargin|.
 %    \begin{macrocode}
     \advance\PositionY by 30
@@ -856,14 +856,14 @@
 %    \end{macrocode}
 %
 %
-%    The |\marginparsep|, this depends on single or double sided
+%    The |\marginparsep|, this depends on single- or double-sided
 %    printing.
 %    \begin{macrocode}
     \advance\PositionY by 30
     \if@twoside
 %    \end{macrocode}
 %
-%    Twosided mode, reversemargin;
+%    Two-sided mode, reversemargin:
 % \changes{v1.1b}{1994/03/23}{\cs{OutSideHArrow} should be
 %    \cs{OutsideHArrow}}
 % \changes{v1.2}{1998/04/13}{Added check for reversemargin}
@@ -878,7 +878,7 @@
         \fi
       \else
 %    \end{macrocode}
-%    Not reversemargin;
+%    Not reversemargin:
 %    \begin{macrocode}
         \ifodd\count\z@
           \OutsideHArrow\ref@marginpar\cnt@marginparsep{20}
@@ -891,7 +891,7 @@
     \else
 %    \end{macrocode}
 %
-%    Single sided mode.
+%    Single-sided mode.
 % \changes{v1.2}{1998/04/13}{Added check for reversemargin}
 %    \begin{macrocode}
       \if@reversemargin
@@ -911,7 +911,7 @@
     \Identify{9}
 %    \end{macrocode}
 %
-%    Identify the |\footskip|. The arrow will be located on $1/8$th of
+%    Identify the |\footskip|. The arrow will be located on $1/8$ of
 %    the |\textwidth|.
 % \changes{v1.2}{1998/04/13}{The \cs{PositionY} of the label 11 is
 %    changed to the upper side of the arrows}
@@ -942,7 +942,7 @@
 %
 %    Identify |\topmargin|, |\headheight| and |\headsep|.
 %
-%    The arrows will be located on $1/8$th of the |\textwidth|, with
+%    The arrows will be located on $1/8$ of the |\textwidth|, with
 %    intervals of the same size, stored in |\Interval|.
 %    \begin{macrocode}
     \Interval = \cnt@textwidth
@@ -983,7 +983,7 @@
     \Identify{5}
     \advance\PositionX by \Interval
 %    \end{macrocode}
-%    and finally the |\headsep|
+%    and finally the |\headsep|.
 % \changes{v1.2}{1998/04/13}{The \cs{PositionY} of the label 6 is
 %    fixed}
 %    \begin{macrocode}
@@ -1006,7 +1006,7 @@
 %
 %    Below the picture we put a table to show the actual values of the
 %    parameters.  Note that fractional points are truncated, i.e.,
-%    \texttt{72.27pt} is displayed as \texttt{72pt}
+%    \texttt{72.27pt} is displayed as \texttt{72pt}.
 %
 %    The table is typeset inside a box with a depth of 0 to always
 %    keep it on the same page as the picture.

--- a/required/tools/longtable.dtx
+++ b/required/tools/longtable.dtx
@@ -37,7 +37,7 @@
 %<driver> \ProvidesFile{longtable.drv}
 % \fi
 %         \ProvidesFile{longtable.dtx}
-          [2021-09-01 v4.17 Multi-page Table package (DPC)]
+          [2023-07-08 v4.17 Multi-page Table package (DPC)]
 %
 % \iffalse
 %<*driver>
@@ -54,7 +54,7 @@
 %        has version number \fileversion, last
 %        revised \filedate.}}
 % \author{David Carlisle\thanks{The new algorithm for aligning `chunks'
-% of a table used in version 4 of this package was devised coded
+% of a table used in version 4 of this package was devised, coded
 % and documented by David Kastrup.}}
 % \date{\filedate}
 %
@@ -317,7 +317,7 @@
 % ".aux" file, so that it can line up the different chunks.
 % Prior to version~4 of this package, this information was not used
 % unless a "\setlongtables" command was issued,  however, now the
-% information is always used, using a new algorithm\footnote{Due to
+% information is always used, via a new algorithm,\footnote{Due to
 % David Kastrup.} and so "\setlongtables" is no longer needed. It is
 % defined (but does nothing) for the benefit of old documents that
 % use it.
@@ -396,7 +396,7 @@
 % are modified in a compatible manner.
 %
 % You may use the "\label" command so that you can cross reference
-% \env{longtable}s with "\ref". Note however, that the "\label" command
+% \env{longtable}s with "\ref". Note, however, that the "\label" command
 % should not be used in a heading that may appear more than once. Place
 % it either in the \env{firsthead}, or in the body of the table. It
 % should not be the \emph{first} command in any entry.
@@ -493,7 +493,7 @@
 % always converged in three passes as described above, but in examples
 % such as the ones in Tables \ref{pass1}--\ref{pass4}, the final
 % widths were not optimal as the width of column~2, which is
-% determined by a "\multicolumn" entry was not known when the final
+% determined by a "\multicolumn" entry, was not known when the final
 % width for column~3 was fixed, due to the fact that \emph{both}
 % "\multicolumn" commands were switched from `draft' mode to `normal'
 % mode at the same time.
@@ -511,7 +511,7 @@
 % many overlapping "\multicolumn" entries, all being wider than the
 % natural widths of the columns they span, and all occurring in
 % different chunks. In the typical case the algorithm will converge
-% after three or four passes, and, the benefits of not needing to edit
+% after three or four passes, and the benefits of not needing to edit
 % the document before the final run to add "\setlongtables", and the
 % better choice of final column widths in the case of multiple
 % "\multicolumn" entries  will hopefully more than pay for the extra
@@ -576,7 +576,7 @@
 % \item The mechanism for adding the head and foot of the table has been
 % completely rewritten. With this new mechanism, \env{longtable} does
 % not need to issue a "\clearpage" at the start of the table, and so the
-% table may start half way down a page. Also the "\endlastfoot" command
+% table may start half way down a page. Also the "\endlastfoot" command,
 % which could not safely be implemented under the old scheme, has been
 % added.
 % \item \env{longtable} now issues an error if started in the scope of
@@ -673,7 +673,7 @@
 % "\endhead"&
 %     Specifies rows to appear at the top of every page.\\
 % "\endfirsthead"&
-%     Specifies rows to appear at the top the first page.\\
+%     Specifies rows to appear at the top of the first page.\\
 % "\endfoot"&
 %     Specifies rows to appear at the bottom of every page.\\
 % "\endlastfoot"&
@@ -885,7 +885,7 @@
 % \begin{macro}{\LTchunksize}
 % \changes{v4.14}{2020/02/07}
 %      {Increase default chunksize from 20 to 200}
-% Chunk size (The number of rows taken per "\halign"). Default 200.
+% Chunk size (the number of rows taken per "\halign"). Default 200.
 %    \begin{macrocode}
 \newcount\LTchunksize \LTchunksize=200
 %    \end{macrocode}
@@ -1189,12 +1189,12 @@
 % \changes{v4.05}{1996/11/12}
 %      {\cs{LT@setprevdepth} added}
 % The following line was added in v4.05.
-% In order to get the "\penalties" to work at chunk boundaries
-% Need to take more care about where and when "\lineskip" glue
+% In order to get the "\penalties" to work at chunk boundaries,
+% we need to take more care about where and when "\lineskip" glue
 % is added. The following does nothing at top of table, and in
 % header chunks, but in normal body chunks it sets "\prevdepth"
 % (to 0pt, but any value would do) so that "\lineskip" glue will
-% be added. the important thing to note is that the glue will be
+% be added. The important thing to note is that the glue will be
 % added \emph{after} any vertical material coming from "\noalign".
 %    \begin{macrocode}
        \LT@setprevdepth
@@ -1257,7 +1257,7 @@
 %    \end{macrocode}
 % \changes{v4.14}{2020/02/07}
 %      {Guard against shrink glue on current page tools/3396 and github 183}
-% This next block was suggested by Lars Hellström in pr tools/3396
+% This next block was suggested by Lars Hellström in pr tools/3396.
 % He documents it as:
 %
 % The original problem occurs because TeX has not yet found an awfully bad
@@ -1325,7 +1325,7 @@
 % \changes{v4.14}{2020/02/07}
 %      {Guard against shrink glue on current page see github 183}
 % The LT output routine does not handle shrink on the page, which can cause
-% The first page to be over-long, so forget it is there.
+% the first page to be over-long, so forget it is there.
 %    \begin{macrocode}
     \ifdim\pageshrink>\z@\pageshrink\z@\fi
   \fi
@@ -1551,7 +1551,7 @@
 % Increment the counter, and do  \env{tabular}'s "\\" or finish the
 % chunk.\\ The "\expandafter" trick was added in Version~3.
 % Set the "\prevdepth" at the start of a new chunk. (Done here
-% so not set in header chunks).
+% so not set in header chunks.)
 %    \begin{macrocode}
   \global\advance\LT@rows\@ne
   \ifnum\LT@rows=\LTchunksize

--- a/required/tools/shellesc.dtx
+++ b/required/tools/shellesc.dtx
@@ -20,7 +20,7 @@
 %<driver> \ProvidesFile{shellesc.drv}
 % \fi
 %         \ProvidesFile{shellesc.dtx}
-       [2023/04/15 v1.0d unified shell escape interface for LaTeX]
+       [2023/07/08 v1.0d unified shell escape interface for LaTeX]
 %
 % \iffalse
 %<*driver>
@@ -50,7 +50,7 @@
 % \section{Introduction}
 %
 %
-% For many years web2c based \TeX\ implementations have used the syntax
+% For many years web2c-based \TeX\ implementations have used the syntax
 % of the \verb|\write| command to access  system commands by using a
 % special stream 18 (streams above 15 can not be allocated to files in
 % classical \TeX\ so stream 18 would otherwise just print to the
@@ -59,9 +59,9 @@
 % This is a useful extension that did not break the strict rules on
 % extensions in classical \TeX.  This package provides a simple
 % macro level interface hiding the \verb|write18| implementation
-% so a command to remove a file on a unix-like system could be
+% so a command to remove a file on a Unix-like system could be
 % specified  using \verb|\ShellEscape{rm file.txt}| (or \verb|del| in
-% windows). Note that by default system access is not allowed and
+% Windows). Note that by default system access is not allowed and
 % \LaTeX\ will typically need to be called with the \verb|--shell-escape|
 % command line option.
 %
@@ -77,7 +77,7 @@
 % \verb|\ShellEscape| in fact corresponds to \verb|\immediate\write18|
 % (or \verb|\directlua|). Very rarely you may need to delay a system
 % command until the current page is output (when page numbers are
-% known) for this classically you could use \verb|\write18| (or
+% known), for this you could classically use \verb|\write18| (or
 % (\verb|\latelua|). This package provides \verb|\DelayedShellEscape|
 % as a common syntax for this use.
 %
@@ -92,7 +92,7 @@
 % \verb|\immediate| will work as normal when writing to file streams
 % or the terminal but the special case of stream 18 which is defined to
 % use \verb|os.execute| always uses \verb|\directlua| (so corresponds
-% to \verb|\immediate\write18|. In the rare situations that you need
+% to \verb|\immediate\write18|). In the rare situations that you need
 % non-immediate \verb|\write18| in a document being ported to current
 % Lua\TeX, you will need to change to use the
 % \verb|\DelayedShellEscape| command.
@@ -118,7 +118,7 @@
 %
 % \begin{macro}{\ShellEscapeStatus}
 % \changes{v1.0a}{2019/10/13}{Command Introduced}
-% Integer value with meanings 0 (shell escape disabled), 1 (shell escape allowed), 2 (Restricted shell escape).
+% Integer value with meanings 0 (shell escape disabled), 1 (shell escape allowed), 2 (restricted shell escape).
 %
 %    \begin{macrocode}
 \chardef\ShellEscapeStatus
@@ -215,8 +215,8 @@ if status == nil then
 %
 % \subsection{The write18 package interface}
 %
-% In web2c based engines other than Lua\TeX, |\write18| may be used
-% directly.  The same was true in older LuaTeX, but from version 0.85
+% In web2c-based engines other than Lua\TeX, |\write18| may be used
+% directly.  The same was true in older Lua\TeX, but from version 0.85
 % onwards that is not available.
 %
 % The above |shellesc| package interface is recommended for new code,

--- a/required/tools/showkeys.dtx
+++ b/required/tools/showkeys.dtx
@@ -39,7 +39,7 @@
 %<driver> \ProvidesFile{showkeys.drv}
 % \fi
 %         \ProvidesFile{showkeys.dtx}
-          [2023/05/11 v3.19 Show cite and label keys (DPC, MH)]
+          [2023/07/08 v3.19 Show cite and label keys (DPC, MH)]
 %
 % \iffalse
 %<*driver>
@@ -112,13 +112,13 @@
 % print its key argument (usually in the margin).
 %
 % If you find the printed keys distracting, but don't want to use the
-% above options to stop them altogether you may use:
+% above options to stop them altogether, you may use:
 % \begin{description}
 % \item[color] Print the keys in a distinguishing colour. The default
 %  value is a light grey.
 % \end{description}
 % The colours may be changed by redefining the following two colours
-% after the package is loaded.
+% after the package is loaded:
 % |refkey| (also used for |\cite|) and
 % |labelkey| (also used for |\bibitem|).
 % The defaults are:
@@ -131,7 +131,7 @@
 %
 % The package accepts two further options.
 % \begin{description}
-% \item[final] to suporess the action of this package, for `final'
+% \item[final] to suppress the action of this package, for `final'
 % versions.
 % \item[draft] the normal behaviour of this package.
 % \end{description}
@@ -437,7 +437,7 @@
 % change |\prevdepth| as that would affect vertical spacing in the
 % document. (The box itself should not cause any difference in break
 % points as there is a node there anyway coming from the |\write| to
-% the aux file.
+% the aux file.)
 %    \begin{macrocode}
       \dimen@\prevdepth
       \nointerlineskip
@@ -451,8 +451,8 @@
 % In inner vertical mode, attach the label to the right of the
 % immediately preceding box, if it is a box before the current point.
 % Otherwise just put it in a box of zero dimensions, with no interline
-% skip. (This may slightly move the surrounding text (but perhaps not
-% now that |\prevdepth| is restored.)
+% skip. This may slightly move the surrounding text (but perhaps not
+% now that |\prevdepth| is restored).
 % \changes{v3.00}{1994/09/07}
 %      {Back up over a previous skip because of the new
 %       \cs{belowcaptionskip}}
@@ -502,7 +502,7 @@
     \fi
   \else
 %    \end{macrocode}
-% If we are in an numbered equation-style environment, do nothing as the
+% If we are in a numbered equation-style environment, do nothing as the
 % code to print the number will also print the label, otherwise just
 % stick the label at the current point, in a box of zero dimensions.
 % \changes{v3.02}{1995/03/17}
@@ -650,7 +650,7 @@
 % The following environments print an equation number, so |\label|
 % should not print its argument at the point where it appears.
 % Note this will fail to show the label if you are in an |eqnarray|
-% environment, and use |\label| together with |\nonumber| This might
+% environment, and use |\label| together with |\nonumber|. This might
 % just about make sense if you are going to use |\pageref|, but that is
 % too bad\ldots
 %    \begin{macrocode}
@@ -665,7 +665,7 @@
 % \changes{v3.09}{1996/08/30}
 %      {Fix eqnarray AMS incompatibility. tools/2252}
 % When the AMS packages are loaded |showkeys| assumes environments
-% work `The AMS way' However |eqnarray| (unlike |equation|) is not
+% work `The AMS way'. However, |eqnarray| (unlike |equation|) is not
 % redefined, so here we need to remove some of the AMS hacks.
 %    \begin{macrocode}
 \toks@\expandafter{\eqnarray}

--- a/required/tools/tabularx.dtx
+++ b/required/tools/tabularx.dtx
@@ -31,7 +31,7 @@
 %<driver> \ProvidesFile{tabularx.drv}
 % \fi
 %         \ProvidesFile{tabularx.dtx}
-          [2020/01/15 v2.11c `tabularx' package (DPC)]
+          [2023/07/08 v2.11c `tabularx' package (DPC)]
 % \iffalse
 %<*driver>
 \documentclass{ltxdoc}
@@ -164,7 +164,7 @@
 % \item The body of the {\ttfamily tabularx} environment is in fact the
 % argument to a command, and so certain constructions which are not
 % allowed in command arguments (like "\verb") may not be used.\footnote
-% {Since Version 1.02, {\ttfamily\bslash verb and \ttfamily\bslash
+% {Since Version 1.02, {\ttfamily\bslash verb} and {\ttfamily\bslash
 % verb*} may be used, but they may treat spaces incorrectly, and the
 % argument can not contain an unmatched {\ttfamily\char`\{} or
 % {\ttfamily\char`\}}, or a  {\ttfamily\char`\%} character.}
@@ -207,7 +207,7 @@
 %
 % \DescribeMacro{\newcolumntype}
 % These preamble specifications may of course be saved using the
-% command, "\newcolumntype", defined in {\ttfamily array.sty}. Thus we
+% command "\newcolumntype" defined in {\ttfamily array.sty}. Thus we
 % may say\\
 % "\newcolumntype{Y}{>{\small\raggedright\arraybackslash}X}"\\
 % and then use {\ttfamily Y} in the {\ttfamily tabularx} preamble
@@ -314,7 +314,7 @@
 % \footnote{This adds an extra level of grouping,
 % which is not really needed. Instead, I could use \box0\ here, and
 % \box2\ below, however the code here would then have to be moved after
-% the first line, because of the footnote to page 386 of the \TeX{}Book,
+% the first line, because of the footnote to page 386 of the \TeX{}book,
 % and I do not think I should be writing code that is so obscure as to
 % be documented in a footnote in an appendix called ``Dirty Tricks''!}
 %
@@ -331,9 +331,9 @@
 %\newenvironment{foo}{\tabularx{XX}}{\endtabularx}
 %\end{verbatim}
 % The scanner now looks for the end of the current environment ("foo" in
-% this example.) There are some restrictions on this usage, the
-% principal one being that "\endtabularx" must not be inside any "{ }" pairs
-% ao that the code before "\endtabularx"  may be extracted and added to the table body
+% this example). There are some restrictions on this usage, the
+% principal one being that "\endtabularx" must not be inside any "{ }" pairs,
+% so that the code before "\endtabularx"  may be extracted and added to the table body
 % (prior to version 2.09  "\endtabularx" had to be
 % the \emph{first} token of the `end code' of the environment).
 %    \begin{macrocode}
@@ -396,7 +396,7 @@
 % \changes{v2.09}{2014/04/22}{macro added}
 % \changes{v2.10}{2014/05/13}{macro modified to test for missing \cs{endtabularx}}
 % \changes{v2.11}{2016/01/03}{Fix to previous change to guard against empty arg 2. (Ulrike Fischer)}
-% split up the end code, and extract the part that lives in the table body.
+% Split up the end code, and extract the part that lives in the table body.
 %    \begin{macrocode}
 \long\def\TX@find@endtabularxa
        #1\endtabularx#2\endtabularx#3\TX@find@endtabularxa{%
@@ -408,7 +408,7 @@
 % \begin{macro}{\TX@find@endtabularxb}
 % \changes{v2.09}{2014/04/22}{macro added}
 % \changes{v2.10}{2014/05/13}{macro modified to test for missing \cs{endtabularx}}
-% split up the end code, and extract the part that lives outside the table body.
+% Split up the end code, and extract the part that lives outside the table body.
 %    \begin{macrocode}
 \long\def\TX@find@endtabularxb
        #1\endtabularx#2\endtabularx#3\TX@find@endtabularxb{%
@@ -502,7 +502,7 @@
   \TX@col@width\TX@target
   \global\TX@cols\@ne
 %    \end{macrocode}
-% Typeout some headings (unless this is disabled).
+% Type out some headings (unless this is disabled).
 %    \begin{macrocode}
   \TX@typeout@
     {\@spaces Table Width\@spaces Column Width\@spaces X Columns}%
@@ -514,7 +514,7 @@
           \global\advance\TX@cols\@ne\NC@find p{\TX@col@width}}}%
 %    \end{macrocode}
 % Repeatedly decrease column width until table is the correct width,
-% or stops shrinking, or the columns become two narrow.
+% or stops shrinking, or the columns become too narrow.
 % If there are no multicolumn entries, this will only take one attempt.
 %    \begin{macrocode}
   \loop
@@ -601,7 +601,7 @@
     \ifdim\dimen@<\TX@delta
 %    \end{macrocode}
 % If this amount is less than "\TX@delta", stop. ("\TX@delta"
-% should be non-zero otherwise we may miss the target due to rounding
+% should be non-zero, otherwise we may miss the target due to rounding
 % error.)
 %    \begin{macrocode}
       \TX@typeout@{Reached target.}%
@@ -621,7 +621,7 @@
       \ifdim \dimen@ >\z@
 %    \end{macrocode}
 % If the new width would be too narrow, abort the loop. At the moment
-% too narrow, means less than 0\,pt!
+% too narrow means less than 0\,pt!
 %
 % Prior to v2.03, if the loop was aborted here, the X columns were left
 % with the width of the previous run, but this may make the table far
@@ -715,7 +715,7 @@
    \expandafter\let\expandafter\endtabularx\csname endtabular*\endcsname
 %    \end{macrocode}
 % Added at v1.05: disable "\write"s during a trial run. This trick is
-% from the \TeX{}Book.\footnote{Actually the \TeX{}Book trick does
+% from the \TeX{}book.\footnote{Actually the \TeX{}book trick does
 % not work correctly, so changed for v2.05.}
 % \changes{v2.05}{1997/09/18}
 %    {New \cs{write} trick. tools/2607}
@@ -789,7 +789,7 @@
 % \end{macro}
 %
 % \begin{macro}{\TX@typeout}
-% The default is to be to be quiet
+% The default is to be quiet.
 %    \begin{macrocode}
 \let\TX@typeout\@gobble
 \let\TX@typeout@\@gobble
@@ -830,7 +830,7 @@
 % tabularx}, but that did not stop people using it! This usually put
 % \LaTeX\ into an irrecoverable error position, with error messages that
 % did not mention the cause of the error. The `poor man's "\verb"' (and
-% "\verb*") defined here is based on page 382 of the \TeX{}Book. As
+% "\verb*") defined here is based on page 382 of the \TeX{}book. As
 % explained there, doing verbatim this way means that spaces are not
 % treated correctly, and so "\verb*" may well be useless, however I
 % consider this section of code to be error-recovery, rather than a real
@@ -882,10 +882,10 @@
 % does not consist of a single "{ }" group. \TeX\ would strip the outer
 % braces from such a group. The `"!"' will be removed later.
 %
-% Originally I followed Knuth, and had "\def\@tempa{##1}", however this
+% Originally I followed Knuth, and had "\def\@tempa{##1}", however, this
 % did not allow "#" to appear in the argument. So in v1.04, I changed
-% this to use a token register, and "\edef". This allows "#" appear,
-% but makes each one appear twice!, so later we loop through, replacing
+% this to use a token register, and "\edef". This allows "#" to appear
+% but makes each one appear twice, so later we loop through, replacing
 % "##" by "#".
 %    \begin{macrocode}
 \def\TX@vb#1{\def\@tempa##1#1{\toks@{##1}\edef\@tempa{\the\toks@}%

--- a/required/tools/theorem.dtx
+++ b/required/tools/theorem.dtx
@@ -24,7 +24,7 @@
 %%
 %
 %
-\def\FMithmInfo{2014/10/28 v2.2c Theorem extension package (FMi)}
+\def\FMithmInfo{2023/07/05 v2.2c Theorem extension package (FMi)}
 %
 % \ProvidesFile{theorem.dtx}[\FMithmInfo]
 %\iffalse   % this is a METACOMMENT !
@@ -100,7 +100,7 @@
 %
 % \begin{abstract}
 %    The macros described in this paper yield an extension of the
-%    \LaTeX{} theorem mechanism. It is designed is to satisfy the
+%    \LaTeX{} theorem mechanism. It is designed to satisfy the
 %    different requirements of various journals. Thus, the
 %    layout of the ``theorems'' can be manipulated by determining a
 %    ``style''. This article describes not only the use, but
@@ -226,7 +226,7 @@
 % |\theorempreskipamount| and |\theorempostskipamount| define,
 % respectively, the spacing before and after such an environment.
 % These parameters apply for all theorem sets and can be manipulated
-% with the ordinary length macros.  They are rubber lengths,
+% with the ordinary length macros.  They are rubber lengths
 % (`\textsf{skips}'), and therefore can contain \texttt{plus} and
 % \texttt{minus} parts.
 %
@@ -385,7 +385,7 @@
 % \section{Definition of the Macros}
 %
 % If the file has been loaded before, we abort immediately. If not the
-% package announces itself (this is actually done at the very top if
+% package announces itself (this is actually done at the very top of
 % the file---the way it is done isn't good style so don't copy it).
 % \changes{v2.0e}{89/07/19}{Spaces removed from `typeout'.}
 % \changes{v2.2b}{95/11/19}{Announce moved to top of file}
@@ -546,8 +546,8 @@
 %    ``non-Big-versions'', we have to avoid offering too many unused
 %    definitions.  Therefore we define these styles in separate files
 %    that can be loaded on demand.  Thus the commands themselves only
-%    load these files. We use |\@input@| a \LaTeXe{} internal command
-%    that ensures that the file will be listed with |\listfiles|
+%    load these files. We use |\@input@|, a \LaTeXe{} internal command
+%    that ensures that the file will be listed with |\listfiles|.
 % \changes{v2.2a}{94/02/02}{Use `@input@ to load theorem layout files}
 %    \begin{macrocode}
 \gdef\th@plain{\@input@{thp.sty}}

--- a/required/tools/verbatim.dtx
+++ b/required/tools/verbatim.dtx
@@ -48,14 +48,14 @@
 \pagestyle{myheadings}
 
 \title{A New Implementation of \LaTeX{}'s \\ \texttt{verbatim}
-       and \texttt{verbatim*} Environments.}
+       and \texttt{verbatim*} Environments}
 \author{Rainer Sch\"opf\\
         \and
         Bernd Raichle\\
         \and
         Chris Rowley}
 
-\date{2022/07/02}
+\date{2023/07/08}
 \begin{document}
 \markboth{Verbatim style option}{Verbatim style option}
 \MaintainedByLaTeXTeam{tools}
@@ -434,7 +434,7 @@
 %
 % A further possibility is to define a variant of the |verbatim|
 % environment that boxes and centers the whole verbatim text.
-% Note that the boxed text should be less than a page otherwise you
+% Note that the boxed text should be less than a page, otherwise you
 % have to change this example.
 %
 %\begin{verbatim}
@@ -706,7 +706,7 @@
 %           necessary for correct vertical spacing if \texttt{verbatim}
 %           is nested inside \texttt{quote}.}
 %    The following extra vertical space is for compatibility with the
-%    \LaTeX kernel: otherwise, using the |verbatim| package changes
+%    \LaTeX{} kernel: otherwise, using the |verbatim| package changes
 %    the vertical spacing of a |verbatim| environment nested within a
 %    |quote| environment.
 %    \begin{macrocode}
@@ -790,18 +790,18 @@
   \def\@noitemerr{\@warning{No verbatim text}}%
 %    \end{macrocode}
 %    Now we call |\obeylines| to make the end of line character
-%    active,
+%    active.
 %    \begin{macrocode}
   \obeylines
 %    \end{macrocode}
-%    change the category code of all special characters,
+%    The category code of all special characters is changed,
 %    to $12$ (other).
 %    \changes{v1.5i}{1996/06/04}{Moved \cs{verbatim@font} after
 %           \cs{dospecials}.}
 %    \begin{macrocode}
   \let\do\@makeother \dospecials
 %    \end{macrocode}
-%    and switch to the font to be used.
+%    We switch to the font to be used.
 %    \begin{macrocode}
   \verbatim@font
 %    \end{macrocode}
@@ -1391,7 +1391,7 @@
 %    (This token list was inserted after the current macro
 %    by |\verbatim@@@|.)
 %    Since we are still in an |\edef| we protect it
-%    by means of|\noexpand|.
+%    by means of |\noexpand|.
 %    \begin{macrocode}
                     \noexpand\verbatim@rescan{\@currenvir}}%
 %    \end{macrocode}
@@ -1493,7 +1493,7 @@
   \else
 %    \end{macrocode}
 %    At this point we pass the name of the file to |\@addtofilelist|
-%    so that its appears in the output of a |\listfiles|
+%    so that it appears in the output of a |\listfiles|
 %    command.
 % \changes{v1.5j}{1996/09/25}{Add \cs{@addtofilelist} and
 %    \cs{ProvidesFile} so that the name of the file
@@ -1579,9 +1579,9 @@
 %    the contents of |\@filef@und|, we need to save it by expanding it
 %    first. The use of |\@swaptwoargs| makes it so that the
 %    \emph{expansion} of |\@filef@und| gets to be the second argument
-%    of |\verbatim@readfile|. 
+%    of |\verbatim@readfile|.
 % \changes{v1.5t}{2020-07-06}{Expand \cs{@filef@und} before the call
-%    of \cs{@verbatim} (gh/222)}m 
+%    of \cs{@verbatim} (gh/222)}
 %    \begin{macrocode}
 \def\verbatim@input#1#2{%
   \IfFileExists {#2}{%
@@ -1606,7 +1606,7 @@
 % \end{macro}
 %
 %
-% \subsection{Getting verbatim text into arguments.}
+% \subsection{Getting verbatim text into arguments}
 %
 % One way of achieving this is to define a macro (command) whose
 % expansion is the required verbatim text.  This command can then be

--- a/required/tools/xr.dtx
+++ b/required/tools/xr.dtx
@@ -25,7 +25,7 @@
 %
 %<package>\NeedsTeXFormat{LaTeX2e}
 %<package>\ProvidesPackage{xr}
-%<package>         [2020-05-10 v5.06 eXternal References (DPC)]
+%<package>         [2023-07-04 v5.06 eXternal References (DPC)]
 %
 %<*driver>
 \documentclass{ltxdoc}
@@ -74,7 +74,7 @@
 % If any of the external documents, or the main document, use the same
 % |\label| then an error will occur as the label will be multiply
 % defined. To overcome this problem |\externaldocument| has an optional
-% argument. If you declare |\externaldocument[A-]{aaa}| Then all
+% argument. If you declare |\externaldocument[A-]{aaa}|, then all
 % references from |aaa| are prefixed by |A-|. So for instance, if a
 % section of |aaa| had |\label{intro}|, then this could be referenced
 % with |\ref{A-intro}|. The prefix need not be |A-|, it can be any


### PR DESCRIPTION
I fixed some mistakes in the documentation such as `specifies takes` (instead of `specifies`) and `the with` (instead of `the width`).