### PR TITLE
Cleanup firstaid

### DIFF
--- a/base/testfiles-lthooks/ltcmdhooks-001.tlg
+++ b/base/testfiles-lthooks/ltcmdhooks-001.tlg
@@ -178,18 +178,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -224,8 +212,6 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
  cmd/foo/before -> before 1 before 2 \__hook_toplevel cmd/foo/before {#1}{#2}{#3}{#4}{#5}{#6}{#7}{#8}{#9}\__hook_next cmd/foo/before {#1}{#2}{#3}{#4}{#5}{#6}{#7}{#8}{#9} 
  cmd/foo/after -> \__hook_toplevel cmd/foo/after {#1}{#2}{#3}{#4}{#5}{#6}{#7}{#8}{#9}after 2 after 1 \__hook_next cmd/foo/after {#1}{#2}{#3}{#4}{#5}{#6}{#7}{#8}{#9} 

--- a/base/testfiles-lthooks/lthooks-000.tlg
+++ b/base/testfiles-lthooks/lthooks-000.tlg
@@ -118,18 +118,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -148,8 +136,6 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
 No file lthooks-000.aux.
 LaTeX Font Info:    Checking defaults for OML/cmm/m/it on input line ....

--- a/base/testfiles-lthooks/lthooks-001.tlg
+++ b/base/testfiles-lthooks/lthooks-001.tlg
@@ -124,18 +124,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -162,8 +150,6 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
  xxx -> foobar\__hook_toplevel xxx \__hook_next xxx  
 LaTeX hooks Warning: Cannot remove chunk 'label3' from hook 'xxx' because it
@@ -227,8 +213,6 @@ The sequence \g__hook_all_seq contains the items (without outer braces):
 >  {file/varwidth.sty/after}
 >  {file/german.sty/after}
 >  {file/ngerman.sty/after}
->  {file/memoir.cls/before}
->  {file/memoir.cls/after}
 >  {package/l3graphics/after}
 >  {xxx}.
 Update code for hook 'para/before' on input line ...:
@@ -349,18 +333,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -385,8 +357,6 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
  xxx -> foo\__hook_toplevel xxx \__hook_next xxx  
 The hook xxx contains the rules:

--- a/base/testfiles-lthooks/lthooks-002.tlg
+++ b/base/testfiles-lthooks/lthooks-002.tlg
@@ -124,18 +124,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -162,8 +150,6 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
  xxx -> foobar\__hook_toplevel xxx \__hook_next xxx  
 LaTeX hooks Warning: Cannot remove chunk 'label3' from hook 'xxx' because it
@@ -229,8 +215,6 @@ The sequence \g__hook_all_seq contains the items (without outer braces):
 >  {file/varwidth.sty/after}
 >  {file/german.sty/after}
 >  {file/ngerman.sty/after}
->  {file/memoir.cls/before}
->  {file/memoir.cls/after}
 >  {package/l3graphics/after}
 >  {xxx}.
 Update code for hook 'para/before' on input line ...:
@@ -351,18 +335,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -387,8 +359,6 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
  xxx -> foo\__hook_toplevel xxx \__hook_next xxx  
 The hook xxx contains the rules:

--- a/base/testfiles-lthooks/lthooks-003.tlg
+++ b/base/testfiles-lthooks/lthooks-003.tlg
@@ -74,8 +74,6 @@ The sequence \g__hook_all_seq contains the items (without outer braces):
 >  {file/varwidth.sty/after}
 >  {file/german.sty/after}
 >  {file/ngerman.sty/after}
->  {file/memoir.cls/before}
->  {file/memoir.cls/after}
 >  {package/l3graphics/after}
 >  {xxx}.
 The hook xxx contains the rules:
@@ -207,18 +205,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -269,7 +255,5 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
  xxx ->  foo1 foo9 foo3 foo2 foo7 foo4 foo5 foo8 foo6\__hook_toplevel xxx \__hook_next xxx  

--- a/base/testfiles-lthooks/lthooks-004.tlg
+++ b/base/testfiles-lthooks/lthooks-004.tlg
@@ -64,8 +64,6 @@ The sequence \g__hook_all_seq contains the items (without outer braces):
 >  {file/varwidth.sty/after}
 >  {file/german.sty/after}
 >  {file/ngerman.sty/after}
->  {file/memoir.cls/before}
->  {file/memoir.cls/after}
 >  {package/l3graphics/after}
 >  {xxx}.
 The hook xxx contains the rules:
@@ -191,18 +189,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -244,7 +230,5 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
  xxx ->  foo4\__hook_toplevel xxx \__hook_next xxx  

--- a/base/testfiles-lthooks/lthooks-005.tlg
+++ b/base/testfiles-lthooks/lthooks-005.tlg
@@ -81,8 +81,6 @@ The sequence \g__hook_all_seq contains the items (without outer braces):
 >  {file/varwidth.sty/after}
 >  {file/german.sty/after}
 >  {file/ngerman.sty/after}
->  {file/memoir.cls/before}
->  {file/memoir.cls/after}
 >  {package/l3graphics/after}
 >  {xxx}.
 The hook xxx contains the rules:
@@ -214,18 +212,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -276,7 +262,5 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
  xxx ->  foo1 foo9 foo3 foo2 foo7 foo4 foo5 foo8 foo6\__hook_toplevel xxx \__hook_next xxx  

--- a/base/testfiles-lthooks/lthooks-006.tlg
+++ b/base/testfiles-lthooks/lthooks-006.tlg
@@ -62,8 +62,6 @@ The sequence \g__hook_all_seq contains the items (without outer braces):
 >  {file/varwidth.sty/after}
 >  {file/german.sty/after}
 >  {file/ngerman.sty/after}
->  {file/memoir.cls/before}
->  {file/memoir.cls/after}
 >  {package/l3graphics/after}
 >  {xxx}.
 The hook xxx contains the rules:
@@ -187,18 +185,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -231,7 +217,5 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
  xxx ->  foo1 foo3 foo2\__hook_toplevel xxx \__hook_next xxx  

--- a/base/testfiles-lthooks/lthooks-007.tlg
+++ b/base/testfiles-lthooks/lthooks-007.tlg
@@ -62,8 +62,6 @@ The sequence \g__hook_all_seq contains the items (without outer braces):
 >  {file/varwidth.sty/after}
 >  {file/german.sty/after}
 >  {file/ngerman.sty/after}
->  {file/memoir.cls/before}
->  {file/memoir.cls/after}
 >  {package/l3graphics/after}
 >  {xxx}.
 The hook xxx contains the rules:
@@ -188,18 +186,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -232,8 +218,6 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
  xxx ->  foo1 foo3\__hook_toplevel xxx \__hook_next xxx  
 Update code for hook 'para/before' on input line ...:
@@ -354,18 +338,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -396,7 +368,5 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
  xxx ->  foo1 foo3\__hook_toplevel xxx \__hook_next xxx  

--- a/base/testfiles-lthooks/lthooks-008.tlg
+++ b/base/testfiles-lthooks/lthooks-008.tlg
@@ -64,8 +64,6 @@ The sequence \g__hook_all_seq contains the items (without outer braces):
 >  {file/varwidth.sty/after}
 >  {file/german.sty/after}
 >  {file/ngerman.sty/after}
->  {file/memoir.cls/before}
->  {file/memoir.cls/after}
 >  {package/l3graphics/after}.
 The hook enddocument contains the rules:
 Update code for hook 'para/before' on input line ...:
@@ -195,18 +193,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -226,8 +212,6 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
 No file lthooks-008.aux.
 LaTeX Font Info:    Checking defaults for OML/cmm/m/it on input line ....

--- a/base/testfiles-lthooks/lthooks-009.tlg
+++ b/base/testfiles-lthooks/lthooks-009.tlg
@@ -124,18 +124,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -155,8 +143,6 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
 No file lthooks-009.aux.
 LaTeX Font Info:    Checking defaults for OML/cmm/m/it on input line ....

--- a/base/testfiles-lthooks/lthooks-011.tlg
+++ b/base/testfiles-lthooks/lthooks-011.tlg
@@ -119,18 +119,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -160,8 +148,6 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
  xxx -> foo\__hook_toplevel xxx \__hook_next xxx  
 **** Add to hook xxx (rear) on input line ... <- bar
@@ -283,18 +269,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -326,8 +300,6 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
  xxx -> foobar\__hook_toplevel xxx \__hook_next xxx  
 **** Add to hook xxx (labels) on input line ... <- baz
@@ -449,18 +421,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -494,8 +454,6 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
  xxx -> foobarbaz\__hook_toplevel xxx \__hook_next xxx  
 **** Add to hook xxx (return) on input line ... <- boom
@@ -617,18 +575,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -664,7 +610,5 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
  xxx -> foobarbazboom\__hook_toplevel xxx \__hook_next xxx  

--- a/base/testfiles-lthooks/lthooks-013.tlg
+++ b/base/testfiles-lthooks/lthooks-013.tlg
@@ -171,18 +171,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -209,8 +197,6 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
  env/itemize/begin -> \typeout {env itemize first}\__hook_toplevel env/itemize/begin \__hook_next env/itemize/begin  
 No file lthooks-013.aux.

--- a/base/testfiles-lthooks/lthooks-021.tlg
+++ b/base/testfiles-lthooks/lthooks-021.tlg
@@ -118,18 +118,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -148,8 +136,6 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
 No file lthooks-021.aux.
 LaTeX Font Info:    Checking defaults for OML/cmm/m/it on input line ....

--- a/base/testfiles-lthooks/lthooks-legacy.tlg
+++ b/base/testfiles-lthooks/lthooks-legacy.tlg
@@ -143,18 +143,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -177,8 +165,6 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
 legacy defaultfamily on input line ...
 No file lthooks-legacy.aux.

--- a/base/testfiles-lthooks2/lthooks2-002.tlg
+++ b/base/testfiles-lthooks2/lthooks2-002.tlg
@@ -130,18 +130,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -160,8 +148,6 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
 (lthooks2-002.aux)
 LaTeX Font Info:    Checking defaults for OML/cmm/m/it on input line ....

--- a/base/testfiles-lthooks2/lthooks2-005.tlg
+++ b/base/testfiles-lthooks2/lthooks2-005.tlg
@@ -119,18 +119,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -149,8 +137,6 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
 **** Add to hook some-hook (other-package) on input line ... <- code from other-package,
 Update code for hook 'para/before' on input line ...:
@@ -271,18 +257,6 @@ Code labels for sorting:
 Data structure for label rules:
  firstaid = 0 -> 
 Handled code for firstaid
-Update code for hook 'file/memoir.cls/before' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
-Update code for hook 'file/memoir.cls/after' on input line ...:
-Code labels for sorting:
- firstaid
-Data structure for label rules:
- firstaid = 0 -> 
-Handled code for firstaid
 Update code for hook 'package/l3graphics/after' on input line ...:
 Code labels for sorting:
  backend
@@ -309,7 +283,5 @@ All initialized (non-empty) hooks:
  file/varwidth.sty/after -> \__hook_toplevel file/varwidth.sty/after \FirstAidNeededT {varwidth}{sty}{....-..-.. ver 0.92; \space Variable-width minipages}{\def \@vwid@sift {\skip@ \lastskip \unskip \ifdim \lastskip =\z@ \unskip \fi \dimen@ \lastkern \unkern \count@ \lastpenalty \unpenalty \setbox \z@ \lastbox \ifvoid \z@ \advance \sift@deathcycles \@ne \else \sift@deathcycles \z@ \fi \ifnum \sift@deathcycles >33 \let \@vwid@sift \relax \PackageWarning {varwidth}{Failed to reprocess entire contents}\fi \ifnum \count@ =\@vwid@preeqp \@vwid@eqmodefalse \fi \ifnum \count@ =\@vwid@posteqp \@vwid@eqmodetrue \fi \ifnum \count@ =\@vwid@toppen \let \@vwid@sift \relax \else \ifnum \count@ =\@vwid@offsets \@vwid@setoffsets \else \ifnum \count@ =\@vwid@postw \else \@vwid@resetb \fi \@vwid@append \fi \fi \@vwid@sift }}\__hook_next file/varwidth.sty/after  
  file/german.sty/after -> \__hook_toplevel file/german.sty/after \FirstAidNeededT {german}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\germanTeX }\__hook_next file/german.sty/after  
  file/ngerman.sty/after -> \__hook_toplevel file/ngerman.sty/after \FirstAidNeededT {ngerman}{sty}{....-..-.. v... Support for writing german texts (br)} {\let \grmn@active@dq@ \@active@dq \def \@active@dq {\protect \grmn@active@dq@ }\ngermanTeX }\__hook_next file/ngerman.sty/after  
- file/memoir.cls/before -> \expandafter \def \expandafter \@tempa \string \dimen {}\edef \kernel@stockheight {\expandafter \@tempa \meaning \stockheight }\edef \kernel@stockwidth {\expandafter \@tempa \meaning \stockwidth }\let \stockheight \@undefined \let \stockwidth \@undefined \__hook_toplevel file/memoir.cls/before \__hook_next file/memoir.cls/before  
- file/memoir.cls/after -> \__hook_toplevel file/memoir.cls/after \dimen \kernel@stockheight =\stockheight \dimen \kernel@stockwidth =\stockwidth \dimendef \stockheight =\kernel@stockheight \dimendef \stockwidth =\kernel@stockwidth \__hook_next file/memoir.cls/after  
  package/l3graphics/after -> \__hook_toplevel package/l3graphics/after \seq_set_from_clist:Nn \l_graphics_search_ext_seq {.pdf,.eps,.ps,.png,.jpg,.jpeg}\__hook_next package/l3graphics/after  
  some-hook -> code to run when other-package is loaded,code from other-package,\__hook_toplevel some-hook \__hook_next some-hook  

--- a/required/firstaid/changes.txt
+++ b/required/firstaid/changes.txt
@@ -1,6 +1,7 @@
 2023-07-18  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
     * latex2e-first-aid-for-external-files.dtx: remove no longer needed code for 
       everysel
+    * latex2e-first-aid-for-external-files.dtx: remove no longer needed code for bidi 
      
 2023-05-20  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
 

--- a/required/firstaid/changes.txt
+++ b/required/firstaid/changes.txt
@@ -2,6 +2,8 @@
     * latex2e-first-aid-for-external-files.dtx: remove no longer needed code for 
       everysel
     * latex2e-first-aid-for-external-files.dtx: remove no longer needed code for bidi 
+    * latex2e-first-aid-for-external-files.dtx: 
+      remove no longer needed code for memoir/stockheight 
      
 2023-05-20  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
 

--- a/required/firstaid/changes.txt
+++ b/required/firstaid/changes.txt
@@ -1,3 +1,7 @@
+2023-07-18  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
+    * latex2e-first-aid-for-external-files.dtx: remove no longer needed code for 
+      everysel
+     
 2023-05-20  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
 
 	* latex2e-first-aid-for-external-files.dtx: removed temporary fix for 
@@ -137,5 +141,3 @@
 	* latex2e-first-aid-for-external-files.dtx:
 	Initial version for 2020-10-01 release containing first aid
 	for packages bidi, filehook and class dinbrief.
-
-

--- a/required/firstaid/firstaid.ins
+++ b/required/firstaid/firstaid.ins
@@ -72,7 +72,4 @@ without such generated files.
 \generate{\file{filehook-ltx.sty}
                {\from{latex2e-first-aid-for-external-files.dtx}{filehook-ltx}}}
 
-\generate{\file{everysel-ltx.sty}
-               {\from{latex2e-first-aid-for-external-files.dtx}{everysel-ltx}}}
-
 \endbatchfile

--- a/required/firstaid/latex2e-first-aid-for-external-files.dtx
+++ b/required/firstaid/latex2e-first-aid-for-external-files.dtx
@@ -285,60 +285,8 @@
 %</filehook-ltx>
 %    \end{macrocode}
 %
-%
-%
-%
-% \subsection{The \pkg{bidi} package first aid}
-%
-%     The \pkg{bidi} package adds a lot of hooks in various places and
-%    those added to \cs{document} and \cs{enddocument} are now no
-%    longer necessary as the kernel already provides the right hooks
-%    there.
-%
-%    However, we aren't trying to change that but instead only make
-%    sure that the existing patches still work by adding some first
-%    aid after \pkg{biditools} has been loaded.
-%
-%    If the package gets updated one can easily take that out simply
-%    through
-%\begin{verbatim}
-%  \RemoveFromHook{file/biditools.sty/after}[firstaid]
-%\end{verbatim}
-%    This makes it easy to test new bidi code while the first aid code
-%    is still in the kernel.
-%
 %    \begin{macrocode}
 %<*kernel>
-%    \end{macrocode}
-%
-%    Bidi is now ar a new version: patches are no longer needed.  
-%    \begin{macrocode}
-%\AddToHook{file/biditools.sty/after}[firstaid]{%
-%  \FirstAidNeededT{biditools}{sty}%
-%                  {2020/05/13 v2 Programming tools for bidi package}%
-%  {%
-%    \end{macrocode}
-%    \pkg{bidi} adds some code to the beginning of \cs{document} which
-%    contains \cs{endgroup} and \cs{begingroup} which is no longer
-%    correct.
-%  
-%    Patching \cs{document} using \cs{bidi@patchcmd} doesn't work so
-%    we take the extra groups out by hand:
-%    \begin{macrocode}
-%  \def\firstaid@bidi@document@patch
-%          \endgroup#1\begingroup#2\firstaid@bidi@document@patch
-%          {\unexpanded{#1#2}}%
-%  \edef\document{\expandafter\firstaid@bidi@document@patch\document
-%            \firstaid@bidi@document@patch}%
-%    \end{macrocode}
-%    There are also some patches into \cs{enddocument}, some continue
-%    to go in but one fails, so we add that now into the right place.
-%    \begin{macrocode}
-%  \AddToHook{enddocument/info}%
-%            {\let\bidi@AfterEndDocumentCheckLabelsRerun\@firstofone
-%              \bidi@afterenddocumentchecklabelsrerunhook}%
-%  }%
-%}
 %    \end{macrocode}
 %
 % \subsection{The \pkg{dinbrief} class first aid}

--- a/required/firstaid/latex2e-first-aid-for-external-files.dtx
+++ b/required/firstaid/latex2e-first-aid-for-external-files.dtx
@@ -560,31 +560,6 @@
 }
 %    \end{macrocode}
 %
-%
-% \subsection{First aid for \pkg{memoir}}
-%
-%  The introduction of \cs{stockheight} and \cs{stockwidth} into the
-%  kernel requires some first aid. This has to go in \emph{before}
-%  loading the class, so we cannot check the version string here.
-%    \begin{macrocode}
-\AddToHook{file/memoir.cls/before}[firstaid]{%
-  \expandafter\def\expandafter\@tempa\string\dimen{}%
-  \edef\kernel@stockheight{\expandafter\@tempa\meaning\stockheight}%
-  \edef\kernel@stockwidth{\expandafter\@tempa\meaning\stockwidth}%
-  \let\stockheight\@undefined
-  \let\stockwidth\@undefined
-}
-\AddToHook{file/memoir.cls/after}[firstaid]{%
-  \dimen\kernel@stockheight=\stockheight
-  \dimen\kernel@stockwidth=\stockwidth
-  \dimendef\stockheight=\kernel@stockheight
-  \dimendef\stockwidth=\kernel@stockwidth
-}
-%    \end{macrocode}
-%
-%
-%
-%
 %    \begin{macrocode}
 %</kernel>
 %    \end{macrocode}

--- a/required/firstaid/latex2e-first-aid-for-external-files.dtx
+++ b/required/firstaid/latex2e-first-aid-for-external-files.dtx
@@ -111,8 +111,8 @@
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\def\LaTeXFirstAidDate{2023/05/20}
-\def\LaTeXFirstAidVersion{v1.0z}
+\def\LaTeXFirstAidDate{2023/07/18}
+\def\LaTeXFirstAidVersion{v1.1a}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
@@ -481,46 +481,6 @@
 %    \begin{macrocode}
 %</kernel>
 %    \end{macrocode}
-%
-% \subsection{The \pkg{everysel} package first aid}
-%     
-%
-%    The \cs{selectfont} command got a hook (with the 2021/05 release) which
-%    was originally provided by the \pkg{everysel}
-%    package. Now that it is in the kernel this package is no longer
-%    needed (or only in a simplified manner).
-%
-%    If it is requested we replace it with a simplified package
-%    (until) it gets updated at which point this line can be removed.
-% \changes{v2.2k}{2020/12/04}{Emulate everysel package}
-%    \begin{macrocode}
-%<*kernel>
-% this has been updated
-%\declare@file@substitution{everysel.sty}{everysel-ltx.sty}
-%</kernel>
-%    \end{macrocode}
-%
-%
-%
-%    \begin{macrocode}
-%<*everysel-ltx>
-\ProvidesPackage{everysel-ltx}
-   [2020/12/04 v1.0a
-     Emulation of the original everysel^^Jpackage with kernel methods]
-%    \end{macrocode}
-%
-%    \begin{macrocode}
-\newcommand*{\EverySelectfont}[1]
-   {\AddToHook{selectfont}{#1}}
-\newcommand*{\AtNextSelectfont}[1]
-   {\AddToHookNext{selectfont}{#1}}
-%    \end{macrocode}
-%
-%
-%    \begin{macrocode}
-%</everysel-ltx>
-%    \end{macrocode}
-%
 %
 %
 %    \begin{macrocode}


### PR DESCRIPTION
This removes three unneeded firstaids (everysel, bidi, memoir) from the firstaid file.

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added (not needed)
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included (imho unneeded in firstaid)
- [ x] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated (imho unneeded)
