### PR TITLE
Correct similar typos of missing backslashes in `macro` env markups

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -11,6 +11,8 @@ not part of the distribution.
 	Correct typo (gh/1223)
 	* doc.dtx, ltfntcmd.dtx, lthooks.dtx
 	Correct similar typos of missing backslashes
+	* ltfilehook.dtx
+	Change flag markup in macro env
 
 2023-12-02  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 	* doc.dtx (subsection{API creation}):

--- a/base/changes.txt
+++ b/base/changes.txt
@@ -9,6 +9,8 @@ not part of the distribution.
 2023-12-26 Yukai Chou  <muzimuzhi@gmai.com>
 	* ltproperties.dtx:
 	Correct typo (gh/1223)
+	* doc.dtx, ltfntcmd.dtx, lthooks.dtx
+	Correct similar typos of missing backslashes
 
 2023-12-02  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 	* doc.dtx (subsection{API creation}):

--- a/base/doc.dtx
+++ b/base/doc.dtx
@@ -45,7 +45,7 @@
 %<+package>
 %<+package>\ProvidesPackage{doc}
 %<+shortvrb>\ProvidesPackage{shortvrb}
-%<+package|shortvrb>  [2023/12/02 v3.0n
+%<+package|shortvrb>  [2023/12/26 v3.0n
 %<+package|shortvrb>   Standard LaTeX documentation package V3 (FMi)]
 %\catcode`\<=12
 %
@@ -57,7 +57,7 @@
 %
 %
 %% Package `doc' to use with LaTeX 2e
-%% Copyright (C) 1989-2022 Frank Mittelbach, all rights reserved.
+%% Copyright (C) 1989-2023 Frank Mittelbach, all rights reserved.
 %
 %
 % Version:     Date:     Changes:
@@ -6138,7 +6138,7 @@
 %    \end{macrocode}
 
 
-%  \begin{macro}{SpecialMainIndex}
+%  \begin{macro}{\SpecialMainIndex}
 %
 %    In \DOC v2 we had \cs{SpecialMainIndex} and
 %    \cs{SpecialMainEnvIndex} but now with additional \DOC elements we
@@ -6150,7 +6150,7 @@
 %    \end{macrocode}
 %  \end{macro}
 
-%  \begin{macro}{SpecialUsageIndex}
+%  \begin{macro}{\SpecialUsageIndex}
 %    \DOC v2 also had \cs{SpecialUsageIndex} which is now called
 %    \cs{SpecialMacroIndex} generating the ``usage'' index entry  for
 %    a macro. Again we provide that as an alias via |\def|.

--- a/base/ltfilehook.dtx
+++ b/base/ltfilehook.dtx
@@ -32,7 +32,7 @@
 %
 %    \begin{macrocode}
 \providecommand\ltfilehookversion{v1.0o}
-\providecommand\ltfilehookdate{2023/07/10}
+\providecommand\ltfilehookdate{2023/12/26}
 %    \end{macrocode}
 %
 %<*driver>
@@ -1328,7 +1328,7 @@
 % \end{macro}
 % \end{macro}
 %
-% \begin{macro}{flag @@_file_replaced}
+% \begin{macro}{@@_file_replaced}
 % \begin{macro}{\@@_if_file_replaced:TF}
 % \begin{macro}{\@@_clear_replacement_flag:}
 %   Since the file replacement is done expandably in a \cs{csname}, use

--- a/base/ltfntcmd.dtx
+++ b/base/ltfntcmd.dtx
@@ -32,7 +32,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltfntcmd.dtx}
-             [2021/09/12 v3.5a LaTeX Kernel (Font commands)]
+             [2023/12/26 v3.5a LaTeX Kernel (Font commands)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltfntcmd.dtx}
@@ -393,9 +393,9 @@
 %  \end{macro}
 
 
-%  \begin{macro}{textulc}
-%  \begin{macro}{textsw}
-%  \begin{macro}{textssc}
+%  \begin{macro}{\textulc}
+%  \begin{macro}{\textsw}
+%  \begin{macro}{\textssc}
 %
 % \changes{v3.4c}{2019/12/17}{Macro added}
 %    \begin{macrocode}

--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -32,7 +32,7 @@
 %
 %    \begin{macrocode}
 \def\lthooksversion{v1.1f}
-\def\lthooksdate{2023/11/28}
+\def\lthooksdate{2023/12/26}
 %    \end{macrocode}
 %
 %<*driver>
@@ -2703,7 +2703,7 @@
 %    \hook_new:n,
 %    \hook_new_with_args:nn
 %  }
-%  \begin{macro}{@@_new:nn}
+%  \begin{macro}{\@@_new:nn}
 %    The \cs{hook_new:n} declaration declares a new hook and expects
 %    the hook \meta{name} as its argument, e.g.,
 %    \hook{begindocument}.


### PR DESCRIPTION
Similar to #1224.

Filtered with (`rg` is available from https://github.com/BurntSushi/ripgrep)
```
rg --no-heading '\{macro\}\{[^\\]' -g '*.dtx'
```

**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version <s>and date</s> string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
