### PR TITLE
extra } replaced with $ in bm doc

### DIFF
--- a/required/tools/bm.dtx
+++ b/required/tools/bm.dtx
@@ -22,7 +22,7 @@
 % \fi
 %
 % \iffalse
-%% Copyright 1996 1997 1998 1999 2002 2003 2004 2016 2017 2019 2021 2022
+%% Copyright 1996 1997 1998 1999 2002 2003 2004 2016 2017 2019 2021 2022 2023
 %% David Carlisle Frank Mittelbach
 %%
 %% Development of this package was commissioned by Y&Y Inc.
@@ -36,7 +36,7 @@
 %<driver>\ProvidesFile{bm.drv}
 % \fi
 %         \ProvidesFile{bm.dtx}
-          [2023/07/08 v1.2f Bold Symbol Support (DPC/FMi)]
+          [2023/12/19 v1.2f Bold Symbol Support (DPC/FMi)]
 %
 % \iffalse
 %<*driver>
@@ -185,7 +185,7 @@
 % is obtained.
 %
 % Similarly the last example is equivalent to
-% |$\mbox{\boldmath$\mathrm{g}$}}| and so in this case, one obtains a
+% |$\mbox{\boldmath$\mathrm{g}$}$| and so in this case, one obtains a
 % bold roman \textbf{g}.
 %
 % \subsection{Delimiters}


### PR DESCRIPTION
Caught when checking out bd9872b2 (extra {} in doc fixes davidcarlisle/dpctex#45, 2023-12-18).

**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] <s>Version and</s> date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
