### PR TITLE
Fix error message for para/begin hook

### DIFF
--- a/base/ltpara.dtx
+++ b/base/ltpara.dtx
@@ -813,7 +813,7 @@
 %    If we aren't in horizontal mode any longer the hooks above misbehaved.
 %    \begin{macrocode}
   \if_mode_horizontal: \else:
-    \msg_error:nnnn { hooks }{ para-mode }{begin}{vertical} \fi:
+    \msg_error:nnnn { hooks }{ para-mode }{begin}{horizontal} \fi:
 %    \end{macrocode}
 %    Finally we reinsert the indentation box (unless suppressed) and
 %    then call \cs{everypar} the way legacy \LaTeX\ code expects it.


### PR DESCRIPTION
The error message is correctly issued if the hook switches out of horizontal mode, but the message itself says that the hook switched out of vertical mode instead.

I can send the one-word patch by e-mail as well if that's easier.