### PR TITLE
Define `\ShowHookInfo` and `\LogHookInfo`.

### DIFF
--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -898,6 +898,26 @@
 %    rule it is helpful to get some information about the code
 %    associated with a hook, its current order and the existing rules.
 %
+% \begin{function}{\ShowHookInfo,\LogHookInfo}
+%   \begin{syntax}
+%     \cs{ShowHookInfo} \Arg{hook name}
+%     \cs{LogHookInfo}  \Arg{hook name}
+%   \end{syntax}
+%   Displays information about the hook such as
+%   \begin{itemize}
+%   \item
+%      the code chunks added to it,
+%   \item
+%      any rules set up to order them,
+%   \item
+%      the order in which the chunks are executed, if any.
+%   \end{itemize}
+%   \cs{LogHookInfo} prints the information to the |.log| file, and
+%   \cs{ShowHookInfo} prints them to the terminal/command window and when in
+%   \cs{errorstopmode}, starts \TeX's prompt to wait for user action.
+%
+% \end{function}
+%
 % \begin{function}{\ShowHook,\LogHook}
 %   \begin{syntax}
 %     \cs{ShowHook} \Arg{hook}
@@ -1276,6 +1296,19 @@
 %
 %    The \meta{hook} can be specified using the dot-syntax to denote
 %    the current package name. See section~\ref{sec:default-label}.
+% \end{function}
+%
+% \begin{function}{\hook_info_show:n,\hook_info_log:n}
+%   \begin{syntax}
+%     \cs{hook_info_show:n} \Arg{hook name}
+%     \cs{hook_info_log:n}  \Arg{hook name}
+%   \end{syntax}
+%   Displays information about the hook in a more friendly way than
+%   \cs{hook_show:n}.
+%
+%   \cs{hook_info_log:n} prints the information to the |.log| file, and
+%   \cs{hook_info_show:n} prints them to the terminal/command window and starts
+%   \TeX's prompt (only if \cs{errorstopmode}) to wait for user action.
 % \end{function}
 %
 % \begin{function}{\hook_debug_on:,\hook_debug_off:}
@@ -2345,7 +2378,7 @@
 %
 %  \begin{macro}{\g_@@_all_seq}
 %    In a few places we need a list of all hook names ever defined so
-%    we keep track if them in this sequence.
+%    we keep track of them in this sequence.
 %    \begin{macrocode}
 \seq_new:N \g_@@_all_seq
 %    \end{macrocode}
@@ -3511,7 +3544,9 @@
         \msg_error:nnnnn { hooks } { set-top-level }
           { for } { SetDefaultHookLabel } {#1}
       }
