### PR TITLE
Replace quotation with quote envs for zero par indent

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,10 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
+2023-11-09 Yukai Chou  <muzimuzhi@gmail.com>
+	* clsguide-historic.tex, usrguide.tex:
+	Replace quotation with quote envs for zero para indent
+
 2023-11-07  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 	* ltcounts.dtx (subsection{Environment Counter Macros}):
 	In \newcounter do not change \the... if already defined (gh/823)

--- a/base/changes.txt
+++ b/base/changes.txt
@@ -10,6 +10,9 @@ not part of the distribution.
 	* clsguide-historic.tex, usrguide.tex:
 	Replace quotation with quote envs for zero para indent
 
+	* clsguide-historic.tex, usrguide-historic.tex
+	Mention correct source file names in license footnotes
+
 2023-11-07  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 	* ltcounts.dtx (subsection{Environment Counter Macros}):
 	In \newcounter do not change \the... if already defined (gh/823)

--- a/base/doc/clsguide-historic.tex
+++ b/base/doc/clsguide-historic.tex
@@ -34,12 +34,12 @@
 
 \title{\LaTeXe~for class and package writers --- historic version}
 
-\author{Copyright \copyright~1995--2006 The \LaTeX\ Project\\
+\author{Copyright \copyright~1995--2023 The \LaTeX\ Project\\
    All rights reserved.%
    \footnote{This file may be distributed and/or modified under the
      conditions of the \LaTeX{} Project Public License, either version 1.3c
      of this license or (at your option) any later version. See the source
-    \texttt{clsguide.tex} for full details.}%
+    \texttt{clsguide-historic.tex} for full details.}%
 }
 
 \date{09 November 2023}

--- a/base/doc/clsguide-historic.tex
+++ b/base/doc/clsguide-historic.tex
@@ -42,7 +42,7 @@
     \texttt{clsguide.tex} for full details.}%
 }
 
-\date{11 January 2023}
+\date{09 November 2023}
 
 \begin{document}
 
@@ -1481,7 +1481,7 @@ problem, \LaTeX{} provides two new commands |\MakeUppercase| and
 |\MakeLowercase| to do this.
 
 For example:
-\begin{quotation}
+\begin{quote}
 \begin{tabular}{rl}
    |\uppercase{aBcD\ae\AA\ss\OE}| & \uppercase{aBcD\ae\AA\ss\OE}\\
    |\lowercase{aBcD\ae\AA\ss\OE}| & \lowercase{aBcD\ae\AA\ss\OE}\\
@@ -1489,7 +1489,7 @@ For example:
                                       \MakeUppercase{aBcD\ae\AA\ss\OE}\\
    |\MakeLowercase{aBcD\ae\AA\ss\OE}| & \MakeLowercase{aBcD\ae\AA\ss\OE}
 \end{tabular}
-\end{quotation}
+\end{quote}
 
 The commands |\MakeUppercase| and |\MakeLowercase| themselves are
 robust, but they have moving arguments.

--- a/base/doc/usrguide-historic.tex
+++ b/base/doc/usrguide-historic.tex
@@ -34,15 +34,15 @@
 
 \title{\LaTeX\ for authors --- historic version}
 
-\author{\copyright~Copyright 1995--2022, \LaTeX\ Project Team.\\
+\author{\copyright~Copyright 1995--2023, \LaTeX\ Project Team.\\
    All rights reserved.%
    \footnote{This file may be distributed and/or modified under the
      conditions of the \LaTeX{} Project Public License, either version 1.3c
      of this license or (at your option) any later version. See the source
-    \texttt{usrguide.tex} for full details.}%
+    \texttt{usrguide-historic.tex} for full details.}%
 }
 
-\date{30 August 2022}
+\date{09 November 2023}
 
 
 \begin{document}

--- a/base/doc/usrguide.tex
+++ b/base/doc/usrguide.tex
@@ -43,7 +43,7 @@
     \texttt{usrguide.tex} for full details.}%
 }
 
