### PR TITLE
Tag new functions in lthooks.dtx

### DIFF
--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -160,7 +160,7 @@
 % \end{function}
 %
 %
-% \begin{function}{\NewHookWithArguments}
+% \begin{function}[added=2023-06-01]{\NewHookWithArguments}
 %   \begin{syntax}
 %     \cs{NewHookWithArguments} \Arg{hook} \Arg{number}
 %   \end{syntax}
@@ -172,7 +172,7 @@
 %    the current package name. See section~\ref{sec:default-label}.
 % \end{function}
 %
-% \begin{function}{\NewReversedHookWithArguments}
+% \begin{function}[added=2023-06-01]{\NewReversedHookWithArguments}
 %   \begin{syntax}
 %     \cs{NewReversedHookWithArguments} \Arg{hook} \Arg{number}
 %   \end{syntax}
@@ -184,7 +184,7 @@
 %    the current package name. See section~\ref{sec:default-label}.
 % \end{function}
 %
-% \begin{function}{\NewMirroredHookPairWithArguments}
+% \begin{function}[added=2023-06-01]{\NewMirroredHookPairWithArguments}
 %   \begin{syntax}
 %     \cs{NewMirroredHookPairWithArguments} \Arg{hook-1} \Arg{hook-2} \Arg{number}
 %   \end{syntax}
@@ -264,7 +264,7 @@
 %    A leading |.| is treated literally.
 % \end{function}
 %
-% \begin{function}{\UseHookWithArguments}
+% \begin{function}[added=2023-06-01]{\UseHookWithArguments}
 %   \begin{syntax}
 %     \cs{UseHookWithArguments} \Arg{hook} \Arg{number} \Arg{arg_1} \ldots \Arg{arg_n}
 %   \end{syntax}
@@ -314,7 +314,7 @@
 %
 % \end{function}
 %
-% \begin{function}{\UseOneTimeHookWithArguments}
+% \begin{function}[added=2023-06-01]{\UseOneTimeHookWithArguments}
 %   \begin{syntax}
 %     \cs{UseOneTimeHookWithArguments} \Arg{hook} \Arg{number} \Arg{arg_1} \ldots \Arg{arg_n}
 %   \end{syntax}
@@ -368,7 +368,7 @@
 %    See section~\ref{sec:default-label}.
 % \end{function}
 %
-% \begin{function}{\AddToHookWithArguments}
+% \begin{function}[added=2023-06-01]{\AddToHookWithArguments}
 %   \begin{syntax}
 %     \cs{AddToHookWithArguments} \Arg{hook}\oarg{label}\Arg{code}
 %   \end{syntax}
@@ -505,7 +505,7 @@
 % \end{function}\footnotetext{There is
 %    no mechanism to reorder such code chunks (or delete them).}
 %
-% \begin{function}{\AddToHookNextWithArguments}
+% \begin{function}[added=2023-06-01]{\AddToHookNextWithArguments}
 %   \begin{syntax}
 %     \cs{AddToHookNextWithArguments} \Arg{hook}\Arg{code}
 %   \end{syntax}
@@ -1044,7 +1044,7 @@
 %    the current package name. See section~\ref{sec:default-label}.
 % \end{function}
 %
-% \begin{function}{
+% \begin{function}[added=2023-06-01]{
 %     \hook_new_with_args:nn,
 %     \hook_new_reversed_with_args:nn,
 %     \hook_new_pair_with_args:nnn
@@ -1100,9 +1100,14 @@
 %
 %
 %
-% \begin{function}{\hook_use:n,\hook_use:nnw}
+% \begin{function}{\hook_use:n}
 %   \begin{syntax}
-%     \cs{hook_use:n} \Arg{hook}
+%     ~~\cs{hook_use:n} \Arg{hook}
+%   \end{syntax}
+% \end{function}
+% \vskip-1.2\baselineskip
+% \begin{function}[added=2023-06-01]{\hook_use:nnw}
+%   \begin{syntax}
 %     \cs{hook_use:nnw} \Arg{hook} \Arg{number} \Arg{arg_1} \ldots \Arg{arg_n}
 %   \end{syntax}
 %    Executes the \Arg{hook} code followed (if set up) by the code for next
@@ -1118,9 +1123,14 @@
 %    A leading |.| is treated literally.
 % \end{function}
 %
-% \begin{function}{\hook_use_once:n,\hook_use_once:nnw}
+% \begin{function}{\hook_use_once:n}
 %   \begin{syntax}
 %     \cs{hook_use_once:n} \Arg{hook}
+%   \end{syntax}
+% \end{function}
+% \vskip-1.2\baselineskip
+% \begin{function}[added=2023-06-01]{\hook_use_once:nnw}
+%   \begin{syntax}
 %     \cs{hook_use_once:nnw} \Arg{hook} \Arg{number} \Arg{arg_1} \ldots \Arg{arg_n}
 %   \end{syntax}
 %     Changes the \Arg{hook} status so that from now on any addition to
@@ -1139,10 +1149,16 @@
 %
 % \begin{function}{
 %     \hook_gput_code:nnn,
+%   }
+%   \begin{syntax}
+%     ~~~~~~~~~\cs{hook_gput_code:nnn} \Arg{hook} \Arg{label} \Arg{code}
+%   \end{syntax}
+% \end{function}
+% \vskip -1.2\baselineskip
+% \begin{function}[added=2023-06-01]{
 %     \hook_gput_code_with_args:nnn
 %   }
 %   \begin{syntax}
-%     \cs{hook_gput_code:nnn} \Arg{hook} \Arg{label} \Arg{code}
 %     \cs{hook_gput_code_with_args:nnn} \Arg{hook} \Arg{label} \Arg{code}
 %   \end{syntax}
 %    Adds a chunk of \meta{code} to the \meta{hook} labeled
@@ -1168,10 +1184,17 @@
 %
 % \begin{function}{
 %     \hook_gput_next_code:nn,
+%   }
+%   \begin{syntax}
+%     ~~~~~~~~~~~~~\cs{hook_gput_next_code:nn} \Arg{hook} \Arg{code}
+%   \end{syntax}
+% \end{function}
+% \vskip-1.2\baselineskip
+% \begin{function}[added=2023-06-01]{
 %     \hook_gput_next_code_with_args:nn,
 %   }
 %   \begin{syntax}
-%     \cs{hook_gput_next_code:nn} \Arg{hook} \Arg{code}
+%     \cs{hook_gput_next_code_with_args:nn} \Arg{hook} \Arg{code}
 %   \end{syntax}
 %    Adds a chunk of \meta{code} for use only in the next invocation of the
 %    \meta{hook}. Once used it is gone.
@@ -1183,6 +1206,7 @@
 %    In that case, if an actual parameter token should be added to the
 %    code, it should be doubled.
 %
+% \end{function}
 %    This is simpler than \cs{hook_gput_code:nnn}, the code is simply
 %    appended to the hook in the order of declaration at the very end,
 %    i.e., after all standard code for the hook got executed.
@@ -1191,7 +1215,6 @@
 %
 %    The \meta{hook} can be specified using the dot-syntax to denote
 %    the current package name. See section~\ref{sec:default-label}.
-% \end{function}
 %
 %
 % \begin{function}{\hook_gclear_next_code:n}


### PR DESCRIPTION
New functions were recently added. The online doc won't always reflect the actual distribution of the reader. We tag the new functions as added to the 2023-06-01 release. This is not very pretty for L3 API because new and old functions are documented altogether. But this problem will disappear in a forthcoming release.

**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
- Under development
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