-      { \exp_args:Nx \@@_set_default_label:n { \@@_make_name:n {#1} } }
+      {
+        \exp_args:Nx \@@_set_default_label:n { \@@_make_name:n {#1} }
+      }
   }
 \cs_new_protected:Npn \@@_set_default_label:n #1
   {
@@ -5982,8 +6017,6 @@
 %    \end{macrocode}
 %  \end{macro}
 %
-%
-%
 % \begin{macro}{\hook_show:n,\hook_log:n}
 % \begin{macro}{\@@_log_line:x,\@@_log_line_indent:x}
 % \begin{macro}{\@@_log:nN}
@@ -6029,7 +6062,7 @@
         hook~'#1'
         \@@_if_disabled:nF {#1}
           {
-            \exp_args:Nf \@@_print_args:nn {#1}
+            \exp_args:Nnf \@@_print_args:nn {#1}
               {
                 \int_eval:n
                   { \str_count:e { \@@_parameter:n {#1} } / 3 }
@@ -6271,8 +6304,9 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\@@_print_args:n}
+% \begin{macro}{\@@_print_args:nn, \@@_info_print_args:nn}
 %    Pretty-prints the number of arguments of a hook.
+%    |#1| is a hook name, |#2| expands to a number.
 %    \begin{macrocode}
 \cs_new:Npn \@@_print_args:nn #1 #2
   {
@@ -6285,11 +6319,217 @@
         argument \int_compare:nNnT {#2} > { 1 } { s } )
       }
   }
+\cs_new:Npn \@@_info_print_args:nn #1 #2
+  {
+    \int_compare:nNnT { #2 } > { 0 }
+      {
+        \@@_if_declared:nF { #1 } { \use_none:nn }
+        \use:n { #2 ~ argument \int_compare:nNnT { #2 } > { 1 } { s } }
+      }
+  }
 %    \end{macrocode}
 % \end{macro}
 %
 % \end{macro}
 % \end{macro}
+% \end{macro}
+%
+% \begin{variable}{\l_@@_info_seq}
+% Sequence to record the code chunk labels by order of execution.
+%    \begin{macrocode}
+\seq_new:N \l_@@_info_seq
+%    \end{macrocode}
+% \end{variable}
+% \begin{macro}{\hook_info_show:n,\hook_info_log:n}
+%   This writes out information about the hook given in its argument onto the
+%   \texttt{.log} file and also to the terminal if \cs{show_info_hook:n} is
+%   used.  Internally both share the same structure, except that at the
+%   end, \cs{hook_info_show:n} triggers \TeX's prompt.
+%    \begin{macrocode}
+\cs_new_protected:Npn \hook_info_log:n #1
+  {
+    \cs_set_eq:NN \@@_log_cmd:x \iow_log:x
+    \@@_normalize_hook_args:Nn \@@_info_log:nN {#1} \tl_log:x
+  }
+\cs_new_protected:Npn \hook_info_show:n #1
+  {
+    \cs_set_eq:NN \@@_log_cmd:x \iow_term:x
+    \@@_normalize_hook_args:Nn \@@_info_log:nN {#1} \tl_show:x
+  }
+%    \end{macrocode}
+% Next function makes the difference between \cs{ShowHookInfo} and
+% \cs{ShowHook}. In order to call |#2| in due time, we feed
+% \cs{l_@@_info_seq} and use |#2| for the last item.
+%    \begin{macrocode}
+\tl_new:N \l_@@_info_tl
+\cs_new_protected:Npn \@@_info_log:nN #1 #2
+  {
+    \@@_if_deprecated_generic:nT { #1 }
+      {
+        \@@_deprecated_generic_warn:n { #1 }
+        \@@_do_deprecated_generic:Nn \@@_info_log:nN { #1 } #2
+        \use_none:nnnnnnnnn
+      }
+    \@@_preamble_hook:n { #1 }
+    \@@_log_cmd:x { ^^J ==>~Hook:~'#1' }
+    \use:n
+      {
+        \seq_clear:N \l_@@_info_seq
+        \@@_if_generic:nT { #1 }
+          {
+            \seq_put_right:Nn \l_@@_info_seq { buitin~generic }
+            \use_none:nnn
+          }
+        \@@_if_usable:nF { #1 }
+          { \seq_put_right:Nn \l_@@_info_seq { not~declared } }
+        \@@_if_disabled:nF { #1 }
+          {
+            \exp_args:Nf \int_compare:nNnT
+              { \str_count:e { \@@_parameter:n { #1 } } } > 2
+              {
+                \seq_put_right:Nx \l_@@_info_seq
+                  {
+                    \@@_info_print_args:nn { #1 }
+                      {
+                        \int_eval:n
+                          { \str_count:e { \@@_parameter:n { #1 } } / 3 }
+                      }
+                  }
+              }
+              \use_none:nnn
+          }
+        \seq_put_right:Nn \l_@@_info_seq { disabled }
+        \hook_if_empty:nT { #1 }
+          {
+            \seq_if_empty:NT \l_@@_info_seq
+              { \seq_put_right:Nn \l_@@_info_seq { empty } }
+            #2 { \seq_use:Nn \l_@@_info_seq { ,~ } }
+            \use_none:nnnnnn
+          }
+        \seq_if_empty:NF \l_@@_info_seq
+          {
+            \@@_log_line_indent:x { \seq_use:Nn \l_@@_info_seq { ,~ } }
+          }
+      }
+%    \end{macrocode}
+% |#2| will be used whenn displaying the last executed code label.
+%    \begin{macrocode}
+    \hook_if_empty:nF { #1 }
+      {
+        \@@_log_line:x { Code~chunks: }
+        \prop_if_empty:cF { g_@@_#1_code_prop }
+          {
+            \prop_map_inline:cn { g_@@_#1_code_prop }
+              {
+                \exp_after:wN \cs_set:Npn \exp_after:wN \@@_info_log_nN:w
+                  \c_@@_nine_parameters_tl { ##2 }
+                \@@_log_line_indent:x
+                  { '##1' ~->~\cs_replacement_spec:N \@@_info_log_nN:w }
+              }
+          }
+        \@@_cs_if_empty:cF { @@_toplevel~#1 }
+          {
+            \@@_log_line_indent:x
+              { top~level ~->~ \cs_replacement_spec:c { @@_toplevel~#1 } }
+          }
+        \@@_cs_if_empty:cF { @@_next~#1 }
+          {
+            \@@_log_line_indent:x
+              {
+                next~only ~->~ \exp_last_unbraced:Nf \@@_log_next_code:w
+                  { \cs_replacement_spec:c { @@_next~#1 } }
+              }
+          }
+%    \end{macrocode}
+%   Loop through the default rules in a hook and for every rule found, print it.
+%   The boolean \cs{l_@@_tmpa_bool} here indicates if the hook has no default rules.
+%    \begin{macrocode}
+        \cs_set:Npn \@@_info_log:nN:nw ##1 ##2 | ##3 \scan_stop:
+          {
+            \l_@@_info_tl
+            \tl_clear:N \l_@@_info_tl
+            \@@_log_line_indent:x
+              {
+                \str_case:nnF { ##1 }
+                  {
+                    { xE } { '##2'~incompatible-error~  '##3' }
+                    { xW } { '##2'~incompatible-warning~'##3' }
+                    { <  } { '##2'~before~'##3' }
+                    { <- } { '##2'~voids~ '##3' }
+                    {  > } { '##2'~after~ '##3' }
+                    { -> } { '##3'~voids~ '##2' }
+                  }
+                  { '##2'~UNKNOWN(##1)~ '##3' }
+              }
+          }
+        \tl_set:Nn \l_@@_info_tl
+          {
+            \@@_log_line:x
+              {
+                Default~rules
+                \@@_if_reversed:nT { #1 } { ,~to~be~mirrored }:
+              }
+          }
+        \@@_list_rules:nn {#1}
+          {
+            \str_if_eq:nnT { ##3 } { ?? }
+              { \@@_info_log:nN:nw { ##1 } ##2 \scan_stop: }
+          }
+%    \end{macrocode}
+%   Loop through the rules in a hook and for every non default rule found, print
+%   it. The boolean \cs{l_@@_tmpa_bool} here indicates if the hook only has 
+%   default rules.
+%    \begin{macrocode}
+        \tl_set:Nn \l_@@_info_tl
+          { \@@_log_line:x { Rules: } }
+        \@@_list_rules:nn { #1 }
+          {
+            \str_if_eq:nnF { ##3 } { ?? }
+              { \@@_info_log:nN:nw { ##1 } ##2 \scan_stop: }
+          }
+%    \end{macrocode}
+%   When the hook is declared (that is, the sorting algorithm is applied
+%   to that hook)
+%    \begin{macrocode}
+        \@@_if_usable:nT { #1 }
+          {
+            \@@_log_line:x { Execution~order: }
+            \seq_clear:N \l_@@_info_seq
+            \@@_if_reversed:nT { #1 }
+              {
+                \@@_cs_if_empty:cF { @@_toplevel~#1 }
+                  { \seq_put_right:Nn \l_@@_info_seq { top~level } }
+              }
+            \clist_if_empty:cF { g_@@_#1_labels_clist }
+              {
+                \clist_map_inline:cn { g_@@_#1_labels_clist }
+                  { \seq_put_right:Nn \l_@@_info_seq { ##1 } }
+              }
+            \@@_if_reversed:nF { #1 }
+              {
+                \@@_cs_if_empty:cF { @@_toplevel~#1 }
+                  { \seq_put_right:Nn \l_@@_info_seq { top~level } }
+              }
+            \@@_cs_if_empty:cF { @@_next~#1 }
+              { \seq_put_right:Nn \l_@@_info_seq { next~only } }
+            \seq_pop_right:NN \l_@@_info_seq \l_@@_info_tl
+            \seq_map_indexed_inline:Nn \l_@@_info_seq
+                {
+                  \@@_log_line_indent:x { ##1:~'##2' }
+                }
+              #2
+                {
+                  \@spaces
+                  \int_eval:n { \seq_count:N \l_@@_info_seq + 1 }
+                  :~
+                  \l_@@_info_tl
+              }
+            \use_none:nn
+          }
+        #2 { No~execution }
+      }
+  }
+%    \end{macrocode}
 % \end{macro}
 %
 % \begin{macro}{\@@_list_rules:nn}
@@ -7560,6 +7800,13 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \ShowHook { \hook_show:n }
 \cs_new_protected:Npn \LogHook { \hook_log:n }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\ShowHookInfo,\LogHookInfo}
+%    \begin{macrocode}
+\cs_new_protected:Npn \ShowHookInfo { \hook_info_show:n }
+\cs_new_protected:Npn \LogHookInfo { \hook_info_log:n }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/base/testfiles-lthooks/lthooks-info.lvt
+++ b/base/testfiles-lthooks/lthooks-info.lvt
@@ -1,0 +1,188 @@
+% for getting the examples in the code really ...
+
+\ExplSyntaxOn
+\debug_on:n { check-declarations , deprecation }
+\ExplSyntaxOff
+
+\documentclass{article}
+
+\input{regression-test}
+
+\START
+
+\typeout{========== UNDECLARED}
+\ShowHook{HOOK NAME 0}
+\ShowHookInfo{HOOK NAME 0}
+\UseHook{HOOK NAME 0}
+\typeout{========== + TOP LEVEL}
+\AddToHook{HOOK NAME 0}{\typeout{[TOP LEVEL]}}
+\ShowHook{HOOK NAME 0}
+\ShowHookInfo{HOOK NAME 0}
+\UseHook{HOOK NAME 0}
+\typeout{========== + LABEL 1}
+\AddToHook{HOOK NAME 0}[LABEL 1]{\typeout{[code 1]}}
+\ShowHook{HOOK NAME 0}
+\ShowHookInfo{HOOK NAME 0}
+\UseHook{HOOK NAME 0}
+\typeout{========== + LABEL 2}
+\AddToHook{HOOK NAME 0}[LABEL 2]{\typeout{[code 2]}}
+\ShowHook{HOOK NAME 0}
+\ShowHookInfo{HOOK NAME 0}
+\UseHook{HOOK NAME 0}
+\typeout{========== + LABEL 3}
+\AddToHook{HOOK NAME 0}[LABEL 3]{\typeout{[code 3]}}
+\ShowHook{HOOK NAME 0}
+\ShowHookInfo{HOOK NAME 0}
+\UseHook{HOOK NAME 0}
+\typeout{========== + NEXT}
+\AddToHookNext{HOOK NAME 0}{\typeout{[Next only]}}
+\ShowHook{HOOK NAME 0}
+\ShowHookInfo{HOOK NAME 0}
+\UseHook{HOOK NAME 0}
+\typeout{========== LABEL 3 < LABEL 1}
+\DeclareHookRule{HOOK NAME 0}{LABEL 3}{before}{LABEL 1}
+\ShowHook{HOOK NAME 0}
+\ShowHookInfo{HOOK NAME 0}
+\UseHook{HOOK NAME 0}
+\typeout{========== DEFAULT LABEL 2 > LABEL 3}
+\DeclareDefaultHookRule{LABEL 2}{after}{LABEL 3}
+\ShowHook{HOOK NAME 0}
+\ShowHookInfo{HOOK NAME 0}
+\UseHook{HOOK NAME 0}
+
+\typeout{============================================}
+
+\typeout{========== UNDECLARED}
+\ShowHook{HOOK NAME}
+\ShowHookInfo{HOOK NAME}
+\UseHook{HOOK NAME}
+\typeout{========== DECLARED EMPTY}
+\NewHook{HOOK NAME}
+\ShowHook{HOOK NAME}
+\ShowHookInfo{HOOK NAME}
+\UseHook{HOOK NAME}
+\typeout{========== + TOP LEVEL}
+\AddToHook{HOOK NAME}{\typeout{[TOP LEVEL]}}
+\ShowHook{HOOK NAME}
+\ShowHookInfo{HOOK NAME}
+\UseHook{HOOK NAME}
+\typeout{========== + LABEL 1}
+\AddToHook{HOOK NAME}[LABEL 1]{\typeout{[code 1]}}
+\ShowHook{HOOK NAME}
+\ShowHookInfo{HOOK NAME}
+\UseHook{HOOK NAME}
+\typeout{========== + LABEL 2}
+\AddToHook{HOOK NAME}[LABEL 2]{\typeout{[code 2]}}
+\ShowHook{HOOK NAME}
+\ShowHookInfo{HOOK NAME}
+\UseHook{HOOK NAME}
+\typeout{========== + LABEL 3}
+\AddToHook{HOOK NAME}[LABEL 3]{\typeout{[code 3]}}
+\ShowHook{HOOK NAME}
+\ShowHookInfo{HOOK NAME}
+\UseHook{HOOK NAME}
+\typeout{========== + NEXT}
+\AddToHookNext{HOOK NAME}{\typeout{[Next only]}}
+\ShowHook{HOOK NAME}
+\ShowHookInfo{HOOK NAME}
+\UseHook{HOOK NAME}
+\typeout{========== LABEL 3 < LABEL 1}
+\DeclareHookRule{HOOK NAME}{LABEL 3}{before}{LABEL 1}
+\ShowHook{HOOK NAME}
+\ShowHookInfo{HOOK NAME}
+\UseHook{HOOK NAME}
+\typeout{========== DEFAULT LABEL 2 > LABEL 3}
+\DeclareDefaultHookRule{LABEL 2}{after}{LABEL 3}
+\ShowHook{HOOK NAME}
+\ShowHookInfo{HOOK NAME}
+\UseHook{HOOK NAME}
+
+\typeout{============================================}
+
+\typeout{========== UNDECLARED}
+\ShowHook{EMAN KOOH}
+\ShowHookInfo{EMAN KOOH}
+\UseHook{EMAN KOOH}
+\typeout{========== DECLARED REVERSED}
+\NewReversedHook{EMAN KOOH}
+\ShowHook{EMAN KOOH}
+\ShowHookInfo{EMAN KOOH}
+\UseHook{EMAN KOOH}
+\typeout{========== + TOP LEVEL}
+\AddToHook{EMAN KOOH}{\typeout{[TOP LEVEL]}}
+\ShowHook{EMAN KOOH}
+\ShowHookInfo{EMAN KOOH}
+\UseHook{EMAN KOOH}
+\typeout{========== + LABEL 1}
+\AddToHook{EMAN KOOH}[LABEL 1]{\typeout{[code 1]}}
+\ShowHook{EMAN KOOH}
+\ShowHookInfo{EMAN KOOH}
+\UseHook{EMAN KOOH}
+\typeout{========== + LABEL 2}
+\AddToHook{EMAN KOOH}[LABEL 2]{\typeout{[code 2]}}
+\ShowHook{EMAN KOOH}
+\ShowHookInfo{EMAN KOOH}
+\UseHook{EMAN KOOH}
+\typeout{========== + LABEL 3}
+\AddToHook{EMAN KOOH}[LABEL 3]{\typeout{[code 3]}}
+\ShowHook{EMAN KOOH}
+\ShowHookInfo{EMAN KOOH}
+\UseHook{EMAN KOOH}
+\typeout{========== + NEXT}
+\AddToHookNext{EMAN KOOH}{\typeout{[Next only]}}
+\ShowHook{EMAN KOOH}
+\ShowHookInfo{EMAN KOOH}
+\UseHook{EMAN KOOH}
+\typeout{========== + LABEL 3 < LABEL 1}
+\DeclareHookRule{EMAN KOOH}{LABEL 3}{before}{LABEL 1}
+\ShowHook{EMAN KOOH}
+\ShowHookInfo{EMAN KOOH}
+\UseHook{EMAN KOOH}
+\typeout{========== + DEFAULT LABEL 2 > LABEL 3}
+\DeclareDefaultHookRule{LABEL 2}{after}{LABEL 3}
+\ShowHook{EMAN KOOH}
+\ShowHookInfo{EMAN KOOH}
+\UseHook{EMAN KOOH}
+
+\typeout{============================================}
+
+\typeout{UNKNOWN ENVIRONMENT}
+\ShowHook{env/lthooks.regression test/before}
+\ShowHookInfo{env/lthooks.regression test/before}
+\typeout{CREATING ENVIRONMENT}
+\NewDocumentEnvironment{lthooks.regression test}{}{}{}
+\ShowHook{env/lthooks.regression test/before}
+\ShowHookInfo{env/lthooks.regression test/before}
+
+\typeout{============================================}
+
+\typeout{========== GENERIC HOOK}
+
+\ShowHook{GENERIC}
+\ShowHookInfo{GENERIC}
+\AddToHook{GENERIC}[LABEL]{\typeout{[CODE]}}
+\ShowHook{GENERIC}
+\ShowHookInfo{GENERIC}
+\UseHook{GENERIC}
+\typeout{========== ACTIVATE GENERIC HOOK}
+\ActivateGenericHook{GENERIC}
+\ShowHook{GENERIC}
+\ShowHookInfo{GENERIC}
+\UseHook{GENERIC}
+
+\typeout{============================================}
+
+\typeout{========== HOOK WITH ARGUMENTS A}
+
+\ShowHook{HWA-a)}
+\ShowHookInfo{HWA-a)}
+\NewHookWithArguments{HWA-a)}{2}
+\ShowHook{HWA-a)}
+\ShowHookInfo{HWA-a)}
+
+\typeout{============================================}
+
+
+\typeout{!!!! If this test changes the documentation needs updating !!!!}
+
+\END

--- a/base/testfiles-lthooks/lthooks-info.tlg
+++ b/base/testfiles-lthooks/lthooks-info.tlg
@@ -1,0 +1,786 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+========== UNDECLARED
+-> The hook 'HOOK NAME 0':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...\ShowHook{HOOK NAME 0}
+==> Hook: 'HOOK NAME 0'
+> not declared.
+<recently read> }
+l. ...\ShowHookInfo{HOOK NAME 0}
+========== + TOP LEVEL
+-> The hook 'HOOK NAME 0':
+> The hook is not declared.
+> Code chunks:
+>     ---
+> Document-level (top-level) code:
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...\ShowHook{HOOK NAME 0}
+==> Hook: 'HOOK NAME 0'
+>     not declared
+> Code chunks:
+>     top level -> \typeout {[TOP LEVEL]}
+> No execution.
+<recently read> }
+l. ...\ShowHookInfo{HOOK NAME 0}
+========== + LABEL 1
+-> The hook 'HOOK NAME 0':
+> The hook is not declared.
+> Code chunks:
+>     LABEL 1 -> \typeout {[code 1]}
+> Document-level (top-level) code:
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...\ShowHook{HOOK NAME 0}
+==> Hook: 'HOOK NAME 0'
+>     not declared
+> Code chunks:
+>     'LABEL 1' -> \typeout {[code 1]}
+>     top level -> \typeout {[TOP LEVEL]}
+> No execution.
+<recently read> }
+l. ...\ShowHookInfo{HOOK NAME 0}
+========== + LABEL 2
+-> The hook 'HOOK NAME 0':
+> The hook is not declared.
+> Code chunks:
+>     LABEL 1 -> \typeout {[code 1]}
+>     LABEL 2 -> \typeout {[code 2]}
+> Document-level (top-level) code:
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...\ShowHook{HOOK NAME 0}
+==> Hook: 'HOOK NAME 0'
+>     not declared
+> Code chunks:
+>     'LABEL 1' -> \typeout {[code 1]}
+>     'LABEL 2' -> \typeout {[code 2]}
+>     top level -> \typeout {[TOP LEVEL]}
+> No execution.
+<recently read> }
+l. ...\ShowHookInfo{HOOK NAME 0}
+========== + LABEL 3
+-> The hook 'HOOK NAME 0':
+> The hook is not declared.
+> Code chunks:
+>     LABEL 1 -> \typeout {[code 1]}
+>     LABEL 2 -> \typeout {[code 2]}
+>     LABEL 3 -> \typeout {[code 3]}
+> Document-level (top-level) code:
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...\ShowHook{HOOK NAME 0}
+==> Hook: 'HOOK NAME 0'
+>     not declared
+> Code chunks:
+>     'LABEL 1' -> \typeout {[code 1]}
+>     'LABEL 2' -> \typeout {[code 2]}
+>     'LABEL 3' -> \typeout {[code 3]}
+>     top level -> \typeout {[TOP LEVEL]}
+> No execution.
+<recently read> }
+l. ...\ShowHookInfo{HOOK NAME 0}
+========== + NEXT
+-> The hook 'HOOK NAME 0':
+> The hook is not declared.
+> Code chunks:
+>     LABEL 1 -> \typeout {[code 1]}
+>     LABEL 2 -> \typeout {[code 2]}
+>     LABEL 3 -> \typeout {[code 3]}
+> Document-level (top-level) code:
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     -> \typeout {[Next only]}
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...\ShowHook{HOOK NAME 0}
+==> Hook: 'HOOK NAME 0'
+>     not declared
+> Code chunks:
+>     'LABEL 1' -> \typeout {[code 1]}
+>     'LABEL 2' -> \typeout {[code 2]}
+>     'LABEL 3' -> \typeout {[code 3]}
+>     top level -> \typeout {[TOP LEVEL]}
+>     next only -> \typeout {[Next only]}
+> No execution.
+<recently read> }
+l. ...\ShowHookInfo{HOOK NAME 0}
+========== LABEL 3 < LABEL 1
+-> The hook 'HOOK NAME 0':
+> The hook is not declared.
+> Code chunks:
+>     LABEL 1 -> \typeout {[code 1]}
+>     LABEL 2 -> \typeout {[code 2]}
+>     LABEL 3 -> \typeout {[code 3]}
+> Document-level (top-level) code:
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     -> \typeout {[Next only]}
+> Rules:
+>     LABEL 3|LABEL 1 with relation <
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...\ShowHook{HOOK NAME 0}
+==> Hook: 'HOOK NAME 0'
+>     not declared
+> Code chunks:
+>     'LABEL 1' -> \typeout {[code 1]}
+>     'LABEL 2' -> \typeout {[code 2]}
+>     'LABEL 3' -> \typeout {[code 3]}
+>     top level -> \typeout {[TOP LEVEL]}
+>     next only -> \typeout {[Next only]}
+> Rules:
+>     'LABEL 3' before 'LABEL 1'
+> No execution.
+<recently read> }
+l. ...\ShowHookInfo{HOOK NAME 0}
+========== DEFAULT LABEL 2 > LABEL 3
+-> The hook 'HOOK NAME 0':
+> The hook is not declared.
+> Code chunks:
+>     LABEL 1 -> \typeout {[code 1]}
+>     LABEL 2 -> \typeout {[code 2]}
+>     LABEL 3 -> \typeout {[code 3]}
+> Document-level (top-level) code:
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     -> \typeout {[Next only]}
+> Rules:
+>     LABEL 3|LABEL 1 with relation <
+>     LABEL 3|LABEL 2 with default relation <
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...\ShowHook{HOOK NAME 0}
+==> Hook: 'HOOK NAME 0'
+>     not declared
+> Code chunks:
+>     'LABEL 1' -> \typeout {[code 1]}
+>     'LABEL 2' -> \typeout {[code 2]}
+>     'LABEL 3' -> \typeout {[code 3]}
+>     top level -> \typeout {[TOP LEVEL]}
+>     next only -> \typeout {[Next only]}
+> Default rules:
+>     'LABEL 3' before 'LABEL 2'
+> Rules:
+>     'LABEL 3' before 'LABEL 1'
+> No execution.
+<recently read> }
+l. ...\ShowHookInfo{HOOK NAME 0}
+============================================
+========== UNDECLARED
+-> The hook 'HOOK NAME':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...\ShowHook{HOOK NAME}
+==> Hook: 'HOOK NAME'
+> not declared.
+<recently read> }
+l. ...\ShowHookInfo{HOOK NAME}
+========== DECLARED EMPTY
+-> The hook 'HOOK NAME':
+> The hook is empty.
+<recently read> }
+l. ...\ShowHook{HOOK NAME}
+==> Hook: 'HOOK NAME'
+> empty.
+<recently read> }
+l. ...\ShowHookInfo{HOOK NAME}
+========== + TOP LEVEL
+-> The hook 'HOOK NAME':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...\ShowHook{HOOK NAME}
+==> Hook: 'HOOK NAME'
+> Code chunks:
+>     top level -> \typeout {[TOP LEVEL]}
+> Execution order:
+>     1: top level.
+<recently read> }
+l. ...\ShowHookInfo{HOOK NAME}
+[TOP LEVEL]
+========== + LABEL 1
+-> The hook 'HOOK NAME':
+> Code chunks:
+>     LABEL 1 -> \typeout {[code 1]}
+> Document-level (top-level) code (executed last):
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     LABEL 1.
+<recently read> }
+l. ...\ShowHook{HOOK NAME}
+==> Hook: 'HOOK NAME'
+> Code chunks:
+>     'LABEL 1' -> \typeout {[code 1]}
+>     top level -> \typeout {[TOP LEVEL]}
+> Execution order:
+>     1: 'LABEL 1'
+>     2: top level.
+<recently read> }
+l. ...\ShowHookInfo{HOOK NAME}
+[code 1]
+[TOP LEVEL]
+========== + LABEL 2
+-> The hook 'HOOK NAME':
+> Code chunks:
+>     LABEL 1 -> \typeout {[code 1]}
+>     LABEL 2 -> \typeout {[code 2]}
+> Document-level (top-level) code (executed last):
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     LABEL 1, LABEL 2.
+<recently read> }
+l. ...\ShowHook{HOOK NAME}
+==> Hook: 'HOOK NAME'
+> Code chunks:
+>     'LABEL 1' -> \typeout {[code 1]}
+>     'LABEL 2' -> \typeout {[code 2]}
+>     top level -> \typeout {[TOP LEVEL]}
+> Execution order:
+>     1: 'LABEL 1'
+>     2: 'LABEL 2'
+>     3: top level.
+<recently read> }
+l. ...\ShowHookInfo{HOOK NAME}
+[code 1]
+[code 2]
+[TOP LEVEL]
+========== + LABEL 3
+-> The hook 'HOOK NAME':
+> Code chunks:
+>     LABEL 1 -> \typeout {[code 1]}
+>     LABEL 2 -> \typeout {[code 2]}
+>     LABEL 3 -> \typeout {[code 3]}
+> Document-level (top-level) code (executed last):
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     LABEL 3|LABEL 2 with default relation <
+> Execution order (after applying rules):
+>     LABEL 1, LABEL 3, LABEL 2.
+<recently read> }
+l. ...\ShowHook{HOOK NAME}
+==> Hook: 'HOOK NAME'
+> Code chunks:
+>     'LABEL 1' -> \typeout {[code 1]}
+>     'LABEL 2' -> \typeout {[code 2]}
+>     'LABEL 3' -> \typeout {[code 3]}
+>     top level -> \typeout {[TOP LEVEL]}
+> Default rules:
+>     'LABEL 3' before 'LABEL 2'
+> Execution order:
+>     1: 'LABEL 1'
+>     2: 'LABEL 3'
+>     3: 'LABEL 2'
+>     4: top level.
+<recently read> }
+l. ...\ShowHookInfo{HOOK NAME}
+[code 1]
+[code 3]
+[code 2]
+[TOP LEVEL]
+========== + NEXT
+-> The hook 'HOOK NAME':
+> Code chunks:
+>     LABEL 1 -> \typeout {[code 1]}
+>     LABEL 2 -> \typeout {[code 2]}
+>     LABEL 3 -> \typeout {[code 3]}
+> Document-level (top-level) code (executed last):
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     -> \typeout {[Next only]}
+> Rules:
+>     LABEL 3|LABEL 2 with default relation <
+> Execution order (after applying rules):
+>     LABEL 1, LABEL 3, LABEL 2.
+<recently read> }
+l. ...\ShowHook{HOOK NAME}
+==> Hook: 'HOOK NAME'
+> Code chunks:
+>     'LABEL 1' -> \typeout {[code 1]}
+>     'LABEL 2' -> \typeout {[code 2]}
+>     'LABEL 3' -> \typeout {[code 3]}
+>     top level -> \typeout {[TOP LEVEL]}
+>     next only -> \typeout {[Next only]}
+> Default rules:
+>     'LABEL 3' before 'LABEL 2'
+> Execution order:
+>     1: 'LABEL 1'
+>     2: 'LABEL 3'
+>     3: 'LABEL 2'
+>     4: 'top level'
+>     5: next only.
+<recently read> }
+l. ...\ShowHookInfo{HOOK NAME}
+[code 1]
+[code 3]
+[code 2]
+[TOP LEVEL]
+[Next only]
+========== LABEL 3 < LABEL 1
+-> The hook 'HOOK NAME':
+> Code chunks:
+>     LABEL 1 -> \typeout {[code 1]}
+>     LABEL 2 -> \typeout {[code 2]}
+>     LABEL 3 -> \typeout {[code 3]}
+> Document-level (top-level) code (executed last):
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     LABEL 3|LABEL 1 with relation <
+>     LABEL 3|LABEL 2 with default relation <
+> Execution order (after applying rules):
+>     LABEL 3, LABEL 1, LABEL 2.
+<recently read> }
+l. ...\ShowHook{HOOK NAME}
+==> Hook: 'HOOK NAME'
+> Code chunks:
+>     'LABEL 1' -> \typeout {[code 1]}
+>     'LABEL 2' -> \typeout {[code 2]}
+>     'LABEL 3' -> \typeout {[code 3]}
+>     top level -> \typeout {[TOP LEVEL]}
+> Default rules:
+>     'LABEL 3' before 'LABEL 2'
+> Rules:
+>     'LABEL 3' before 'LABEL 1'
+> Execution order:
+>     1: 'LABEL 3'
+>     2: 'LABEL 1'
+>     3: 'LABEL 2'
+>     4: top level.
+<recently read> }
+l. ...\ShowHookInfo{HOOK NAME}
+[code 3]
+[code 1]
+[code 2]
+[TOP LEVEL]
+========== DEFAULT LABEL 2 > LABEL 3
+-> The hook 'HOOK NAME':
+> Code chunks:
+>     LABEL 1 -> \typeout {[code 1]}
+>     LABEL 2 -> \typeout {[code 2]}
+>     LABEL 3 -> \typeout {[code 3]}
+> Document-level (top-level) code (executed last):
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     LABEL 3|LABEL 1 with relation <
+>     LABEL 3|LABEL 2 with default relation <
+> Execution order (after applying rules):
+>     LABEL 3, LABEL 1, LABEL 2.
+<recently read> }
+l. ...\ShowHook{HOOK NAME}
+==> Hook: 'HOOK NAME'
+> Code chunks:
+>     'LABEL 1' -> \typeout {[code 1]}
+>     'LABEL 2' -> \typeout {[code 2]}
+>     'LABEL 3' -> \typeout {[code 3]}
+>     top level -> \typeout {[TOP LEVEL]}
+> Default rules:
+>     'LABEL 3' before 'LABEL 2'
+> Rules:
+>     'LABEL 3' before 'LABEL 1'
+> Execution order:
+>     1: 'LABEL 3'
+>     2: 'LABEL 1'
+>     3: 'LABEL 2'
+>     4: top level.
+<recently read> }
+l. ...\ShowHookInfo{HOOK NAME}
+[code 3]
+[code 1]
+[code 2]
+[TOP LEVEL]
+============================================
+========== UNDECLARED
+-> The hook 'EMAN KOOH':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...\ShowHook{EMAN KOOH}
+==> Hook: 'EMAN KOOH'
+> not declared.
+<recently read> }
+l. ...\ShowHookInfo{EMAN KOOH}
+========== DECLARED REVERSED
+-> The hook 'EMAN KOOH':
+> The hook is empty.
+<recently read> }
+l. ...\ShowHook{EMAN KOOH}
+==> Hook: 'EMAN KOOH'
+> empty.
+<recently read> }
+l. ...\ShowHookInfo{EMAN KOOH}
+========== + TOP LEVEL
+-> The hook 'EMAN KOOH':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed first):
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     ---.
+<recently read> }
+l. ...\ShowHook{EMAN KOOH}
+==> Hook: 'EMAN KOOH'
+> Code chunks:
+>     top level -> \typeout {[TOP LEVEL]}
+> Execution order:
+>     1: top level.
+<recently read> }
+l. ...\ShowHookInfo{EMAN KOOH}
+[TOP LEVEL]
+========== + LABEL 1
+-> The hook 'EMAN KOOH':
+> Code chunks:
+>     LABEL 1 -> \typeout {[code 1]}
+> Document-level (top-level) code (executed first):
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     LABEL 1.
+<recently read> }
+l. ...\ShowHook{EMAN KOOH}
+==> Hook: 'EMAN KOOH'
+> Code chunks:
+>     'LABEL 1' -> \typeout {[code 1]}
+>     top level -> \typeout {[TOP LEVEL]}
+> Execution order:
+>     1: 'top level'
+>     2: LABEL 1.
+<recently read> }
+l. ...\ShowHookInfo{EMAN KOOH}
+[TOP LEVEL]
+[code 1]
+========== + LABEL 2
+-> The hook 'EMAN KOOH':
+> Code chunks:
+>     LABEL 1 -> \typeout {[code 1]}
+>     LABEL 2 -> \typeout {[code 2]}
+> Document-level (top-level) code (executed first):
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     LABEL 2, LABEL 1.
+<recently read> }
+l. ...\ShowHook{EMAN KOOH}
+==> Hook: 'EMAN KOOH'
+> Code chunks:
+>     'LABEL 1' -> \typeout {[code 1]}
+>     'LABEL 2' -> \typeout {[code 2]}
+>     top level -> \typeout {[TOP LEVEL]}
+> Execution order:
+>     1: 'top level'
+>     2: 'LABEL 2'
+>     3: LABEL 1.
+<recently read> }
+l. ...\ShowHookInfo{EMAN KOOH}
+[TOP LEVEL]
+[code 2]
+[code 1]
+========== + LABEL 3
+-> The hook 'EMAN KOOH':
+> Code chunks:
+>     LABEL 1 -> \typeout {[code 1]}
+>     LABEL 2 -> \typeout {[code 2]}
+>     LABEL 3 -> \typeout {[code 3]}
+> Document-level (top-level) code (executed first):
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     LABEL 3|LABEL 2 with default relation <
+> Execution order (after reversal and applying rules):
+>     LABEL 2, LABEL 3, LABEL 1.
+<recently read> }
+l. ...\ShowHook{EMAN KOOH}
+==> Hook: 'EMAN KOOH'
+> Code chunks:
+>     'LABEL 1' -> \typeout {[code 1]}
+>     'LABEL 2' -> \typeout {[code 2]}
+>     'LABEL 3' -> \typeout {[code 3]}
+>     top level -> \typeout {[TOP LEVEL]}
+> Default rules, to be reversed:
+>     'LABEL 3' before 'LABEL 2'
+> Execution order:
+>     1: 'top level'
+>     2: 'LABEL 2'
+>     3: 'LABEL 3'
+>     4: LABEL 1.
+<recently read> }
+l. ...\ShowHookInfo{EMAN KOOH}
+[TOP LEVEL]
+[code 2]
+[code 3]
+[code 1]
+========== + NEXT
+-> The hook 'EMAN KOOH':
+> Code chunks:
+>     LABEL 1 -> \typeout {[code 1]}
+>     LABEL 2 -> \typeout {[code 2]}
+>     LABEL 3 -> \typeout {[code 3]}
+> Document-level (top-level) code (executed first):
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     -> \typeout {[Next only]}
+> Rules:
+>     LABEL 3|LABEL 2 with default relation <
+> Execution order (after reversal and applying rules):
+>     LABEL 2, LABEL 3, LABEL 1.
+<recently read> }
+l. ...\ShowHook{EMAN KOOH}
+==> Hook: 'EMAN KOOH'
+> Code chunks:
+>     'LABEL 1' -> \typeout {[code 1]}
+>     'LABEL 2' -> \typeout {[code 2]}
+>     'LABEL 3' -> \typeout {[code 3]}
+>     top level -> \typeout {[TOP LEVEL]}
+>     next only -> \typeout {[Next only]}
+> Default rules, to be reversed:
+>     'LABEL 3' before 'LABEL 2'
+> Execution order:
+>     1: 'top level'
+>     2: 'LABEL 2'
+>     3: 'LABEL 3'
+>     4: 'LABEL 1'
+>     5: next only.
+<recently read> }
+l. ...\ShowHookInfo{EMAN KOOH}
+[TOP LEVEL]
+[code 2]
+[code 3]
+[code 1]
+[Next only]
+========== + LABEL 3 < LABEL 1
+-> The hook 'EMAN KOOH':
+> Code chunks:
+>     LABEL 1 -> \typeout {[code 1]}
+>     LABEL 2 -> \typeout {[code 2]}
+>     LABEL 3 -> \typeout {[code 3]}
+> Document-level (top-level) code (executed first):
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     LABEL 3|LABEL 1 with relation <
+>     LABEL 3|LABEL 2 with default relation <
+> Execution order (after reversal and applying rules):
+>     LABEL 2, LABEL 3, LABEL 1.
+<recently read> }
+l. ...\ShowHook{EMAN KOOH}
+==> Hook: 'EMAN KOOH'
+> Code chunks:
+>     'LABEL 1' -> \typeout {[code 1]}
+>     'LABEL 2' -> \typeout {[code 2]}
+>     'LABEL 3' -> \typeout {[code 3]}
+>     top level -> \typeout {[TOP LEVEL]}
+> Default rules, to be reversed:
+>     'LABEL 3' before 'LABEL 2'
+> Rules:
+>     'LABEL 3' before 'LABEL 1'
+> Execution order:
+>     1: 'top level'
+>     2: 'LABEL 2'
+>     3: 'LABEL 3'
+>     4: LABEL 1.
+<recently read> }
+l. ...\ShowHookInfo{EMAN KOOH}
+[TOP LEVEL]
+[code 2]
+[code 3]
+[code 1]
+========== + DEFAULT LABEL 2 > LABEL 3
+-> The hook 'EMAN KOOH':
+> Code chunks:
+>     LABEL 1 -> \typeout {[code 1]}
+>     LABEL 2 -> \typeout {[code 2]}
+>     LABEL 3 -> \typeout {[code 3]}
+> Document-level (top-level) code (executed first):
+>     -> \typeout {[TOP LEVEL]}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     LABEL 3|LABEL 1 with relation <
+>     LABEL 3|LABEL 2 with default relation <
+> Execution order (after reversal and applying rules):
+>     LABEL 2, LABEL 3, LABEL 1.
+<recently read> }
+l. ...\ShowHook{EMAN KOOH}
+==> Hook: 'EMAN KOOH'
+> Code chunks:
+>     'LABEL 1' -> \typeout {[code 1]}
+>     'LABEL 2' -> \typeout {[code 2]}
+>     'LABEL 3' -> \typeout {[code 3]}
+>     top level -> \typeout {[TOP LEVEL]}
+> Default rules, to be reversed:
+>     'LABEL 3' before 'LABEL 2'
+> Rules:
+>     'LABEL 3' before 'LABEL 1'
+> Execution order:
+>     1: 'top level'
+>     2: 'LABEL 2'
+>     3: 'LABEL 3'
+>     4: LABEL 1.
+<recently read> }
+l. ...\ShowHookInfo{EMAN KOOH}
+[TOP LEVEL]
+[code 2]
+[code 3]
+[code 1]
+============================================
+UNKNOWN ENVIRONMENT
+-> The generic hook 'env/lthooks.regression test/before':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ......wHook{env/lthooks.regression test/before}
+==> Hook: 'env/lthooks.regression test/before'
+> buitin generic.
+<recently read> }
+l. ......kInfo{env/lthooks.regression test/before}
+CREATING ENVIRONMENT
+-> The generic hook 'env/lthooks.regression test/before':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ......wHook{env/lthooks.regression test/before}
+==> Hook: 'env/lthooks.regression test/before'
+> buitin generic.
+<recently read> }
+l. ......kInfo{env/lthooks.regression test/before}
+============================================
+========== GENERIC HOOK
+-> The hook 'GENERIC':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...\ShowHook{GENERIC}
+==> Hook: 'GENERIC'
+> not declared.
+<recently read> }
+l. ...\ShowHookInfo{GENERIC}
+-> The hook 'GENERIC':
+> The hook is not declared.
+> Code chunks:
+>     LABEL -> \typeout {[CODE]}
+> Document-level (top-level) code:
+>     ---
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...\ShowHook{GENERIC}
+==> Hook: 'GENERIC'
+>     not declared
+> Code chunks:
+>     'LABEL' -> \typeout {[CODE]}
+> No execution.
+<recently read> }
+l. ...\ShowHookInfo{GENERIC}
+========== ACTIVATE GENERIC HOOK
+-> The hook 'GENERIC':
+> Code chunks:
+>     LABEL -> \typeout {[CODE]}
+> Document-level (top-level) code (executed last):
+>     ---
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     LABEL.
+<recently read> }
+l. ...\ShowHook{GENERIC}
+==> Hook: 'GENERIC'
+> Code chunks:
+>     'LABEL' -> \typeout {[CODE]}
+> Execution order:
+>     1: LABEL.
+<recently read> }
+l. ...\ShowHookInfo{GENERIC}
+[CODE]
+============================================
+========== HOOK WITH ARGUMENTS A
+-> The hook 'HWA-a)':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...\ShowHook{HWA-a)}
+==> Hook: 'HWA-a)'
+> not declared.
+<recently read> }
+l. ...\ShowHookInfo{HWA-a)}
+-> The hook 'HWA-a)' (2 arguments):
+> The hook is empty.
+<recently read> }
+l. ...\ShowHook{HWA-a)}
+==> Hook: 'HWA-a)'
+> 2 arguments.
+<recently read> }
+l. ...\ShowHookInfo{HWA-a)}
+============================================
+!!!! If this test changes the documentation needs updating !!!!


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

The actual `\ShowHook` is too verbose, cryptic and rather inefficient.

The `lthooks-info.tlg` contains many examples of `\ShowHook` output vs `\ShowHookInfo` output.
For example, we have 
```
-> The generic hook 'env/lthooks.regression test/before':
> The hook is not declared.
> The hook is empty.
```
for `\ShowHook` and
```
==> Hook: 'env/lthooks.regression test/before'
> buitin generic.
```
for `\ShowHookInfo`.

For non empty hooks, we have
```
-> The hook 'EMAN KOOH':
> Code chunks:
>     LABEL 1 -> \typeout {[code 1]}
>     LABEL 2 -> \typeout {[code 2]}
>     LABEL 3 -> \typeout {[code 3]}
> Document-level (top-level) code (executed first):
>     -> \typeout {[TOP LEVEL]}
> Extra code for next invocation:
>     ---
> Rules:
>     LABEL 3|LABEL 1 with relation <
>     LABEL 3|LABEL 2 with default relation <
> Execution order (after reversal and applying rules):
>     LABEL 2, LABEL 3, LABEL 1.
```
versus
```
==> Hook: 'EMAN KOOH'
> Code chunks:
>     'LABEL 1' -> \typeout {[code 1]}
>     'LABEL 2' -> \typeout {[code 2]}
>     'LABEL 3' -> \typeout {[code 3]}
>     top level -> \typeout {[TOP LEVEL]}
> Default rules, to be mirrored:
>     'LABEL 3' before 'LABEL 2'
> Rules:
>     'LABEL 3' before 'LABEL 1'
> Execution order:
>     1: 'top level'
>     2: 'LABEL 2'
>     3: 'LABEL 3'
>     4: LABEL 1.
```

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
- Ready to merge

## Checklist of required changes before merge will be approved
- [ X] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
