### PR TITLE
Drop a redundant \ExplSyntaxOff

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,11 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 ================================================================================
 
+2023-07-10 Yukai Chou  <muzimuzhi@gmail.com>
+
+    * ltfilehook.dtx (subsection{Declaring a file substitution}):
+    Drop a redundant \ExplSyntaxOff
+
 2023-06-12  Joseph Wright  <Joseph.Wright@latex-project.org>
 
 	* usrguide.tex

--- a/base/ltfilehook.dtx
+++ b/base/ltfilehook.dtx
@@ -32,7 +32,7 @@
 %
 %    \begin{macrocode}
 \providecommand\ltfilehookversion{v1.0o}
-\providecommand\ltfilehookdate{2023/04/02}
+\providecommand\ltfilehookdate{2023/07/10}
 %    \end{macrocode}
 %
 %<*driver>
@@ -1043,7 +1043,6 @@
 %
 %    \begin{macrocode}
 %<@@=>
-\ExplSyntaxOff
 %    \end{macrocode}
 %
 % \subsection{Selecting a file (\cs{set@curr@file})}


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

I happened to notice that in the generated `latex.ltx` for LaTeX2e 2023-06-01 PL1, there are two adjacent `\ExplSyntaxOff`:

```tex
% latex.ltx, 2023-06-01 PL1, lines 16009 to 16014
\ExplSyntaxOn
\cs_new_eq:NN \declare@file@substitution   \__filehook_subst_add:nn
\cs_new_eq:NN \undeclare@file@substitution \__filehook_subst_remove:n
\ExplSyntaxOff
\ExplSyntaxOff
\def\set@curr@file{%
  \begingroup
    \set@curr@file@aux}
```
https://github.com/latex3/latex2e/blob/d2ac4bbbb8bbc289bed94c6aa257a00e06ee7b06/base/ltfilehook.dtx#L1014-L1047
This PR drops the second `\ExplSyntaxOff`.

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] <s>Version and</s> date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
