### PR TITLE
Correct expansion of \__hook_print_args:nn argument

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,10 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
+2024-01-03  Phelype Oleinik  <phelype.oleinik@latex-project.org>
+	* lthooks.dtx:
+	Correct expansion of \@@_print_args:nn argument (gh/1221).
+
 2023-12-30  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 	* doc.dtx (subsection{Macros surrounding the `definition parts'}):
 	Use \@noligs from the LaTeX kernel, so that the upquote
@@ -189,7 +193,7 @@ All changes above are only part of the development branch for the next release.
 	* ltfiles.dtx
 	Allow for pipes in \input, etc.
 
-2023-06-16  Phelype Oleinik  <Joseph.Wright@latex-project.org>
+2023-06-16  Phelype Oleinik  <phelype.oleinik@latex-project.org>
 
 	* lthooks.dtx, ltcmdhooks.dtx
 	Correct some rollback labels and dates.

--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -31,8 +31,8 @@
 %%% From File: lthooks.dtx
 %
 %    \begin{macrocode}
-\def\lthooksversion{v1.1f}
-\def\lthooksdate{2023/12/26}
+\def\lthooksversion{v1.1g}
+\def\lthooksdate{2024/01/03}
 %    \end{macrocode}
 %
 %<*driver>
@@ -6010,6 +6010,8 @@
 %
 % \changes{v1.1a}{2023/04/06}
 %         {Changes to add hook arguments (hook-args).}
+% \changes{v1.1g}{2024/01/03}
+%         {Fix expansion of \cs{@@_print_args:nn} argument (gh/1221).}
 %    \begin{macrocode}
 %<latexrelease>\IncludeInRelease{2023/06/01}{\@@_log:nN}
 %<latexrelease>                 {Hooks~with~args}
@@ -6029,7 +6031,7 @@
         hook~'#1'
         \@@_if_disabled:nF {#1}
           {
-            \exp_args:Nf \@@_print_args:nn {#1}
+            \exp_args:Nne \@@_print_args:nn {#1}
               {
                 \int_eval:n
                   { \str_count:e { \@@_parameter:n {#1} } / 3 }


### PR DESCRIPTION
Fixes #1221

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [N/A] Test file(s) added&mdash;no difference in behaviour
- [X] Version and date string updated in changed source files
- [X] Relevant `\changes` entries in source included
- [X] Relevant `changes.txt` updated
- [N/A] Rollback provided (if necessary)?&mdash;not needed, I think
- [N/A] `ltnewsX.tex` (and/or `latexchanges.tex`) updated&mdash;no noticeable change