-\date{2023-05-23}
+\date{2023-11-09}
 
 \NewDocumentCommand\cs{m}{\texttt{\textbackslash\detokenize{#1}}}
 \NewDocumentCommand\marg{m}{\arg{#1}}
@@ -1186,13 +1186,13 @@ Titlecasing here follows the definition given by the Unicode Consortium: the
 first character of the input will be converted to (broadly) uppercase, and the
 rest of the input to lowercase. The full range of Unicode UTF-8 input can be
 supported.
-\begin{quotation}
+\begin{quote}
   \begin{tabular}{rl}
     |\MakeUppercase{hello WORLD ßüé}| & \MakeUppercase{hello WORLD ßüé} \\
     |\MakeLowercase{hello WORLD ßüé}| & \MakeLowercase{hello WORLD ßüé} \\
     |\MakeTitlecase{hello WORLD ßüé}| & \MakeTitlecase{hello WORLD ßüé} \\
   \end{tabular}
-\end{quotation}
+\end{quote}
 
 The case-changing commands take an optional argument which can be used to
 tailor the output. This optional argument accepts the key \texttt{locale},
@@ -1208,14 +1208,14 @@ are the arguments to the commands \cs{label}, \cs{ref}, \cs{cite}, \cs{begin}
 and \cs{end}. Additional exclusions can be added using the command
 \cs{AddToNoCaseChangeList}. Input can be excluded from case changing using the
 command \cs{NoCaseChange}.
-\begin{quotation}
+\begin{quote}
   \begin{tabular}{rl}
     |\MakeUppercase{Some text $y = mx + c$}|
       & \MakeUppercase{Some text $y = mx + c$} \\
     |\MakeUppercase{\NoCaseChange{iPhone}}|
       & \MakeLowercase{\NoCaseChange{iPhone}} \\
   \end{tabular}
-\end{quotation}
+\end{quote}
 
 To allow robust commands to be used within case changing \emph{and} to produce
 the expected output, two additional control commands are available.
@@ -1244,18 +1244,18 @@ apply to a specific one: this is given in BCP-47 format
 (\url{https://en.wikipedia.org/wiki/IETF_language_tag}). For example,
 the kernel customises the mapping for U+01F0 (\v{j}) when uppercasing in
 8-bit engines:
-\begin{quotation}
+\begin{quote}
   |\DeclareUppercaseMapping{"01F0}{\v{J}}|
-\end{quotation}
+\end{quote}
 as there is no pre-composed \v{J} character, and this is problematic if
 the engine does not support Unicode natively. Similarly, to set a locale
 \texttt{xx} to behave in the same way as Turkish and retain the difference
 between dotted- and dotless-i, one could use for example
-\begin{quotation}
+\begin{quote}
   |\DeclareLowercaseMapping[xx]{"0049}{\i}|\\
   |\DeclareLowercaseMapping[xx]{"0130}{i}|\\
   |\DeclareUppercaseMapping[xx]{"0069}{\.{I}}|\\
   |\DeclareUppercaseMapping[xx]{"0131}{I}|
-\end{quotation}
+\end{quote}
 
 \end{document}


### PR DESCRIPTION
In files in `./base/doc` directory, seven quotation-like text blocks are put inside `quotation` environment, while all other  similar blocks are put inside `quote` environment.
```
$ grep -rn '\\begin{quotation}' base/doc
base/doc/clsguide-historic.tex:1484:\begin{quotation}
base/doc/usrguide.tex:1189:\begin{quotation}
base/doc/usrguide.tex:1211:\begin{quotation}
base/doc/usrguide.tex:1247:\begin{quotation}
base/doc/usrguide.tex:1254:\begin{quotation}
base/doc/ltnews26.tex:58:\begin{quotation}
base/doc/ltnews26.tex:64:\begin{quotation}

$ grep -rn '\\begin{quote}' base/doc | wc -l
      70
```

This PR changes all (actually 5) `quotation` environments in non-ltnews tex files into `quote` envs, among which the most noticeable change/improvement is
- Before (on the last page of `usrguide.pdf`)
  ![image](https://github.com/latex3/latex2e/assets/6376638/0ffdcc8f-b5eb-4e4a-aa77-36917554600b)
- After
  ![image](https://github.com/latex3/latex2e/assets/6376638/8d35c127-ae01-4ff3-b963-7a038e05632b)

**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- [x] Feedback wanted 
- Under development
- [x] Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
