### PR TITLE
Remove \GetDocumentCommandArgSpec, etc. from base

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -9,7 +9,10 @@ are not part of the distribution.
 2023-08-19 Joseph Wright  <Joseph.Wright@latex-project.org>
 
 	* ltcmd.dtx, usrguide.tex
-	Remove \GetDocumentCommandArgSpec, etc.
+	Remove \GetDocumentCommandArgSpec,
+	  \GetDocumentEnvironmentArgSpec,
+	  \ShowDocumentCommandArgSpec,
+	  \ShowDocumentEnvironmentArgSpec
 
 2023-08-05  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 

--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,11 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 ================================================================================
 
+2023-08-19 Joseph Wright  <Joseph.Wright@latex-project.org>
+
+	* ltcmd.dtx, usrguide.tex
+	Remove \GetDocumentCommandArgSpec, etc.
+
 2023-08-05  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 
 	* ltsockets.dtx:

--- a/base/doc/ltnews38.tex
+++ b/base/doc/ltnews38.tex
@@ -154,6 +154,17 @@ For documentation see \texttt{texdoc ltsockets-doc} for now.
 %
 \githubissue{xxx}
 
+\section{\emph{Removed} commands}
+
+It is very rare that commands are removed from the \LaTeX{} kernel. However, in
+this release we have elected to remove \cs{GetDocumentCommandArgSpec},
+\cs{GetDocumentEnvironmentArgSpec}, \cs{ShowDocumentCommandArgSpec} and
+\cs{ShowDocumentEnvironmentArgSpec} from the kernel. These commands have been
+moved back to the \enquote{stub} \pkg{xparse} provided in \pkg{l3packages}. The
+reason for this change is that the commands were essentially part of debugging
+early forms of the kernel code, and expose implementation detail in a way that
+was not helpful.
+
 \section{Code improvements}
 
 \section{Bug fixes}

--- a/base/doc/usrguide.tex
+++ b/base/doc/usrguide.tex
@@ -877,33 +877,6 @@ defined as
 [As an aside: the code is written in \pkg{expl3}, so we don't have to
   worry about spaces creeping into the definition.]
 
-\subsection{Access to the argument specification}
-
-The argument specifications for document commands and environments are
-available for examination and use.
-
-\begin{decl}
-  |\GetDocumentCommandArgSpec| \arg{cmd}         \\
-  |\GetDocumentEnvironmentArgSpec| \arg{environment}
-\end{decl}
-These commands transfer the current argument specification for the
-requested \meta{cmd} or \meta{environment} into the token list
-variable \cs{ArgumentSpecification}. If the \meta{cmd} or
-\meta{environment} has no known argument specification then an error
-is issued. The assignment to \cs{ArgumentSpecification} is local to
-the current \TeX{} group.
-
-\begin{decl}
-  |\ShowDocumentCommandArgSpec| \arg{cmd}         \\
-  |\ShowDocumentEnvironmentArgSpec| \arg{environment}
-\end{decl}
-These commands show the current argument specification for the
-requested \meta{cmd} or \meta{environment} at the terminal. If
-the \meta{cmd} or \meta{environment} has no known argument
-specification then an error is issued.
-
-
-
 \section{Copying and showing (robust) commands and environments}
 
 If you want to (slightly) alter an existing command you may want to

--- a/base/ltcmd.dtx
+++ b/base/ltcmd.dtx
@@ -34,7 +34,7 @@
 %%% From File: ltcmd.dtx
 %
 %    \begin{macrocode}
-\def\ltcmdversion{v1.21}
+\def\ltcmdversion{v1.2a}
 \def\ltcmddate{2023-08-19}
 %    \end{macrocode}
 %

--- a/base/ltcmd.dtx
+++ b/base/ltcmd.dtx
@@ -34,8 +34,8 @@
 %%% From File: ltcmd.dtx
 %
 %    \begin{macrocode}
-\def\ltcmdversion{v1.1e}
-\def\ltcmddate{2023-05-26}
+\def\ltcmdversion{v1.21}
+\def\ltcmddate{2023-08-19}
 %    \end{macrocode}
 %
 %<*driver>
@@ -59,6 +59,8 @@
 % \section{Creating document commands}
 %
 % \changes{v1.0a}{2020/11/20}{Initial version derived from \texttt{xparse.dtx}}
+% \changes{v1.2a}{2023/08/19}{Removed commands that should have remained
+%   only in \texttt{xparse.dtx}}
 %
 % Document commands should be created using the tools provided by this module:
 % \cs{NewDocumentCommand}, etc.\@, in almost all cases. This allows clean
@@ -4263,116 +4265,6 @@
 % \end{macro}
 % \end{macro}
 %
