### PR TITLE
Restore a pair of swapped changes.tex entries

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -10,14 +10,14 @@ are not part of the distribution.
       expand consistently the label/property names in the LaTeX2e commands.
 
 2023-09-13 Joseph Wright  <Joseph.Wright@latex-project.org>
-    * ltmiscen.dtx:
-      add test to \enddocument for changes in property values.
+	* ltmiscen.dtx:
+	Correct typo
 
 2023-09-05 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
 	* ltproperties.dtx: 
       First implementation of properties module
     * ltmiscen.dtx:
-      Correct typo
+      add test to \enddocument for changes in property values.
 
 2023-09-01  Joseph Wright  <Joseph.Wright@latex-project.org>
 


### PR DESCRIPTION
Commit 863340926 (Correct a typo, 2023-09-13) swapped content of its changes entry with that of commit 6a2b51036 (integrate ltproperties, 2023-09-06).

@josephwright 

**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
- Under development
[x] Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
