### PR TITLE
Split artifacts for incoming `actions/upload-artifact@4` bumping

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -148,7 +148,11 @@ jobs:
         if: ${{ always() }}
         uses: zauguin/l3build-failure-artifacts@v1
         with:
-          name: testfiles
+          # example names:
+          # - "testfiles-base-build-pdflatex"
+          # - "testfiles-base-config-1run"
+          # - "testfiles-required/amsmath"
+          name: testfiles-${{ matrix.module }}${{ matrix.config && format('-{0}', matrix.config)  || ''}}${{ matrix.engine && format('-{0}', matrix.engine) || ''}}
           # Decide how long to keep the test output artifact:
           retention-days: 3
   docs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -187,7 +187,8 @@ jobs:
       - name: Archive documentation
         uses: actions/upload-artifact@v3
         with:
-          name: Documentation
+          # example names: "Documentation-base-1", "Documentation-requires"
+          name: Documentation-${{ matrix.module }}${{ matrix.environment && format('-{0}', env.LTX_DOC_COMPONENT) || ''}}
           path: "**/*.pdf"
           # Decide how long to keep the test output artifact:
           retention-days: 21

--- a/.github/workflows/pretest.yaml
+++ b/.github/workflows/pretest.yaml
@@ -125,7 +125,11 @@ jobs:
         if: ${{ always() }}
         uses: zauguin/l3build-failure-artifacts@v1
         with:
-          name: testfiles
+          # example names:
+          # - "testfiles-base-build-pdflatex"
+          # - "testfiles-base-config-1run"
+          # - "testfiles-required/amsmath"
+          name: testfiles-${{ matrix.module }}${{ matrix.config && format('-{0}', matrix.config)  || ''}}${{ matrix.engine && format('-{0}', matrix.engine) || ''}}
           # Decide how long to keep the test output artifact:
           retention-days: 3
   docs:

--- a/.github/workflows/pretest.yaml
+++ b/.github/workflows/pretest.yaml
@@ -165,7 +165,8 @@ jobs:
       - name: Archive documentation
         uses: actions/upload-artifact@v3
         with:
-          name: Documentation
+          # example names: "Documentation-base-1", "Documentation-requires"
+          name: Documentation-${{ matrix.module }}${{ matrix.environment && format('-{0}', env.LTX_DOC_COMPONENT) || ''}}
           path: "**/*.pdf"
           # Decide how long to keep the test output artifact:
           retention-days: 21


### PR DESCRIPTION
The changes to documentation artifacts are required by incoming `actions/upload-artifact@v4` bumping (similar to https://github.com/latex3/latex3/pull/1390), which will disable uploading to the same named artifact multiple times.

The changes to testfiles artifacts are for future, when future release of action `zauguin/l3build-failure-artifacts` uses npm package `@actions/artifact` 2.0.0 or newer. Currently actions in this repository uses `zauguin/l3build-failure-artifacts@v1` which depends on `"@actions/artifact": "^1.1.0"`.

See
- GitHub blog on `artifact` v4 https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/
- `@actions/artifact` documentation https://github.com/actions/toolkit/tree/68f22927e727a60caff909aaaec1ab7267b39f75/packages/artifact
- `l3build-failure-artifacts@v1` https://github.com/zauguin/l3build-failure-artifacts/blob/v1/package.json


**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

## Status of pull request

- Feedback wanted 
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
