### PR TITLE
fix typos in lthooks.dtx

### DIFF
--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -32,7 +32,7 @@
 %
 %    \begin{macrocode}
 \def\lthooksversion{v1.1f}
-\def\lthooksdate{2023/08/11}
+\def\lthooksdate{2023/10/02}
 %    \end{macrocode}
 %
 %<*driver>

--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -795,7 +795,7 @@
 %    \end{itemize}
 %    There can only be a single relation between two labels for a
 %    given hook,
-%    i.e., a later \cs{DeclareHookrule} overwrites any previous
+%    i.e., a later \cs{DeclareHookRule} overwrites any previous
 %    declaration.
 %
 %    The \meta{hook} and \meta{label} can be specified using the
@@ -1566,8 +1566,8 @@
 %
 %    Generic hooks defined in this way are always normal hooks (i.e.,
 %    you can't implement reversed hooks this way). This is a
-%    deliberate limitation, because it speeds up the processessing
-%    conciderably.
+%    deliberate limitation, because it speeds up the processing
+%    considerably.
 %
 %
 % \subsection{Hooks with arguments}


### PR DESCRIPTION
Fixed a few small typos in `lthooks.dtx`. 
- `\cs{DeclareHookrule}` -> `\cs{DeclareHookRule}`
- `processessing` -> `processing`
- `conciderably` -> `considerably`
- Updated date