### PR TITLE
Allow CI triggered by branches containing `/`

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,6 +1,6 @@
 name: Create release
 
-# We create releases for all new tags
+# We create releases for all new tags that don't contain '/' in their names
 on:
   push:
     tags:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,7 +5,7 @@ on:
   # Whenever someone pushes to a branch in our repo
   push:
     branches:
-      - "*"
+      - "**"
   # Whenever a pull request is opened, reopened or gets new commits.
   pull_request:
 # This implies that for every push to a local branch in our repo for which a


### PR DESCRIPTION
In forks and perhaps also in this upstream repo, users may use `/` in branch names to classify branches. Currently pushing to such branch won't trigger CI defined in `main.yaml` (through `push` event), because glob pattern `*` used in `on.push.branches: ["*"]` doesn't match the `/` character (see related GitHub Docs [section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet)). One has to use such branch as the head branch of a PR to trigger CI, through `pull_request` event.

This PR relaxes the glob pattern, by using `**` which matches zero or more of _any_ character.

Similar to https://github.com/latex3/latex3/pull/1293.

**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- [x] Feedback wanted 
- Under development
- [x] Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
