### PR TITLE
Fix typos in 2e sockets

### DIFF
--- a/base/ltsockets.dtx
+++ b/base/ltsockets.dtx
@@ -908,15 +908,15 @@
 %  
 %  \begin{macro}{\socket_use:nw,\socket_use:n,\socket_use:nn,\socket_use:nnn,\socket_use:nnnn}
 %    
-%    And using it is more or less a \cs{use:c} so very lightweight. We do not add a
-%    runtime check for speed reasons!
+%    And using it is more or less a \cs{use:c} so very lightweight. We do not
+%    add a runtime check for speed reasons!
 %
 %    This command is named
 %    \cs{socket_use:nw} because we don't know how many inputs the
 %    socket has until we have looked at the socket name (in argument \verb=#1=).
-%    But, of course, the developer knows so we also  offer a few aliases \cs{socket_use:nn},
-%    etc.\ so that one can indicate the correct number of arguments
-%    (socket inputs plus one) in the L3 layer code.
+%    But, of course, the developer knows so we also offer a few aliases
+%    \cs{socket_use:nn}, etc.\ so that one can indicate the correct number of
+%    arguments (socket inputs plus one) in the L3 layer code.
 %
 %    \begin{macrocode}
 \cs_new_protected:Npn \socket_use:nw #1 {

--- a/base/ltsockets.dtx
+++ b/base/ltsockets.dtx
@@ -758,13 +758,13 @@
 %    \end{macrocode}
 %    We only support declarations on top-level.
 %    \begin{macrocode}
-        \int_compare:nNnTF \tex_currentgrouplevel:D = 0
+        \int_if_zero:nTF \tex_currentgrouplevel:D
           {
             \str_new:c { l_@@_#1_plug_str }
             \seq_new:c { l_@@_#1_plugs_seq }
             \int_const:cn { c_@@_#1_args_int } {#2}
             \socket_new_plug:nnn {#1} { noop } {}
-            \int_compare:nNnTF #2 = 1
+            \int_compare:nNnTF {#2} = 1
               {
                 \socket_new_plug:nnn {#1} { identity } {##1}
                 \socket_assign_plug:nn {#1} { identity }
@@ -797,8 +797,8 @@
         \typeout{ \@spaces current~ plug~ =~
                   \str_use:c { l_@@_#1_plug_str } }
         \typeout{ \@spaces definition~ =~
-                  \exp_args:Nc \cs_meaning:N 
-                    { _@@_#1_plug_ \str_use:c { l_@@_#1_plug_str } :w } }
+                  \cs_meaning:c
+                    { @@_#1_plug_ \str_use:c { l_@@_#1_plug_str } :w } }
         \typeout{}
       }
       {
@@ -827,7 +827,7 @@
 \cs_new_protected:Npn \socket_new_plug:nnn #1#2#3 {
   \str_if_exist:cTF { l_@@_#1_plug_str }
       {
-        \str_if_exist:cTF { @@_#1_plug_#2:w }
+        \cs_if_exist:cTF { @@_#1_plug_#2:w }
           {
             \msg_error:nnnn { socket } { plug-already-declared } {#1} {#2}
           }
@@ -858,7 +858,7 @@
 \cs_new_protected:Npn \socket_set_plug:nnn #1#2#3 {
   \str_if_exist:cTF { l_@@_#1_plug_str }
       {
-        \str_if_exist:cTF { @@_#1_plug_#2:w }
+        \cs_if_exist:cTF { @@_#1_plug_#2:w }
           {
             \cs_generate_from_arg_count:cNnn
               { @@_#1_plug_#2:w }
@@ -923,7 +923,7 @@
   \@@_debug_term:n
     { Socket~ '#1'~ containing~ plug~
       '\str_use:c { l_@@_#1_plug_str }'~ used. }
-  \use:c { _@@_#1_plug_ \str_use:c { l_@@_#1_plug_str } :w }
+  \use:c { @@_#1_plug_ \str_use:c { l_@@_#1_plug_str } :w }
 }
 %    \end{macrocode}
 %    To make code a bit more readable we also define functions that

--- a/base/ltsockets.dtx
+++ b/base/ltsockets.dtx
@@ -472,7 +472,7 @@
 %   Socket plug names have to be unique within on a per socket basis,
 %   but it is perfectly allowed (and sensible in some cases) to use
 %   the same plug name with different sockets (where based on the
-%   sockets different actions may be associated with the plug
+%   sockets' purposes, different actions may be associated with the plug
 %   name). For example \plug{noop} is a plug name declared for every
 %   socket, yet it action \enquote{grab the socket inputs and throw
 %   them away} obviously differs depending on how many inputs the

--- a/base/ltsockets.dtx
+++ b/base/ltsockets.dtx
@@ -595,7 +595,7 @@
 % 
 % \begin{function}{\UseSocket,\socket_use:nw,\socket_use:n,\socket_use:nn,\socket_use:nnn,\socket_use:nnnn}
 % \begin{syntax}
-% \cs{UseSocket}   \Arg{socket-name}
+% \cs{UseSocket}     \Arg{socket-name}
 % \cs{socket_use:nnn}\Arg{socket-name} \Arg{socket-arg\textsubscript{1}} \Arg{socket-arg\textsubscript{2}}
 % \end{syntax}
 %   Executes the socket \meta{socket-name} by retrieving the

--- a/base/ltsockets.dtx
+++ b/base/ltsockets.dtx
@@ -730,8 +730,8 @@
     \cs_gset_protected:Npx \@@_debug:n ##1
       { \bool_if:NT \g_@@_debug_bool {##1} }
     \cs_gset_protected:Npx \@@_debug_term:n ##1
-       { \bool_if:NT \g_@@_debug_bool
-           { \iow_term:x { ^^J [Sockets]~ ==>~ ##1} } }
+      { \bool_if:NT \g_@@_debug_bool
+        { \iow_term:x { ^^J [Sockets]~ ==>~ ##1} } }
   }
 %    \end{macrocode}
 %  \end{macro}
@@ -758,23 +758,23 @@
 %    \end{macrocode}
 %    We only support declarations on top-level.
 %    \begin{macrocode}
-        \int_compare:nNnTF  \tex_currentgrouplevel:D  = 0
+        \int_compare:nNnTF \tex_currentgrouplevel:D = 0
           {
             \str_new:c { l_@@_#1_plug_str }
             \seq_new:c { l_@@_#1_plugs_seq }
             \int_const:cn { c_@@_#1_args_int } {#2}
             \socket_new_plug:nnn {#1} { noop } {}
             \int_compare:nNnTF #2 = 1
-               {
-                 \socket_new_plug:nnn {#1} { identity } {##1}
-                 \socket_assign_plug:nn {#1} { identity }
-               }
-               { \socket_assign_plug:nn {#1} { noop } }
+              {
+                \socket_new_plug:nnn {#1} { identity } {##1}
+                \socket_assign_plug:nn {#1} { identity }
+              }
+              { \socket_assign_plug:nn {#1} { noop } }
             \@@_debug_term:n
-               { Socket~ '#1'~ declared~ with~ #2~ input(s) }
+              { Socket~ '#1'~ declared~ with~ #2~ input(s) }
           }
           {
-           \msg_error:nn { socket } { not-top-level }
+            \msg_error:nn { socket } { not-top-level }
           }
       }
 }
@@ -828,23 +828,23 @@
   \str_if_exist:cTF { l_@@_#1_plug_str }
       {
         \str_if_exist:cTF { @@_#1_plug_#2:w }
-           {
-             \msg_error:nnnn { socket } { plug-already-declared } {#1} {#2}
-           }
-           {
-             \cs_generate_from_arg_count:cNnn
-                { @@_#1_plug_#2:w }
-                \cs_new_protected:Npn
-                { \int_use:c { c_@@_#1_args_int } }
-                {#3}
+          {
+            \msg_error:nnnn { socket } { plug-already-declared } {#1} {#2}
+          }
+          {
+            \cs_generate_from_arg_count:cNnn
+              { @@_#1_plug_#2:w }
+              \cs_new_protected:Npn
+              { \int_use:c { c_@@_#1_args_int } }
+              {#3}
 %    \end{macrocode}
-%    This is a new declaration  so we add the name to a seq for the
+%    This is a new declaration so we add the name to a seq for the
 %    debugging info.
 %    \begin{macrocode}
-             \seq_put_right:cn { l_@@_#1_plugs_seq } {#2}
-             \@@_debug_term:n
-               { Plug~ '#2'~ for~ socket~ '#1'~ declared. }
-           }
+            \seq_put_right:cn { l_@@_#1_plugs_seq } {#2}
+            \@@_debug_term:n
+              { Plug~ '#2'~ for~ socket~ '#1'~ declared. }
+          }
       }
       {
         \msg_error:nnn { socket } { undeclared } {#1}
@@ -859,18 +859,18 @@
   \str_if_exist:cTF { l_@@_#1_plug_str }
       {
         \str_if_exist:cTF { @@_#1_plug_#2:w }
-           {
-             \cs_generate_from_arg_count:cNnn
-                { @@_#1_plug_#2:w }
-                \cs_set_protected:Npn
-                { \int_use:c { c_@@_#1_args_int } }
-                {#3}
-             \@@_debug_term:n
-               {  Plug~ '#2'~ for~ socket~ '#1'~ changed. }
-           }
-           {
-             \msg_error:nnnn { socket } { plug-undeclared } {#1} {#2}
-           }
+          {
+            \cs_generate_from_arg_count:cNnn
+              { @@_#1_plug_#2:w }
+              \cs_set_protected:Npn
+              { \int_use:c { c_@@_#1_args_int } }
+              {#3}
+            \@@_debug_term:n
+              {  Plug~ '#2'~ for~ socket~ '#1'~ changed. }
+          }
+          {
+            \msg_error:nnnn { socket } { plug-undeclared } {#1} {#2}
+          }
       }
       {
         \msg_error:nnn { socket } { undeclared } {#1}
@@ -892,8 +892,8 @@
         \cs_if_exist:cTF { @@_#1_plug_#2:w }
           {
             \@@_debug_term:n
-               {  Replacing~ plug~ '\str_use:c {l_@@_#1_plug_str }'~
-                  with~ '#2'~ in~ socket~ '#1'. }
+              { Replacing~ plug~ '\str_use:c { l_@@_#1_plug_str }'~
+                with~ '#2'~ in~ socket~ '#1'. }
             \str_set:cn { l_@@_#1_plug_str } {#2}
           }
           {
@@ -921,8 +921,8 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \socket_use:nw #1 {
   \@@_debug_term:n
-     { Socket~ '#1'~containing~ plug~
-       '\str_use:c { l_@@_#1_plug_str }'~ used. }
+    { Socket~ '#1'~ containing~ plug~
+      '\str_use:c { l_@@_#1_plug_str }'~ used. }
   \use:c { _@@_#1_plug_ \str_use:c { l_@@_#1_plug_str } :w }
 }
 %    \end{macrocode}
@@ -972,13 +972,13 @@
 \msg_new:nnnn { socket } { plug-already-declared }
     { Plug~ '#2'~ for~ socket~ '#1'~ already~ declared! }
     { You~ can't~ change~ an~ existing~ plug~ with~ \NewSocketPlug~ and~ it~
-      is~  normally~ not~ sensible~ to~ do~ so.~ Use~ the~ L3~ programming~
-      layer~  function~ \socket_set_plug:nnn~ if~ you~ really~ have~ to. }
+      is~ normally~ not~ sensible~ to~ do~ so.~ Use~ the~ L3~ programming~
+      layer~ function~ \socket_set_plug:nnn~ if~ you~ really~ have~ to. }
     
 \msg_new:nnnn { socket } { plug-undeclared }
     { Plug~ '#2'~ for~ socket~ '#1'~ undeclared! }
     { The~ plug~ name~ is~ unknown.~ Is~ the~ name~ misspelled~ or~ did~ you~
-      intend~  to~ assign~ it~ to~ a~ different~ socket? }
+      intend~ to~ assign~ it~ to~ a~ different~ socket? }
 %    \end{macrocode}
 %    
 %    \begin{macrocode}

--- a/base/ltsockets.dtx
+++ b/base/ltsockets.dtx
@@ -32,7 +32,7 @@
 %
 %    \begin{macrocode}
 \def\ltsocketsversion{0.9a}
-\def\ltsocketsdate{2023-08-05}
+\def\ltsocketsdate{2023-08-21}
 %    \end{macrocode}
 %
 %<*driver>
@@ -216,7 +216,7 @@
 % 
 % In theory, it would also be possible to use a hook, but again that is
 % basically a misuse of the concept, because in this use case there should
-% never be more that one block of code inside the hook; thus, to alter
+% never be more than one block of code inside the hook; thus, to alter
 % the processing logic one would need to set up rules that replace code
 % rather than (as intended) execute all code added to the hook.
 % 
@@ -325,7 +325,7 @@
 %      \UseSocket{foo}{hello}{world}
 % \end{verbatim}
 % produces nothing because the default plug for sockets with 2 inputs
-% is \plug{noop} (which grabs the additional arguments and thows them
+% is \plug{noop} (which grabs the additional arguments and throws them
 %   away).\footnote{If socket \socket{foo} would have been a socket with one
 %   input, then the default plug would be \plug{identity}, in which case
 %   the socket input would remain without braces and gets typeset!}
@@ -425,7 +425,7 @@
 %     \item
 %       implicit data (registers and other 2e/expl3 data stores) that
 %       the socket is allowed to make use of, with a documented description
-%       what they contain (if relevant for the task at hand---no need to
+%       of what they contain (if relevant for the task at hand---no need to
 %       describe the whole \LaTeX{} universe)
 % 
 %     \item
@@ -472,7 +472,7 @@
 %   Socket plug names have to be unique within on a per socket basis,
 %   but it is perfectly allowed (and sensible in some cases) to use
 %   the same plug name with different sockets (where based on the
-%   socket different actions may be associated with the plug
+%   sockets different actions may be associated with the plug
 %   name). For example \plug{noop} is a plug name declared for every
 %   socket, yet it action \enquote{grab the socket inputs and throw
 %   them away} obviously differs depending on how many inputs the
@@ -535,7 +535,7 @@
 % \end{syntax}
 %   Declares a new socket with name \meta{socket-name} having
 %   \meta{number-of-inputs} inputs. There is automatically a
-%   plug {noop} declared for it, which does nothing, i.e., it gobbles
+%   plug \plug{noop} declared for it, which does nothing, i.e., it gobbles
 %   the socket inputs (if any). This is made the default plug except for
 %   sockets with one input which additionally define the plug
 %   \plug{identity} and assign that as their default.
@@ -665,7 +665,7 @@
 %    The implementation of the socket mechanism should be (partially)
 %    redone and we should probably store the different code chunks in
 %    a property list so that we can have a decent \cs{ShowSocket}
-%    command the shows the available alternatives.\fmi{implement?}
+%    command that shows the available alternatives.\fmi{implement?}
 %
 %    \begin{macrocode}
 %<*2ekernel|latexrelease>


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

Some typo fixing and reindenting for `ltsockets.dtx`. Sorry I didn't catch up the review session of #1121.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] <s>Version and</s> date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