-% \subsection{Access to the argument specification}
-%
-% \begin{macro}{\@@_get_arg_spec_error:N, \@@_get_arg_spec_error:n}
-% \begin{macro}{\@@_get_arg_spec_error_aux:n}
-%   Provide an informative error when trying to get the argument
-%   specification of a non-\pkg{xparse} command or environment.
-%    \begin{macrocode}
-\cs_new_protected:Npn \@@_get_arg_spec_error:N #1
-  {
-    \bool_set_false:N \l_@@_environment_bool
-    \tl_set:Nn \l_@@_fn_tl {#1}
-    \@@_get_arg_spec_error_aux:n { \cs_if_exist:NTF #1 }
-  }
-\cs_new_protected:Npn \@@_get_arg_spec_error:n #1
-  {
-    \bool_set_true:N \l_@@_environment_bool
-    \str_set:Nx \l_@@_environment_str {#1}
-    \@@_get_arg_spec_error_aux:n
-      { \cs_if_exist:cTF { \l_@@_environment_str } }
-  }
-\cs_new_protected:Npn \@@_get_arg_spec_error_aux:n #1
-  {
-    #1
-      {
-        \msg_error:nnx { cmd } { non-xparse }
-          { \@@_environment_or_command: }
-      }
-      {
-        \msg_error:nnx { cmd } { unknown }
-          { \@@_environment_or_command: }
-      }
-  }
-%    \end{macrocode}
-% \end{macro}
-% \end{macro}
-%
-% \begin{macro}{\@@_get_arg_spec:NTF}
-%   If the command is not an \pkg{xparse} command, complain.  If it is,
-%   its second \enquote{item} is the argument specification.
-%    \begin{macrocode}
-\cs_new_protected:Npn \@@_get_arg_spec:NTF #1#2#3
-  {
-    \__kernel_cmd_if_xparse:NTF #1
-      {
-        \tl_set:Nx \ArgumentSpecification { \tl_item:Nn #1 { 2 } }
-        #2
-      }
-      {#3}
-  }
-%    \end{macrocode}
-% \end{macro}
-%
-% Rolling forward from 2020-10-01 is tricky because the entire |ltcmd|
-% module is new, but the user-level commands have the same name, so only
-% these will clash.  To work around that, in |latexrelease| mode we will
-% (temporarily) disable \cs{__kernel_chk_if_free_cs:N} for this final
-% part of the code, then restore at the end.
-%    \begin{macrocode}
-%<latexrelease>\cs_new_eq:NN \@@_chk_if_free_cs:N \__kernel_chk_if_free_cs:N
-%<latexrelease>\cs_gset_eq:NN \__kernel_chk_if_free_cs:N \use_none:n
-%    \end{macrocode}
-%
-% \begin{variable}{\ArgumentSpecification}
-%    \begin{macrocode}
-\tl_new:N \ArgumentSpecification
-%    \end{macrocode}
-% \end{variable}
-%
-% \begin{macro}{\@@_get_arg_spec:N}
-% \begin{macro}{\@@_get_arg_spec:n}
-%   Recovering the argument specification is now trivial.
-%    \begin{macrocode}
-\cs_new_protected:Npn \@@_get_arg_spec:N #1
-  {
-    \@@_get_arg_spec:NTF #1 { }
-      { \@@_get_arg_spec_error:N #1 }
-  }
-\cs_new_protected:Npn \@@_get_arg_spec:n #1
-  {
-    \exp_args:Nc \@@_get_arg_spec:NTF
-      { environment~ \tl_to_str:n {#1} }
-      { }
-      { \@@_get_arg_spec_error:n {#1} }
-  }
-%    \end{macrocode}
-% \end{macro}
-% \end{macro}
-%
-% \begin{macro}{\@@_show_arg_spec:N}
-% \begin{macro}{\@@_show_arg_spec:n}
-%   Showing the argument specification simply means finding it and then
-%   calling the \cs{tl_show:N} function.
-%    \begin{macrocode}
-\cs_new_protected:Npn \@@_show_arg_spec:N #1
-  {
-    \@@_get_arg_spec:NTF #1
-      { \tl_show:N \ArgumentSpecification }
-      { \@@_get_arg_spec_error:N #1 }
-  }
-\cs_new_protected:Npn \@@_show_arg_spec:n #1
-  {
-    \exp_args:Nc \@@_get_arg_spec:NTF
-      { environment~ \tl_to_str:n {#1} }
-      { \tl_show:N \ArgumentSpecification }
-      { \@@_get_arg_spec_error:n {#1} }
-  }
-%    \end{macrocode}
-% \end{macro}
-% \end{macro}
-%
 % \subsection{Utilities}
 %
 % \begin{macro}{\@@_check_definable:nNT, \@@_check_definable_aux:nN}
@@ -4817,24 +4709,12 @@
     LaTeX~did~not~find~this~argument~and~will~insert~a~default~value~
     for~further~processing.
   }
-\msg_new:nnnn { cmd } { non-xparse }
-  { \str_uppercase:n #1~not~defined~using~xparse. }
-  {
-    You~have~asked~for~the~argument~specification~for~the~#1,~
-    but~this~was~not~defined~using~xparse.
-  }
 \msg_new:nnnn { cmd } { arg-split }
   { Too~many~'#1'~separators~in~argument. }
   {
     LaTeX~was~asked~to~split~the~input~'#3'~
     at~each~occurrence~of~the~separator~'#1'~into~#2~parts.~
     Too~many~separators~were~found.
-  }
-\msg_new:nnnn { cmd } { unknown }
-  { Unknown~document~#1. }
-  {
-    You~have~asked~for~the~argument~specification~for~the~#1,~
-    but~it~is~not~defined.
   }
 \msg_new:nnnn { cmd } { verbatim-nl }
   { Verbatim-like~#1~ended~by~end~of~line. }
@@ -5151,31 +5031,6 @@
 %    \begin{macrocode}
 \cs_new_eq:NN \ProcessList \tl_map_function:nN
 %    \end{macrocode}
-% \end{macro}
-%
-% \begin{macro}{\GetDocumentCommandArgSpec}
-% \begin{macro}{\GetDocumentEnvironmentArgSpec}
-% \begin{macro}{\ShowDocumentCommandArgSpec}
-% \begin{macro}{\ShowDocumentEnvironmentArgSpec}
-%   More simple mappings, with a check that the argument is a single
-%   control sequence or active character.
-%    \begin{macrocode}
-\cs_new_protected:Npn \GetDocumentCommandArgSpec #1
-  {
-    \@@_check_definable:nNT {#1} \GetDocumentCommandArgSpec
-      { \@@_get_arg_spec:N #1 }
-  }
-\cs_new_eq:NN \GetDocumentEnvironmentArgSpec \@@_get_arg_spec:n
-\cs_new_protected:Npn \ShowDocumentCommandArgSpec #1
-  {
-    \@@_check_definable:nNT {#1} \ShowDocumentCommandArgSpec
-      { \@@_show_arg_spec:N #1 }
-  }
-\cs_new_eq:NN \ShowDocumentEnvironmentArgSpec \@@_show_arg_spec:n
-%    \end{macrocode}
-% \end{macro}
-% \end{macro}
-% \end{macro}
 % \end{macro}
 %
 % Finally as promised, restore \cs{__kernel_chk_if_free_cs:N}:

--- a/base/testfiles-ltcmd/ltcmd004.luatex.tlg
+++ b/base/testfiles-ltcmd/ltcmd004.luatex.tlg
@@ -210,312 +210,12 @@ TEST 8: Stripping braces in optional args
 ([{bar}])(baz)
 ============================================================
 ============================================================
-TEST 9: Get and show argument spec
-============================================================
-||
-> \ArgumentSpecification=.
-<recently read> }
-l. ...  }
-||
-> \ArgumentSpecification=.
-<recently read> }
-l. ...  }
-============================================================
-============================================================
-TEST 10: First argument must be a command
-============================================================
-! LaTeX cmd Error: First argument of '\DeclareDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\DeclareDocumentCommand' should be the document command
-that will be defined. The provided argument '\foo !' contains more than one
-token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\NewDocumentCommand' must be a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\NewDocumentCommand' should be the document command
-that will be defined. The provided argument '\foo !' contains more than one
-token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\RenewDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\RenewDocumentCommand' should be the document command
-that will be defined. The provided argument '\foo !' contains more than one
-token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\ProvideDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\ProvideDocumentCommand' should be the document command
-that will be defined. The provided argument '\foo !' contains more than one
-token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\DeclareExpandableDocumentCommand' must
-(cmd)              be a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\DeclareExpandableDocumentCommand' should be the
-document command that will be defined. The provided argument '\foo !' contains
-more than one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\NewExpandableDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\NewExpandableDocumentCommand' should be the document
-command that will be defined. The provided argument '\foo !' contains more
-than one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\RenewExpandableDocumentCommand' must be
-(cmd)              a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\RenewExpandableDocumentCommand' should be the document
-command that will be defined. The provided argument '\foo !' contains more
-than one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\ProvideExpandableDocumentCommand' must
-(cmd)              be a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\ProvideExpandableDocumentCommand' should be the
-document command that will be defined. The provided argument '\foo !' contains
-more than one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\GetDocumentCommandArgSpec' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\GetDocumentCommandArgSpec' should be the document
-command that will be defined. The provided argument '\foo !' contains more
-than one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\ShowDocumentCommandArgSpec' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\ShowDocumentCommandArgSpec' should be the document
-command that will be defined. The provided argument '\foo !' contains more
-than one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\DeclareDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\DeclareDocumentCommand' should be the document command
-that will be defined. The provided argument 'foo' contains more than one
-token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\NewDocumentCommand' must be a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\NewDocumentCommand' should be the document command
-that will be defined. The provided argument 'foo' contains more than one
-token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\RenewDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\RenewDocumentCommand' should be the document command
-that will be defined. The provided argument 'foo' contains more than one
-token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\ProvideDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\ProvideDocumentCommand' should be the document command
-that will be defined. The provided argument 'foo' contains more than one
-token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\DeclareExpandableDocumentCommand' must
-(cmd)              be a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\DeclareExpandableDocumentCommand' should be the
-document command that will be defined. The provided argument 'foo' contains
-more than one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\NewExpandableDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\NewExpandableDocumentCommand' should be the document
-command that will be defined. The provided argument 'foo' contains more than
-one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\RenewExpandableDocumentCommand' must be
-(cmd)              a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\RenewExpandableDocumentCommand' should be the document
-command that will be defined. The provided argument 'foo' contains more than
-one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\ProvideExpandableDocumentCommand' must
-(cmd)              be a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\ProvideExpandableDocumentCommand' should be the
-document command that will be defined. The provided argument 'foo' contains
-more than one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\GetDocumentCommandArgSpec' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\GetDocumentCommandArgSpec' should be the document
-command that will be defined. The provided argument 'foo' contains more than
-one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\ShowDocumentCommandArgSpec' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\ShowDocumentCommandArgSpec' should be the document
-command that will be defined. The provided argument 'foo' contains more than
-one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\DeclareDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\DeclareDocumentCommand' should be the document command
-that will be defined. The provided argument '##' is a character. Perhaps a
-backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\NewDocumentCommand' must be a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\NewDocumentCommand' should be the document command
-that will be defined. The provided argument '##' is a character. Perhaps a
-backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\RenewDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\RenewDocumentCommand' should be the document command
-that will be defined. The provided argument '##' is a character. Perhaps a
-backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\ProvideDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\ProvideDocumentCommand' should be the document command
-that will be defined. The provided argument '##' is a character. Perhaps a
-backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\DeclareExpandableDocumentCommand' must
-(cmd)              be a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\DeclareExpandableDocumentCommand' should be the
-document command that will be defined. The provided argument '##' is a
-character. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\NewExpandableDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\NewExpandableDocumentCommand' should be the document
-command that will be defined. The provided argument '##' is a character.
-Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\RenewExpandableDocumentCommand' must be
-(cmd)              a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\RenewExpandableDocumentCommand' should be the document
-command that will be defined. The provided argument '##' is a character.
-Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\ProvideExpandableDocumentCommand' must
-(cmd)              be a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\ProvideExpandableDocumentCommand' should be the
-document command that will be defined. The provided argument '##' is a
-character. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\GetDocumentCommandArgSpec' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\GetDocumentCommandArgSpec' should be the document
-command that will be defined. The provided argument '##' is a character.
-Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\ShowDocumentCommandArgSpec' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\ShowDocumentCommandArgSpec' should be the document
-command that will be defined. The provided argument '##' is a character.
-Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: Command '\?' already defined.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-You have used \NewDocumentCommand with a command that already has a
-definition.
-The existing definition of '\?' will not be altered.
-! LaTeX cmd Error: Command '\?' already defined.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-You have used \NewExpandableDocumentCommand with a command that already has a
-definition.
-The existing definition of '\?' will not be altered.
-> \ArgumentSpecification=m.
-<recently read> }
-l. ...  }
-============================================================
-============================================================
-TEST 11: SplitList
+TEST 9: SplitList
 ============================================================
 > {a(b}.
 ============================================================
 ============================================================
-TEST 12: Defaults referring to other arguments
+TEST 10: Defaults referring to other arguments
 ============================================================
 (walk,walked,walked)
 (find,found,found)
@@ -531,7 +231,7 @@ TEST 12: Defaults referring to other arguments
 {\A }{\B }|{{\A }{\B }}{\D }|\E 
 ============================================================
 ============================================================
-TEST 13: Test ## in expandable argument specification
+TEST 11: Test ## in expandable argument specification
 ============================================================
 ! Use of \??? doesn't match its definition.
 <argument> \???  
@@ -547,7 +247,7 @@ followed by the required stuff, so I'm ignoring it.
 1|\BooleanTrue |##|2##
 ============================================================
 ============================================================
-TEST 14: Refer to other args (expandable)
+TEST 12: Refer to other args (expandable)
 ============================================================
 ! Use of \??? doesn't match its definition.
 <argument> \???  
@@ -573,7 +273,7 @@ followed by the required stuff, so I'm ignoring it.
 \A 
 ============================================================
 ============================================================
-TEST 15: Bad arguments
+TEST 13: Bad arguments
 ============================================================
 ! LaTeX cmd Error: Invalid argument type 'abc' in command '\foo'.
 For immediate help type H <return>.
@@ -625,7 +325,7 @@ LaTeX will ignore this entire definition.
 undefined
 ============================================================
 ============================================================
-TEST 16: Optional+mandatory with same delimiter
+TEST 14: Optional+mandatory with same delimiter
 ============================================================
 LaTeX cmd Warning: Optional and mandatory argument with same delimiter '['.
 (cmd)              
@@ -703,7 +403,7 @@ LaTeX cmd Warning: Optional and mandatory argument with same delimiter '_'.
 |{-NoValue-}{-NoValue-}|\BooleanTrue |a|
 ============================================================
 ============================================================
-TEST 17: par in short expandable
+TEST 15: par in short expandable
 ============================================================
 Runaway argument?
 \ERROR 
@@ -728,13 +428,13 @@ My plan is to forget the whole thing and hope for the best.
 \par 
 ============================================================
 ============================================================
-TEST 18: Environments and expansion
+TEST 16: Environments and expansion
 ============================================================
 \A \B \C 
 \A \B \C 
 ============================================================
 ============================================================
-TEST 19: Expandable r type
+TEST 17: Expandable r type
 ============================================================
 LaTeX cmd Warning: Optional and mandatory argument with same delimiter '['.
 (cmd)              
@@ -748,7 +448,7 @@ LaTeX cmd Warning: Optional and mandatory argument with same delimiter '['.
 |a|b|
 ============================================================
 ============================================================
-TEST 20: Expandable e-type argument definitions
+TEST 18: Expandable e-type argument definitions
 ============================================================
 ({-NoValue-}{-NoValue-})(\the re)
 ({\u p}{-NoValue-})(\he re)
@@ -769,7 +469,7 @@ TEST 20: Expandable e-type argument definitions
 ({\B }{\A })(\C )(\D )
 ============================================================
 ============================================================
-TEST 21: Long status of t-type ignored
+TEST 19: Long status of t-type ignored
 ============================================================
 |\BooleanTrue |\BooleanTrue |\par |\par |
 |\BooleanFalse |\BooleanTrue |-NoValue-|\par \A |
@@ -785,31 +485,31 @@ My plan is to forget the whole thing and hope for the best.
 |\BooleanFalse |\BooleanTrue |[\A ]|\B |
 ============================================================
 ============================================================
-TEST 22: Same expandable command with/without defaults
+TEST 20: Same expandable command with/without defaults
 ============================================================
 |a|b|{c}
 |b|c|
 ============================================================
 ============================================================
-TEST 23: Wrongly undefining an xparse command
+TEST 21: Wrongly undefining an xparse command
 ============================================================
 LaTeX cmd Warning: The command '\foo' was undefined but not the associated
 (cmd)              commands '\foo code' and/or '\foo defaults'. Maybe you
 (cmd)              tried using \let. This may lead to an infinite loop.
 ============================================================
 ============================================================
-TEST 24: NoValue passed to another command
+TEST 22: NoValue passed to another command
 ============================================================
 |-NoValue-|B|C|
 ============================================================
 ============================================================
-TEST 25: Two processors
+TEST 23: Two processors
 ============================================================
 Defining \CountArg on line ...
 |2|{5}|
 ============================================================
 ============================================================
-TEST 26: Non-character token delimiters
+TEST 24: Non-character token delimiters
 ============================================================
 abc
 def
@@ -827,7 +527,7 @@ abc/-NoValue-
 -NoValue-/something
 ============================================================
 ============================================================
-TEST 27: Non-character delimiters: delimiters with the same definition
+TEST 25: Non-character delimiters: delimiters with the same definition
 ============================================================
 (abc)
 (-NoValue-)
@@ -847,7 +547,7 @@ Removed: (\){r})
 (l|r)
 ============================================================
 ============================================================
-TEST 28: Non-character delimiters: delimiters \let to the same token
+TEST 26: Non-character delimiters: delimiters \let to the same token
 ============================================================
 (abc)
 (-NoValue-)
@@ -867,7 +567,7 @@ Removed: (\){r})
 (l|r)
 ============================================================
 ============================================================
-TEST 29: Non-character delimiters: forbidden delimiters
+TEST 27: Non-character delimiters: forbidden delimiters
 ============================================================
 ! LaTeX cmd Error: Argument delimiter '\(' invalid in command '\foo'.
 For immediate help type H <return>.
@@ -924,7 +624,7 @@ LaTeX will ignore this entire definition.
 (abc)
 ============================================================
 ============================================================
-TEST 30: delimited commands in alignments
+TEST 28: delimited commands in alignments
 ============================================================
 A x y&z
 B x yXz
@@ -933,7 +633,7 @@ D x yXz
 E x y&z
 ============================================================
 ============================================================
-TEST 31: IfBoolean multi token
+TEST 29: IfBoolean multi token
 ============================================================
 ! Use of \??? doesn't match its definition.
 <argument> \???  
@@ -963,13 +663,13 @@ followed by the required stuff, so I'm ignoring it.
 FALSE
 ============================================================
 ============================================================
-TEST 32: Processor spaces
+TEST 30: Processor spaces
 ============================================================
 |{a}{bcd}|
 > \box_wd:N \l_tmpa_box =0.0pt.
 ============================================================
 ============================================================
-TEST 33: Processor depending on other argument
+TEST 31: Processor depending on other argument
 ============================================================
 |{a}{bcd;e}|1|
 |{a,bcd}{e}|1|

--- a/base/testfiles-ltcmd/ltcmd004.lvt
+++ b/base/testfiles-ltcmd/ltcmd004.lvt
@@ -154,69 +154,6 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\TEST { Get~and~show~argument~spec }
-  {
-    \OMIT
-    \DeclareDocumentCommand { \null } { } { }
-    % Disabled: test requires deprecated xparse.sty
-    % \DeclareDocumentCommand { \foo } { >{\SplitList{;}} m +o g } { }
-    \DeclareDocumentEnvironment { nullenv } { } { } { }
-    % \DeclareDocumentEnvironment { fooenv } { v D{$}{$} l u{!} } { } { }
-    \TIMO
-    \GetDocumentCommandArgSpec { \null } \TYPE { | \ArgumentSpecification | }
-    \ShowDocumentCommandArgSpec { \null }
-    % \GetDocumentCommandArgSpec { \foo } \TYPE { | \ArgumentSpecification | }
-    % \ShowDocumentCommandArgSpec { \foo }
-    \GetDocumentEnvironmentArgSpec { nullenv } \TYPE { | \ArgumentSpecification | }
-    \ShowDocumentEnvironmentArgSpec { nullenv }
-    % \GetDocumentEnvironmentArgSpec { fooenv } \TYPE { | \ArgumentSpecification | }
-    % \ShowDocumentEnvironmentArgSpec { fooenv }
-  }
-
-\TEST { First~argument~must~be~a~command }
-  {
-    \DeclareDocumentCommand           { \foo! } { x } { y }
-    \NewDocumentCommand               { \foo! } { x } { y }
-    \RenewDocumentCommand             { \foo! } { x } { y }
-    \ProvideDocumentCommand           { \foo! } { x } { y }
-    \DeclareExpandableDocumentCommand { \foo! } { x } { y }
-    \NewExpandableDocumentCommand     { \foo! } { x } { y }
-    \RenewExpandableDocumentCommand   { \foo! } { x } { y }
-    \ProvideExpandableDocumentCommand { \foo! } { x } { y }
-    \GetDocumentCommandArgSpec        { \foo! }
-    \ShowDocumentCommandArgSpec       { \foo! }
-    \DeclareDocumentCommand           { foo } { x } { y }
-    \NewDocumentCommand               { foo } { x } { y }
-    \RenewDocumentCommand             { foo } { x } { y }
-    \ProvideDocumentCommand           { foo } { x } { y }
-    \DeclareExpandableDocumentCommand { foo } { x } { y }
-    \NewExpandableDocumentCommand     { foo } { x } { y }
-    \RenewExpandableDocumentCommand   { foo } { x } { y }
-    \ProvideExpandableDocumentCommand { foo } { x } { y }
-    \GetDocumentCommandArgSpec        { foo }
-    \ShowDocumentCommandArgSpec       { foo }
-    \DeclareDocumentCommand           { # } { x } { y }
-    \NewDocumentCommand               { # } { x } { y }
-    \RenewDocumentCommand             { # } { x } { y }
-    \ProvideDocumentCommand           { # } { x } { y }
-    \DeclareExpandableDocumentCommand { # } { x } { y }
-    \NewExpandableDocumentCommand     { # } { x } { y }
-    \RenewExpandableDocumentCommand   { # } { x } { y }
-    \ProvideExpandableDocumentCommand { # } { x } { y }
-    \GetDocumentCommandArgSpec        { # }
-    \ShowDocumentCommandArgSpec       { # }
-    \DeclareDocumentCommand           { ~\?~ } { m } { y }
-    \NewDocumentCommand               { ~\?~ } { m } { y }
-    \RenewDocumentCommand             { ~\?~ } { m } { y }
-    \ProvideDocumentCommand           { ~\?~ } { m } { y }
-    \DeclareExpandableDocumentCommand { ~\?~ } { m } { y }
-    \NewExpandableDocumentCommand     { ~\?~ } { m } { y }
-    \RenewExpandableDocumentCommand   { ~\?~ } { m } { y }
-    \ProvideExpandableDocumentCommand { ~\?~ } { m } { y }
-    \GetDocumentCommandArgSpec        { ~\?~ }
-    \ShowDocumentCommandArgSpec       { ~\?~ }
-  }
-
 \TEST { SplitList }
   {
     \DeclareDocumentCommand { \foo } { > { \SplitList {)||(\BOOM\c_false_bool} } m } { \tl_log:n {#1} }

--- a/base/testfiles-ltcmd/ltcmd004.tlg
+++ b/base/testfiles-ltcmd/ltcmd004.tlg
@@ -210,312 +210,12 @@ TEST 8: Stripping braces in optional args
 ([{bar}])(baz)
 ============================================================
 ============================================================
-TEST 9: Get and show argument spec
-============================================================
-||
-> \ArgumentSpecification=.
-<recently read> }
-l. ...  }
-||
-> \ArgumentSpecification=.
-<recently read> }
-l. ...  }
-============================================================
-============================================================
-TEST 10: First argument must be a command
-============================================================
-! LaTeX cmd Error: First argument of '\DeclareDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\DeclareDocumentCommand' should be the document command
-that will be defined. The provided argument '\foo !' contains more than one
-token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\NewDocumentCommand' must be a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\NewDocumentCommand' should be the document command
-that will be defined. The provided argument '\foo !' contains more than one
-token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\RenewDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\RenewDocumentCommand' should be the document command
-that will be defined. The provided argument '\foo !' contains more than one
-token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\ProvideDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\ProvideDocumentCommand' should be the document command
-that will be defined. The provided argument '\foo !' contains more than one
-token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\DeclareExpandableDocumentCommand' must
-(cmd)              be a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\DeclareExpandableDocumentCommand' should be the
-document command that will be defined. The provided argument '\foo !' contains
-more than one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\NewExpandableDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\NewExpandableDocumentCommand' should be the document
-command that will be defined. The provided argument '\foo !' contains more
-than one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\RenewExpandableDocumentCommand' must be
-(cmd)              a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\RenewExpandableDocumentCommand' should be the document
-command that will be defined. The provided argument '\foo !' contains more
-than one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\ProvideExpandableDocumentCommand' must
-(cmd)              be a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\ProvideExpandableDocumentCommand' should be the
-document command that will be defined. The provided argument '\foo !' contains
-more than one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\GetDocumentCommandArgSpec' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\GetDocumentCommandArgSpec' should be the document
-command that will be defined. The provided argument '\foo !' contains more
-than one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\ShowDocumentCommandArgSpec' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\ShowDocumentCommandArgSpec' should be the document
-command that will be defined. The provided argument '\foo !' contains more
-than one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\DeclareDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\DeclareDocumentCommand' should be the document command
-that will be defined. The provided argument 'foo' contains more than one
-token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\NewDocumentCommand' must be a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\NewDocumentCommand' should be the document command
-that will be defined. The provided argument 'foo' contains more than one
-token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\RenewDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\RenewDocumentCommand' should be the document command
-that will be defined. The provided argument 'foo' contains more than one
-token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\ProvideDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\ProvideDocumentCommand' should be the document command
-that will be defined. The provided argument 'foo' contains more than one
-token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\DeclareExpandableDocumentCommand' must
-(cmd)              be a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\DeclareExpandableDocumentCommand' should be the
-document command that will be defined. The provided argument 'foo' contains
-more than one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\NewExpandableDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\NewExpandableDocumentCommand' should be the document
-command that will be defined. The provided argument 'foo' contains more than
-one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\RenewExpandableDocumentCommand' must be
-(cmd)              a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\RenewExpandableDocumentCommand' should be the document
-command that will be defined. The provided argument 'foo' contains more than
-one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\ProvideExpandableDocumentCommand' must
-(cmd)              be a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\ProvideExpandableDocumentCommand' should be the
-document command that will be defined. The provided argument 'foo' contains
-more than one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\GetDocumentCommandArgSpec' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\GetDocumentCommandArgSpec' should be the document
-command that will be defined. The provided argument 'foo' contains more than
-one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\ShowDocumentCommandArgSpec' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\ShowDocumentCommandArgSpec' should be the document
-command that will be defined. The provided argument 'foo' contains more than
-one token. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\DeclareDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\DeclareDocumentCommand' should be the document command
-that will be defined. The provided argument '##' is a character. Perhaps a
-backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\NewDocumentCommand' must be a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\NewDocumentCommand' should be the document command
-that will be defined. The provided argument '##' is a character. Perhaps a
-backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\RenewDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\RenewDocumentCommand' should be the document command
-that will be defined. The provided argument '##' is a character. Perhaps a
-backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\ProvideDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\ProvideDocumentCommand' should be the document command
-that will be defined. The provided argument '##' is a character. Perhaps a
-backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\DeclareExpandableDocumentCommand' must
-(cmd)              be a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\DeclareExpandableDocumentCommand' should be the
-document command that will be defined. The provided argument '##' is a
-character. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\NewExpandableDocumentCommand' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\NewExpandableDocumentCommand' should be the document
-command that will be defined. The provided argument '##' is a character.
-Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\RenewExpandableDocumentCommand' must be
-(cmd)              a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\RenewExpandableDocumentCommand' should be the document
-command that will be defined. The provided argument '##' is a character.
-Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\ProvideExpandableDocumentCommand' must
-(cmd)              be a command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\ProvideExpandableDocumentCommand' should be the
-document command that will be defined. The provided argument '##' is a
-character. Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\GetDocumentCommandArgSpec' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\GetDocumentCommandArgSpec' should be the document
-command that will be defined. The provided argument '##' is a character.
-Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: First argument of '\ShowDocumentCommandArgSpec' must be a
-(cmd)              command.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-The first argument of '\ShowDocumentCommandArgSpec' should be the document
-command that will be defined. The provided argument '##' is a character.
-Perhaps a backslash is missing?
-LaTeX will ignore this entire definition.
-! LaTeX cmd Error: Command '\?' already defined.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-You have used \NewDocumentCommand with a command that already has a
-definition.
-The existing definition of '\?' will not be altered.
-! LaTeX cmd Error: Command '\?' already defined.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-You have used \NewExpandableDocumentCommand with a command that already has a
-definition.
-The existing definition of '\?' will not be altered.
-> \ArgumentSpecification=m.
-<recently read> }
-l. ...  }
-============================================================
-============================================================
-TEST 11: SplitList
+TEST 9: SplitList
 ============================================================
 > {a(b}.
 ============================================================
 ============================================================
-TEST 12: Defaults referring to other arguments
+TEST 10: Defaults referring to other arguments
 ============================================================
 (walk,walked,walked)
 (find,found,found)
@@ -531,7 +231,7 @@ TEST 12: Defaults referring to other arguments
 {\A }{\B }|{{\A }{\B }}{\D }|\E 
 ============================================================
 ============================================================
-TEST 13: Test ## in expandable argument specification
+TEST 11: Test ## in expandable argument specification
 ============================================================
 ! Use of \??? doesn't match its definition.
 <argument> \???  
@@ -547,7 +247,7 @@ followed by the required stuff, so I'm ignoring it.
 1|\BooleanTrue |##|2##
 ============================================================
 ============================================================
-TEST 14: Refer to other args (expandable)
+TEST 12: Refer to other args (expandable)
 ============================================================
 ! Use of \??? doesn't match its definition.
 <argument> \???  
@@ -573,7 +273,7 @@ followed by the required stuff, so I'm ignoring it.
 \A 
 ============================================================
 ============================================================
-TEST 15: Bad arguments
+TEST 13: Bad arguments
 ============================================================
 ! LaTeX cmd Error: Invalid argument type 'abc' in command '\foo'.
 For immediate help type H <return>.
@@ -625,7 +325,7 @@ LaTeX will ignore this entire definition.
 undefined
 ============================================================
 ============================================================
-TEST 16: Optional+mandatory with same delimiter
+TEST 14: Optional+mandatory with same delimiter
 ============================================================
 LaTeX cmd Warning: Optional and mandatory argument with same delimiter '['.
 (cmd)              
@@ -703,7 +403,7 @@ LaTeX cmd Warning: Optional and mandatory argument with same delimiter '_'.
 |{-NoValue-}{-NoValue-}|\BooleanTrue |a|
 ============================================================
 ============================================================
-TEST 17: par in short expandable
+TEST 15: par in short expandable
 ============================================================
 Runaway argument?
 \ERROR 
@@ -728,13 +428,13 @@ My plan is to forget the whole thing and hope for the best.
 \par 
 ============================================================
 ============================================================
-TEST 18: Environments and expansion
+TEST 16: Environments and expansion
 ============================================================
 \A \B \C 
 \A \B \C 
 ============================================================
 ============================================================
-TEST 19: Expandable r type
+TEST 17: Expandable r type
 ============================================================
 LaTeX cmd Warning: Optional and mandatory argument with same delimiter '['.
 (cmd)              
@@ -748,7 +448,7 @@ LaTeX cmd Warning: Optional and mandatory argument with same delimiter '['.
 |a|b|
 ============================================================
 ============================================================
-TEST 20: Expandable e-type argument definitions
+TEST 18: Expandable e-type argument definitions
 ============================================================
 ({-NoValue-}{-NoValue-})(\the re)
 ({\u p}{-NoValue-})(\he re)
@@ -769,7 +469,7 @@ TEST 20: Expandable e-type argument definitions
 ({\B }{\A })(\C )(\D )
 ============================================================
 ============================================================
-TEST 21: Long status of t-type ignored
+TEST 19: Long status of t-type ignored
 ============================================================
 |\BooleanTrue |\BooleanTrue |\par |\par |
 |\BooleanFalse |\BooleanTrue |-NoValue-|\par \A |
@@ -785,31 +485,31 @@ My plan is to forget the whole thing and hope for the best.
 |\BooleanFalse |\BooleanTrue |[\A ]|\B |
 ============================================================
 ============================================================
-TEST 22: Same expandable command with/without defaults
+TEST 20: Same expandable command with/without defaults
 ============================================================
 |a|b|{c}
 |b|c|
 ============================================================
 ============================================================
-TEST 23: Wrongly undefining an xparse command
+TEST 21: Wrongly undefining an xparse command
 ============================================================
 LaTeX cmd Warning: The command '\foo' was undefined but not the associated
 (cmd)              commands '\foo code' and/or '\foo defaults'. Maybe you
 (cmd)              tried using \let. This may lead to an infinite loop.
 ============================================================
 ============================================================
-TEST 24: NoValue passed to another command
+TEST 22: NoValue passed to another command
 ============================================================
 |-NoValue-|B|C|
 ============================================================
 ============================================================
-TEST 25: Two processors
+TEST 23: Two processors
 ============================================================
 Defining \CountArg on line ...
 |2|{5}|
 ============================================================
 ============================================================
-TEST 26: Non-character token delimiters
+TEST 24: Non-character token delimiters
 ============================================================
 abc
 def
@@ -827,7 +527,7 @@ abc/-NoValue-
 -NoValue-/something
 ============================================================
 ============================================================
-TEST 27: Non-character delimiters: delimiters with the same definition
+TEST 25: Non-character delimiters: delimiters with the same definition
 ============================================================
 (abc)
 (-NoValue-)
@@ -847,7 +547,7 @@ Removed: (\){r})
 (l|r)
 ============================================================
 ============================================================
-TEST 28: Non-character delimiters: delimiters \let to the same token
+TEST 26: Non-character delimiters: delimiters \let to the same token
 ============================================================
 (abc)
 (-NoValue-)
@@ -867,7 +567,7 @@ Removed: (\){r})
 (l|r)
 ============================================================
 ============================================================
-TEST 29: Non-character delimiters: forbidden delimiters
+TEST 27: Non-character delimiters: forbidden delimiters
 ============================================================
 ! LaTeX cmd Error: Argument delimiter '\(' invalid in command '\foo'.
 For immediate help type H <return>.
@@ -924,7 +624,7 @@ LaTeX will ignore this entire definition.
 (abc)
 ============================================================
 ============================================================
-TEST 30: delimited commands in alignments
+TEST 28: delimited commands in alignments
 ============================================================
 A x y&z
 B x yXz
@@ -933,7 +633,7 @@ D x yXz
 E x y&z
 ============================================================
 ============================================================
-TEST 31: IfBoolean multi token
+TEST 29: IfBoolean multi token
 ============================================================
 ! Use of \??? doesn't match its definition.
 <argument> \???  
@@ -963,13 +663,13 @@ followed by the required stuff, so I'm ignoring it.
 FALSE
 ============================================================
 ============================================================
-TEST 32: Processor spaces
+TEST 30: Processor spaces
 ============================================================
 |{a}{bcd}|
 > \box_wd:N \l_tmpa_box =0.0pt.
 ============================================================
 ============================================================
-TEST 33: Processor depending on other argument
+TEST 31: Processor depending on other argument
 ============================================================
 |{a}{bcd;e}|1|
 |{a,bcd}{e}|1|

--- a/base/testfiles-ltcmd/ltcmd005.luatex.tlg
+++ b/base/testfiles-ltcmd/ltcmd005.luatex.tlg
@@ -94,17 +94,7 @@ My plan is to forget the whole thing and hope for the best.
 |a|\BooleanTrue |\BooleanTrue | \c_space_token |
 ============================================================
 ============================================================
-TEST 3: Signature normalized or not
-============================================================
-> \ArgumentSpecification=!+o.
-<recently read> }
-l. ...  }
-> \ArgumentSpecification=+!o.
-<recently read> }
-l. ...  }
-============================================================
-============================================================
-TEST 4: Environment body valid
+TEST 3: Environment body valid
 ============================================================
 ============================================================
 |...|{\begin {any} \begin {unbalanced} \end {environments} \begin {provided}}{\end {nesting} \end {works} \begin {out} \end {!}}|
@@ -112,7 +102,7 @@ TEST 4: Environment body valid
 |-NoValue-| [...] \begin {any} \begin {unbalanced} \end {environments} \begin {provided} \end {nesting} \end {works} \begin {out} \end {!} |
 |-NoValue-|
 ============================================================
-TEST 5: Body invalid
+TEST 4: Body invalid
 ============================================================
 |-NoValue-|{}|
 ! LaTeX Error: \begin{env1} on input line ... ended by \end{env2}.
@@ -148,7 +138,7 @@ specification. This is not allowed.
 LaTeX will ignore this entire definition.
 ============================================================
 ============================================================
-TEST 6: Invalid signatures
+TEST 5: Invalid signatures
 ============================================================
 ! LaTeX cmd Error: Bad argument specification 'O' for command '\testA'.
 For immediate help type H <return>.
@@ -226,7 +216,7 @@ The letter 'X' does not specify a known argument type.
 LaTeX will ignore this entire definition.
 ============================================================
 ============================================================
-TEST 7: Already or not yet defined
+TEST 6: Already or not yet defined
 ============================================================
 ! LaTeX cmd Error: Command '\space' already defined.
 For immediate help type H <return>.
@@ -259,7 +249,7 @@ defined.
 LaTeX will ignore this entire definition.
 ============================================================
 ============================================================
-TEST 8: Not definable/multi-char
+TEST 7: Not definable/multi-char
 ============================================================
 ! LaTeX cmd Error: First argument of '\NewDocumentCommand' must be a command.
 For immediate help type H <return>.
@@ -312,7 +302,7 @@ followed by the required stuff, so I'm ignoring it.
 FALSE
 ============================================================
 ============================================================
-TEST 9: Invalid signatures for expandable commands
+TEST 8: Invalid signatures for expandable commands
 ============================================================
 ! LaTeX cmd Error: Bad argument specification 'mo' for \testA.
 For immediate help type H <return>.
@@ -343,37 +333,7 @@ expandable ones.
 LaTeX will ignore this entire definition.
 ============================================================
 ============================================================
-TEST 10: Arg spec
-============================================================
-! LaTeX cmd Error: Command '\space' not defined using xparse.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-You have asked for the argument specification for the command '\space', but
-this was not defined using xparse.
-macro:->
-! LaTeX cmd Error: Unknown document command '\undefined'.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-You have asked for the argument specification for the command '\undefined',
-but it is not defined.
-! LaTeX cmd Error: Environment 'verbatim' not defined using xparse.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-You have asked for the argument specification for the environment 'verbatim',
-but this was not defined using xparse.
-macro:->
-! LaTeX cmd Error: Unknown document environment 'undefined'.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-You have asked for the argument specification for the environment 'undefined',
-but it is not defined.
-============================================================
-============================================================
-TEST 11: Run-time errors
+TEST 9: Run-time errors
 ============================================================
 ! LaTeX cmd Error: Circular dependency in defaults of command '\testA'.
 For immediate help type H <return>.

--- a/base/testfiles-ltcmd/ltcmd005.lvt
+++ b/base/testfiles-ltcmd/ltcmd005.lvt
@@ -57,16 +57,6 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\TEST { Signature~normalized~or~not }
-  {
-    \NewDocumentCommand { \testC } { ! + o } { }
-    \ShowDocumentCommandArgSpec \testC
-    \NewDocumentCommand { \testD } { + ! o } { }
-    \ShowDocumentCommandArgSpec \testD
-  }
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
 % The following tests are outside to allow \ExplSyntaxOff and \obeylines
 \TEST { Environment~body~valid } { }
 
@@ -170,18 +160,6 @@
     % \NewExpandableDocumentCommand { \testA } { o l } { }
     % \NewExpandableDocumentCommand { \testA } { o u { + } } { }
     \NewExpandableDocumentCommand { \testA } { >{\TrimSpaces} m } { }
-  }
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-\TEST { Arg~spec }
-  {
-    \GetDocumentCommandArgSpec { \space }
-    \TYPE { \meaning \ArgumentSpecification }
-    \ShowDocumentCommandArgSpec { \undefined }
-    \GetDocumentEnvironmentArgSpec { verbatim }
-    \TYPE { \meaning \ArgumentSpecification }
-    \ShowDocumentEnvironmentArgSpec { undefined }
   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/base/testfiles-ltcmd/ltcmd005.tlg
+++ b/base/testfiles-ltcmd/ltcmd005.tlg
@@ -94,17 +94,7 @@ My plan is to forget the whole thing and hope for the best.
 |a|\BooleanTrue |\BooleanTrue | \c_space_token |
 ============================================================
 ============================================================
-TEST 3: Signature normalized or not
-============================================================
-> \ArgumentSpecification=!+o.
-<recently read> }
-l. ...  }
-> \ArgumentSpecification=+!o.
-<recently read> }
-l. ...  }
-============================================================
-============================================================
-TEST 4: Environment body valid
+TEST 3: Environment body valid
 ============================================================
 ============================================================
 |...|{\begin {any} \begin {unbalanced} \end {environments} \begin {provided}}{\end {nesting} \end {works} \begin {out} \end {!}}|
@@ -112,7 +102,7 @@ TEST 4: Environment body valid
 |-NoValue-| [...] \begin {any} \begin {unbalanced} \end {environments} \begin {provided} \end {nesting} \end {works} \begin {out} \end {!} |
 |-NoValue-|
 ============================================================
-TEST 5: Body invalid
+TEST 4: Body invalid
 ============================================================
 |-NoValue-|{}|
 ! LaTeX Error: \begin{env1} on input line ... ended by \end{env2}.
@@ -148,7 +138,7 @@ specification. This is not allowed.
 LaTeX will ignore this entire definition.
 ============================================================
 ============================================================
-TEST 6: Invalid signatures
+TEST 5: Invalid signatures
 ============================================================
 ! LaTeX cmd Error: Bad argument specification 'O' for command '\testA'.
 For immediate help type H <return>.
@@ -226,7 +216,7 @@ The letter 'X' does not specify a known argument type.
 LaTeX will ignore this entire definition.
 ============================================================
 ============================================================
-TEST 7: Already or not yet defined
+TEST 6: Already or not yet defined
 ============================================================
 ! LaTeX cmd Error: Command '\space' already defined.
 For immediate help type H <return>.
@@ -259,7 +249,7 @@ defined.
 LaTeX will ignore this entire definition.
 ============================================================
 ============================================================
-TEST 8: Not definable/multi-char
+TEST 7: Not definable/multi-char
 ============================================================
 ! LaTeX cmd Error: First argument of '\NewDocumentCommand' must be a command.
 For immediate help type H <return>.
@@ -312,7 +302,7 @@ followed by the required stuff, so I'm ignoring it.
 FALSE
 ============================================================
 ============================================================
-TEST 9: Invalid signatures for expandable commands
+TEST 8: Invalid signatures for expandable commands
 ============================================================
 ! LaTeX cmd Error: Bad argument specification 'mo' for \testA.
 For immediate help type H <return>.
@@ -343,37 +333,7 @@ expandable ones.
 LaTeX will ignore this entire definition.
 ============================================================
 ============================================================
-TEST 10: Arg spec
-============================================================
-! LaTeX cmd Error: Command '\space' not defined using xparse.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-You have asked for the argument specification for the command '\space', but
-this was not defined using xparse.
-macro:->
-! LaTeX cmd Error: Unknown document command '\undefined'.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-You have asked for the argument specification for the command '\undefined',
-but it is not defined.
-! LaTeX cmd Error: Environment 'verbatim' not defined using xparse.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-You have asked for the argument specification for the environment 'verbatim',
-but this was not defined using xparse.
-macro:->
-! LaTeX cmd Error: Unknown document environment 'undefined'.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-You have asked for the argument specification for the environment 'undefined',
-but it is not defined.
-============================================================
-============================================================
-TEST 11: Run-time errors
+TEST 9: Run-time errors
 ============================================================
 ! LaTeX cmd Error: Circular dependency in defaults of command '\testA'.
 For immediate help type H <return>.


### PR DESCRIPTION
# Internal housekeeping

## Status of pull request

- [x] Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [x] `ltnewsX.tex` (and/or `latexchanges.tex`) updated

