### PR TITLE
lthooks-code: less overfull box

### DIFF
--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -3534,7 +3534,8 @@
         \msg_error:nnnnn { hooks } { set-top-level }
           { for } { SetDefaultHookLabel } {#1}
       }
-      { \exp_args:Nx \@@_set_default_label:n { \@@_make_name:n {#1}}}
+      { \exp_args:Nx
+        \@@_set_default_label:n { \@@_make_name:n {#1} } }
   }
 \cs_new_protected:Npn \@@_set_default_label:n #1
   {
@@ -5170,7 +5171,8 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_rule_before_gset:nnn #1#2#3
   {
-    \@@_tl_gset:cx { g_@@_#1_rule_ \@@_label_pair:nn {#2} {#3}_tl}
+    \@@_tl_gset:cx
+      { g_@@_#1_rule_ \@@_label_pair:nn {#2} {#3} _tl }
       { \@@_label_ordered:nnTF {#2} {#3} { < } { > } }
   }
 \cs_new_eq:cN { @@_rule_<_gset:nnn } \@@_rule_before_gset:nnn
@@ -5179,7 +5181,8 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_rule_after_gset:nnn #1#2#3
   {
-    \@@_tl_gset:cx { g_@@_#1_rule_ \@@_label_pair:nn {#3} {#2}_tl}
+    \@@_tl_gset:cx
+      { g_@@_#1_rule_ \@@_label_pair:nn {#3} {#2} _tl }
       { \@@_label_ordered:nnTF {#3} {#2} { < } { > } }
   }
 \cs_new_eq:cN { @@_rule_>_gset:nnn } \@@_rule_after_gset:nnn
@@ -5192,7 +5195,8 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_rule_voids_gset:nnn #1#2#3
   {
-    \@@_tl_gset:cx { g_@@_#1_rule_ \@@_label_pair:nn {#2} {#3}_tl}
+    \@@_tl_gset:cx
+      { g_@@_#1_rule_ \@@_label_pair:nn {#2} {#3} _tl }
       { \@@_label_ordered:nnTF {#2} {#3} { -> } { <- } }
   }
 %    \end{macrocode}
@@ -5206,11 +5210,15 @@
 %   together in hook |#1|.
 %    \begin{macrocode}
 \cs_new_protected:cpn { @@_rule_incompatible-error_gset:nnn } #1#2#3
-  { \@@_tl_gset:cn { g_@@_#1_rule_ \@@_label_pair:nn {#2} {#3}_tl}
-                   { xE } }
+  { \@@_tl_gset:cn
+      { g_@@_#1_rule_ \@@_label_pair:nn {#2} {#3} _tl }
+      { xE }
+  }
 \cs_new_protected:cpn { @@_rule_incompatible-warning_gset:nnn } #1#2#3
-  { \@@_tl_gset:cn { g_@@_#1_rule_ \@@_label_pair:nn {#2} {#3}_tl}
-                   { xW } }
+  { \@@_tl_gset:cn
+      { g_@@_#1_rule_ \@@_label_pair:nn {#2} {#3} _tl }
+      { xW }
+  }
 %    \end{macrocode}
 %  \end{macro}
 %
@@ -5792,7 +5800,8 @@
 %<latexrelease>    \tl_set_eq:Nc \l_@@_front_tl { \@@_tl_csname:n { 0 } }
 %<latexrelease>    \@@_tl_gclear:N #1
 %<latexrelease>    \clist_gclear:N #2
-%<latexrelease>    \bool_while_do:nn { ! \str_if_eq_p:Vn \l_@@_front_tl { 0 }}
+%<latexrelease>    \bool_while_do:nn
+%<latexrelease>      { ! \str_if_eq_p:Vn \l_@@_front_tl { 0 } }
 %<latexrelease>      {
 %<latexrelease>        \int_decr:N \l_@@_labels_int
 %<latexrelease>        \prop_get:NVN \l_@@_work_prop
@@ -6479,7 +6488,8 @@
 %<latexrelease>\IncludeInRelease{2020/10/01}{\hook_gput_next_code:nn}
 %<latexrelease>                 {Hooks~with~args}
 %<latexrelease>\cs_gset_protected:Npn \hook_gput_next_code:nn #1
-%<latexrelease>  { \@@_normalize_hook_args:Nn \@@_gput_next_code:nn {#1}}
+%<latexrelease>  { \@@_normalize_hook_args:Nn
+%<latexrelease>        \@@_gput_next_code:nn {#1} }
 %<latexrelease>\cs_gset_protected:Npn \hook_gput_next_code_with_args:nn #1 #2 { }
 %<latexrelease>\EndIncludeInRelease
 %    \end{macrocode}
@@ -6671,7 +6681,8 @@
 %<latexrelease>    \fi:
 %<latexrelease>    \cs:w @@~#1 \@@_use_end:
 %<latexrelease>  }
-%<latexrelease>\cs_new:Npn \@@_use_undefined:w #1#2 @@~#3\@@_use_end:
+%<latexrelease>\cs_new:Npn \@@_use_undefined:w
+%<latexrelease>    #1 #2 @@~#3 \@@_use_end:
 %<latexrelease>  {
 %<latexrelease>    #1 % fi
 %<latexrelease>    \@@_use:wn #3 / \s_@@_mark {#3}

--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -3893,7 +3893,8 @@
 %<latexrelease>                 {Standardise~generic~hook~names}
 %<latexrelease>\cs_gset_protected:Npn \@@_try_declaring_generic_hook:nnn #1
 %<latexrelease>  {
-%<latexrelease>    \@@_try_declaring_generic_hook:wnTF #1 ///\scan_stop: {#1}
+%<latexrelease>    \@@_try_declaring_generic_hook:wnTF #1 / / / \scan_stop:
+%<latexrelease>      {#1}
 %<latexrelease>      \hook_gput_code:nnn
 %<latexrelease>      \@@_gput_undeclared_hook:nnn
 %<latexrelease>        {#1}
@@ -3901,7 +3902,8 @@
 %<latexrelease>\cs_gset_protected:Npn
 %<latexrelease>  \@@_try_declaring_generic_next_hook:nn #1
 %<latexrelease>  {
-%<latexrelease>    \@@_try_declaring_generic_hook:wnTF #1 ///\scan_stop: {#1}
+%<latexrelease>    \@@_try_declaring_generic_hook:wnTF #1 / / / \scan_stop:
+%<latexrelease>      {#1}
 %<latexrelease>      \hook_gput_next_code:nn
 %<latexrelease>      \@@_gput_next_do:nn
 %<latexrelease>        {#1}
@@ -3957,7 +3959,8 @@
 %<latexrelease>\cs_new_protected:Npn
 %<latexrelease>    \@@_try_declaring_generic_hook_split:nNNnn #1 #2 #3
 %<latexrelease>  {
-%<latexrelease>    \@@_try_declaring_generic_hook:wnTF #1 ///\scan_stop: {#1}
+%<latexrelease>    \@@_try_declaring_generic_hook:wnTF #1 / / / \scan_stop:
+%<latexrelease>      {#1}
 %<latexrelease>      { #2 }
 %<latexrelease>      { #3 } {#1}
 %<latexrelease>  }

--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -32,7 +32,7 @@
 %
 %    \begin{macrocode}
 \def\lthooksversion{v1.1g}
-\def\lthooksdate{2024/01/16}
+\def\lthooksdate{2024/01/17}
 %    \end{macrocode}
 %
 %<*driver>
@@ -3534,7 +3534,7 @@
         \msg_error:nnnnn { hooks } { set-top-level }
           { for } { SetDefaultHookLabel } {#1}
       }
-      { \exp_args:Nx \@@_set_default_label:n { \@@_make_name:n {#1} } }
+      { \exp_args:Nx \@@_set_default_label:n { \@@_make_name:n {#1}}}
   }
 \cs_new_protected:Npn \@@_set_default_label:n #1
   {
@@ -3747,7 +3747,8 @@
 %<latexrelease>\IncludeInRelease{2020/10/01}{\hook_gput_code:nnn}
 %<latexrelease>                 {Providing~hooks}
 %<latexrelease>\cs_gset_protected:Npn \hook_gput_code:nnn #1 #2
-%<latexrelease>  { \@@_normalize_hook_args:Nnn \@@_gput_code:nnn {#1} {#2} }
+%<latexrelease>  { \@@_normalize_hook_args:Nnn
+%<latexrelease>        \@@_gput_code:nnn {#1} {#2} }
 %<latexrelease>\cs_gset_protected:Npn \@@_gput_code:nnn #1 #2 #3
 %<latexrelease>  {
 %<latexrelease>    \@@_if_execute_immediately:nTF {#1}
@@ -3761,7 +3762,8 @@
 %<latexrelease>          {
 %<latexrelease>            \@@_if_disabled:nTF {#1}
 %<latexrelease>              { \msg_error:nnn { hooks } { hook-disabled } {#1} }
-%<latexrelease>              { \@@_try_declaring_generic_hook:nnn {#1} {#2} {#3} }
+%<latexrelease>              { \@@_try_declaring_generic_hook:nnn
+%<latexrelease>                  {#1} {#2} {#3} }
 %<latexrelease>          }
 %<latexrelease>      }
 %<latexrelease>  }
@@ -3773,7 +3775,8 @@
 %<latexrelease>                      \on@line\space <-~ \tl_to_str:n{#3}} }
 %<latexrelease>    \str_if_eq:nnTF {#2} { top-level }
 %<latexrelease>      {
-%<latexrelease>        \str_if_eq:eeTF { top-level } { \@@_currname_or_default: }
+%<latexrelease>        \str_if_eq:eeTF { top-level }
+%<latexrelease>                        { \@@_currname_or_default: }
 %<latexrelease>          {
 %<latexrelease>            \@@_init_structure:n {#1}
 %<latexrelease>            \@@_tl_gput_right:cn { @@_toplevel~#1 } {#3}
@@ -3781,7 +3784,8 @@
 %<latexrelease>          { \msg_error:nnn { hooks } { misused-top-level } {#1} }
 %<latexrelease>      }
 %<latexrelease>      {
-%<latexrelease>        \prop_get:cnNTF { g_@@_#1_code_prop } {#2} \l_@@_return_tl
+%<latexrelease>        \prop_get:cnNTF
+%<latexrelease>          { g_@@_#1_code_prop } {#2} \l_@@_return_tl
 %<latexrelease>          {
 %<latexrelease>            \prop_gput:cno { g_@@_#1_code_prop } {#2}
 %<latexrelease>              { \l_@@_return_tl #3 }
@@ -3865,7 +3869,8 @@
 % \changes{v1.1d}{2023/05/21}
 %         {Changes to allow support arguments in cmd hooks (cmd-args).}
 %    \begin{macrocode}
-%<latexrelease>\IncludeInRelease{2023/06/01}{\@@_try_declaring_generic_hook:nnn}
+%<latexrelease>\IncludeInRelease{2023/06/01}
+%<latexrelease>                 {\@@_try_declaring_generic_hook:nnn}
 %<latexrelease>                 {Hooks~with~args}
 \cs_new_protected:Npn \@@_try_declaring_generic_hook:nnn #1
   {
@@ -3882,31 +3887,36 @@
         {#1}
   }
 %<latexrelease>\EndIncludeInRelease
-%<latexrelease>\IncludeInRelease{2021/11/15}{\@@_try_declaring_generic_hook:nnn}
+%<latexrelease>\IncludeInRelease{2021/11/15}
+%<latexrelease>                 {\@@_try_declaring_generic_hook:nnn}
 %<latexrelease>                 {Standardise~generic~hook~names}
 %<latexrelease>\cs_gset_protected:Npn \@@_try_declaring_generic_hook:nnn #1
 %<latexrelease>  {
-%<latexrelease>    \@@_try_declaring_generic_hook:wnTF #1 / / / \scan_stop: {#1}
+%<latexrelease>    \@@_try_declaring_generic_hook:wnTF #1 ///\scan_stop: {#1}
 %<latexrelease>      \hook_gput_code:nnn
 %<latexrelease>      \@@_gput_undeclared_hook:nnn
 %<latexrelease>        {#1}
 %<latexrelease>  }
-%<latexrelease>\cs_gset_protected:Npn \@@_try_declaring_generic_next_hook:nn #1
+%<latexrelease>\cs_gset_protected:Npn
+%<latexrelease>  \@@_try_declaring_generic_next_hook:nn #1
 %<latexrelease>  {
-%<latexrelease>    \@@_try_declaring_generic_hook:wnTF #1 / / / \scan_stop: {#1}
+%<latexrelease>    \@@_try_declaring_generic_hook:wnTF #1 ///\scan_stop: {#1}
 %<latexrelease>      \hook_gput_next_code:nn
 %<latexrelease>      \@@_gput_next_do:nn
 %<latexrelease>        {#1}
 %<latexrelease>  }
 %<latexrelease>\EndIncludeInRelease
-%<latexrelease>\IncludeInRelease{2020/10/01}{\@@_try_declaring_generic_hook:nnn}
+%<latexrelease>\IncludeInRelease{2020/10/01}
+%<latexrelease>                 {\@@_try_declaring_generic_hook:nnn}
 %<latexrelease>                 {Standardise~generic~hook~names}
-%<latexrelease>\cs_new_protected:Npn \@@_try_declaring_generic_hook:nnn #1
+%<latexrelease>\cs_new_protected:Npn
+%<latexrelease>  \@@_try_declaring_generic_hook:nnn #1
 %<latexrelease>  {
 %<latexrelease>    \@@_try_declaring_generic_hook:nNNnn {#1}
 %<latexrelease>      \hook_gput_code:nnn \@@_gput_undeclared_hook:nnn
 %<latexrelease>  }
-%<latexrelease>\cs_new_protected:Npn \@@_try_declaring_generic_next_hook:nn #1
+%<latexrelease>\cs_new_protected:Npn
+%<latexrelease>  \@@_try_declaring_generic_next_hook:nn #1
 %<latexrelease>  {
 %<latexrelease>    \@@_try_declaring_generic_hook:nNNnn {#1}
 %<latexrelease>      \hook_gput_next_code:nn \@@_gput_next_do:nn
@@ -3934,7 +3944,8 @@
 %<latexrelease>  {
 %<latexrelease>    \@@_if_file_hook:wTF #1 / \s_@@_mark
 %<latexrelease>      {
-%<latexrelease>        \exp_args:Ne \@@_try_declaring_generic_hook_split:nNNnn
+%<latexrelease>        \exp_args:Ne
+%<latexrelease>        \@@_try_declaring_generic_hook_split:nNNnn
 %<latexrelease>          { \exp_args:Ne \@@_file_hook_normalize:n {#1} }
 %<latexrelease>      }
 %<latexrelease>      { \@@_try_declaring_generic_hook_split:nNNnn {#1} }
@@ -3942,9 +3953,10 @@
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-%<latexrelease>\cs_new_protected:Npn \@@_try_declaring_generic_hook_split:nNNnn #1 #2 #3
+%<latexrelease>\cs_new_protected:Npn
+%<latexrelease>    \@@_try_declaring_generic_hook_split:nNNnn #1 #2 #3
 %<latexrelease>  {
-%<latexrelease>    \@@_try_declaring_generic_hook:wnTF #1 / / / \scan_stop: {#1}
+%<latexrelease>    \@@_try_declaring_generic_hook:wnTF #1 ///\scan_stop: {#1}
 %<latexrelease>      { #2 }
 %<latexrelease>      { #3 } {#1}
 %<latexrelease>  }
@@ -3956,9 +3968,11 @@
 % \changes{v1.1a}{2023/04/06}
 %         {Changes to add hook arguments (hook-args).}
 %    \begin{macrocode}
-%<latexrelease>\IncludeInRelease{2023/06/01}{\@@_try_declaring_generic_hook:wn}
+%<latexrelease>\IncludeInRelease{2023/06/01}
+%<latexrelease>                 {\@@_try_declaring_generic_hook:wn}
 %<latexrelease>                 {Hooks~with~args}
-\prg_new_protected_conditional:Npnn \@@_try_declaring_generic_hook:wn
+\prg_new_protected_conditional:Npnn
+    \@@_try_declaring_generic_hook:wn
     #1 / #2 / #3 / #4 \scan_stop: #5 { TF }
   {
     \@@_if_generic:nTF {#5}
@@ -4077,9 +4091,11 @@
 % \end{macro}
 %
 %    \begin{macrocode}
-%<latexrelease>\IncludeInRelease{2021/11/15}{\@@_try_declaring_generic_hook:wn}
+%<latexrelease>\IncludeInRelease{2021/11/15}
+%<latexrelease>                 {\@@_try_declaring_generic_hook:wn}
 %<latexrelease>                 {Standardise~generic~hook~names}
-%<latexrelease>\prg_new_protected_conditional:Npnn \@@_try_declaring_generic_hook:wn
+%<latexrelease>\prg_new_protected_conditional:Npnn
+%<latexrelease>    \@@_try_declaring_generic_hook:wn
 %<latexrelease>    #1 / #2 / #3 / #4 \scan_stop: #5 { TF }
 %<latexrelease>  {
 %<latexrelease>    \@@_if_generic:nTF {#5}
@@ -4108,9 +4124,11 @@
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-%<latexrelease>\IncludeInRelease{2021/06/01}{\@@_try_declaring_generic_hook:wn}
+%<latexrelease>\IncludeInRelease{2021/06/01}
+%<latexrelease>                 {\@@_try_declaring_generic_hook:wn}
 %<latexrelease>                 {Support~cmd~hooks}
-%<latexrelease>\prg_new_protected_conditional:Npnn \@@_try_declaring_generic_hook:wn
+%<latexrelease>\prg_new_protected_conditional:Npnn
+%<latexrelease>    \@@_try_declaring_generic_hook:wn
 %<latexrelease>    #1 / #2 / #3 / #4 \scan_stop: #5 { TF }
 %<latexrelease>  {
 %<latexrelease>    \tl_if_empty:nTF {#2}
@@ -4124,10 +4142,12 @@
 %<latexrelease>                  { \@@_try_put_cmd_hook:n {#5} }
 %<latexrelease>                \@@_make_usable:n {#5}
 %<latexrelease>              }
-%<latexrelease>            \prop_if_in:NnTF \c_@@_generics_reversed_ii_prop {#2}
+%<latexrelease>            \prop_if_in:NnTF
+%<latexrelease>              \c_@@_generics_reversed_ii_prop {#2}
 %<latexrelease>              { \tl_gset:cn { g_@@_#5_reversed_tl } { - } }
 %<latexrelease>              {
-%<latexrelease>                \prop_if_in:NnT \c_@@_generics_reversed_iii_prop {#3}
+%<latexrelease>                \prop_if_in:NnT
+%<latexrelease>                  \c_@@_generics_reversed_iii_prop {#3}
 %<latexrelease>                  { \tl_gset:cn { g_@@_#5_reversed_tl } { - } }
 %<latexrelease>              }
 %<latexrelease>            \prg_return_true:
@@ -4139,9 +4159,11 @@
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-%<latexrelease>\IncludeInRelease{2020/10/01}{\@@_try_declaring_generic_hook:wn}
+%<latexrelease>\IncludeInRelease{2020/10/01}
+%<latexrelease>                 {\@@_try_declaring_generic_hook:wn}
 %<latexrelease>                 {Support~cmd~hooks}
-%<latexrelease>\prg_new_protected_conditional:Npnn \@@_try_declaring_generic_hook:wn
+%<latexrelease>\prg_new_protected_conditional:Npnn
+%<latexrelease>    \@@_try_declaring_generic_hook:wn
 %<latexrelease>    #1 / #2 / #3 / #4 \scan_stop: #5 { TF }
 %<latexrelease>  {
 %<latexrelease>    \tl_if_empty:nTF {#2}
@@ -4150,10 +4172,12 @@
 %<latexrelease>        \prop_if_in:NnTF \c_@@_generics_prop {#1}
 %<latexrelease>          {
 %<latexrelease>            \@@_if_declared:nF {#5} { \hook_new:n {#5} }
-%<latexrelease>            \prop_if_in:NnTF \c_@@_generics_reversed_ii_prop {#2}
+%<latexrelease>            \prop_if_in:NnTF
+%<latexrelease>              \c_@@_generics_reversed_ii_prop {#2}
 %<latexrelease>              { \tl_gset:cn { g_@@_#5_reversed_tl } { - } }
 %<latexrelease>              {
-%<latexrelease>                \prop_if_in:NnT \c_@@_generics_reversed_iii_prop {#3}
+%<latexrelease>                \prop_if_in:NnT
+%<latexrelease>                  \c_@@_generics_reversed_iii_prop {#3}
 %<latexrelease>                  { \tl_gset:cn { g_@@_#5_reversed_tl } { - } }
 %<latexrelease>              }
 %<latexrelease>            \prg_return_true:
@@ -4229,11 +4253,11 @@
 %   \changes{v1.0h}{2021/01/07}{Assume hook name has at least three
 %     nonempty parts (gh/464)}
 %    \begin{macrocode}
-%<latexrelease>\cs_new:Npn \@@_strip_double_slash:w #1/#2/#3 // #4 \s_@@_mark
+%<latexrelease>\cs_new:Npn \@@_strip_double_slash:w #1/#2/#3//#4\s_@@_mark
 %<latexrelease>  {
 %<latexrelease>    \tl_if_empty:nTF {#4}
 %<latexrelease>      { #1/#2/#3 }
-%<latexrelease>      { \@@_strip_double_slash:w #1/#2/#3 / #4 \s_@@_mark }
+%<latexrelease>      { \@@_strip_double_slash:w #1/#2/#3 /#4\s_@@_mark }
 %<latexrelease>  }
 %<latexrelease>\EndIncludeInRelease
 %    \end{macrocode}
@@ -4312,9 +4336,12 @@
 %    \begin{macrocode}
 %<latexrelease>\IncludeInRelease{2020/10/01}{\c_@@_generics_reversed_ii_prop}
 %<latexrelease>                 {Standardise~generic~hook~names}
-%<latexrelease>\prop_const_from_keyval:Nn \c_@@_generics_reversed_ii_prop {after=,end=}
-%<latexrelease>\prop_const_from_keyval:Nn \c_@@_generics_reversed_iii_prop {after=}
-%<latexrelease>\prop_const_from_keyval:Nn \c_@@_generics_file_prop {before=,after=}
+%<latexrelease>\prop_const_from_keyval:Nn
+%<latexrelease>    \c_@@_generics_reversed_ii_prop {after=,end=}
+%<latexrelease>\prop_const_from_keyval:Nn
+%<latexrelease>    \c_@@_generics_reversed_iii_prop {after=}
+%<latexrelease>\prop_const_from_keyval:Nn
+%<latexrelease>    \c_@@_generics_file_prop {before=,after=}
 %<latexrelease>\EndIncludeInRelease
 %    \end{macrocode}
 %  \end{macro}
@@ -4394,7 +4421,8 @@
             \str_if_eq:nnTF {#2} { top-level }
               { \@@_toplevel_gset:nn {#1} { } }
               {
-                \prop_gpop:cnNF { g_@@_#1_code_prop } {#2} \l_@@_return_tl
+                \prop_gpop:cnNF { g_@@_#1_code_prop }
+                  {#2} \l_@@_return_tl
                   { \msg_warning:nnnn { hooks } { cannot-remove } {#1} {#2} }
               }
           }
@@ -4412,7 +4440,8 @@
         \@@_if_deprecated_generic:nTF {#1}
           {
             \@@_deprecated_generic_warn:n {#1}
-            \@@_do_deprecated_generic:Nn \@@_gremove_code:nn {#1} {#2}
+            \@@_do_deprecated_generic:Nn
+                \@@_gremove_code:nn {#1} {#2}
           }
           { \msg_warning:nnnn { hooks } { cannot-remove } {#1} {#2} }
       }
@@ -4437,8 +4466,10 @@
 %<latexrelease>            \str_if_eq:nnTF {#2} { top-level }
 %<latexrelease>              { \@@_tl_gclear:c { @@_toplevel~#1 } }
 %<latexrelease>              {
-%<latexrelease>                \prop_gpop:cnNF { g_@@_#1_code_prop } {#2} \l_@@_return_tl
-%<latexrelease>                  { \msg_warning:nnnn { hooks } { cannot-remove } {#1} {#2} }
+%<latexrelease>                \prop_gpop:cnNF { g_@@_#1_code_prop }
+%<latexrelease>                  {#2} \l_@@_return_tl
+%<latexrelease>                  { \msg_warning:nnnn { hooks } { cannot-remove }
+%<latexrelease>                                      {#1} {#2} }
 %<latexrelease>              }
 %<latexrelease>          }
 %<latexrelease>        \@@_if_usable:nT {#1}
@@ -4448,9 +4479,11 @@
 %<latexrelease>        \@@_if_deprecated_generic:nTF {#1}
 %<latexrelease>          {
 %<latexrelease>            \@@_deprecated_generic_warn:n {#1}
-%<latexrelease>            \@@_do_deprecated_generic:Nn \@@_gremove_code:nn {#1} {#2}
+%<latexrelease>            \@@_do_deprecated_generic:Nn
+%<latexrelease>                \@@_gremove_code:nn {#1} {#2}
 %<latexrelease>          }
-%<latexrelease>          { \msg_warning:nnnn { hooks } { cannot-remove } {#1} {#2} }
+%<latexrelease>          { \msg_warning:nnnn { hooks } { cannot-remove }
+%<latexrelease>                              {#1} {#2} }
 %<latexrelease>      }
 %<latexrelease>  }
 %<latexrelease>\EndIncludeInRelease
@@ -4492,7 +4525,8 @@
         {#1} {#2}
   }
 \cs_new_protected:Npn \@@_cs_gput_right_fast:nnn #1 #2 #3
-  { \cs_gset:cpx { @@#1~#2 } { \exp_not:v { @@#1~#2 } \exp_not:n {#3} } }
+  { \cs_gset:cpx { @@#1~#2 }
+      { \exp_not:v { @@#1~#2 } \exp_not:n {#3} } }
 \cs_new_protected:Npn \@@_cs_gput_right_slow:nnn #1 #2 #3
   {
 %    \end{macrocode}
@@ -4718,7 +4752,8 @@
 %    \begin{macrocode}
     \exp_last_unbraced:NNf
     \cs_set:Npn \@@_tmp:w { \@@_parameter:n {#1} } { }
-    \tl_set:Ne \l_@@_tmpa_tl { \@@_braced_cs_parameter:n { @@_tmp:w } }
+    \tl_set:Ne \l_@@_tmpa_tl
+      { \@@_braced_cs_parameter:n { @@_tmp:w } }
 %    \end{macrocode}
 %   Now this function does the fun part.  It is meant to be used with
 %   \cs{prop_map_function:NN}, taking a label name in \verb|##1| and the
@@ -5094,8 +5129,8 @@
 %<latexrelease>    \@@_if_deprecated_generic:nT {#1}
 %<latexrelease>      {
 %<latexrelease>        \@@_deprecated_generic_warn:n {#1}
-%<latexrelease>        \@@_do_deprecated_generic:Nn \@@_gset_rule:nnnn {#1}
-%<latexrelease>          {#2} {#3} {#4}
+%<latexrelease>        \@@_do_deprecated_generic:Nn \@@_gset_rule:nnnn
+%<latexrelease>          {#1} {#2} {#3} {#4}
 %<latexrelease>        \exp_after:wN \use_none:nnnnnnnnn \use_none:n
 %<latexrelease>      }
 %<latexrelease>    \@@_init_structure:n {#1}
@@ -5135,7 +5170,7 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_rule_before_gset:nnn #1#2#3
   {
-    \@@_tl_gset:cx { g_@@_#1_rule_ \@@_label_pair:nn {#2} {#3} _tl }
+    \@@_tl_gset:cx { g_@@_#1_rule_ \@@_label_pair:nn {#2} {#3}_tl}
       { \@@_label_ordered:nnTF {#2} {#3} { < } { > } }
   }
 \cs_new_eq:cN { @@_rule_<_gset:nnn } \@@_rule_before_gset:nnn
@@ -5144,7 +5179,7 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_rule_after_gset:nnn #1#2#3
   {
-    \@@_tl_gset:cx { g_@@_#1_rule_ \@@_label_pair:nn {#3} {#2} _tl }
+    \@@_tl_gset:cx { g_@@_#1_rule_ \@@_label_pair:nn {#3} {#2}_tl}
       { \@@_label_ordered:nnTF {#3} {#2} { < } { > } }
   }
 \cs_new_eq:cN { @@_rule_>_gset:nnn } \@@_rule_after_gset:nnn
@@ -5157,7 +5192,7 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_rule_voids_gset:nnn #1#2#3
   {
-    \@@_tl_gset:cx { g_@@_#1_rule_ \@@_label_pair:nn {#2} {#3} _tl }
+    \@@_tl_gset:cx { g_@@_#1_rule_ \@@_label_pair:nn {#2} {#3}_tl}
       { \@@_label_ordered:nnTF {#2} {#3} { -> } { <- } }
   }
 %    \end{macrocode}
@@ -5171,10 +5206,10 @@
 %   together in hook |#1|.
 %    \begin{macrocode}
 \cs_new_protected:cpn { @@_rule_incompatible-error_gset:nnn } #1#2#3
-  { \@@_tl_gset:cn { g_@@_#1_rule_ \@@_label_pair:nn {#2} {#3} _tl }
+  { \@@_tl_gset:cn { g_@@_#1_rule_ \@@_label_pair:nn {#2} {#3}_tl}
                    { xE } }
 \cs_new_protected:cpn { @@_rule_incompatible-warning_gset:nnn } #1#2#3
-  { \@@_tl_gset:cn { g_@@_#1_rule_ \@@_label_pair:nn {#2} {#3} _tl }
+  { \@@_tl_gset:cn { g_@@_#1_rule_ \@@_label_pair:nn {#2} {#3}_tl}
                    { xW } }
 %    \end{macrocode}
 %  \end{macro}
@@ -5306,7 +5341,8 @@
 %<latexrelease>                 {Hooks~with~args}
 %<latexrelease>\cs_gset_protected:Npn \@@_initialize_all:
 %<latexrelease>  {
-%<latexrelease>    \cs_gset_eq:NN \@@_update_hook_code:n \@@_initialize_hook_code:n
+%<latexrelease>    \cs_gset_eq:NN \@@_update_hook_code:n
+%<latexrelease>                   \@@_initialize_hook_code:n
 %<latexrelease>    \@@_debug:n { \prop_gclear:N \g_@@_used_prop }
 %<latexrelease>    \seq_map_inline:Nn \g_@@_all_seq
 %<latexrelease>      { \@@_update_hook_code:n {##1} }
@@ -5316,7 +5352,8 @@
 %<latexrelease>        \prop_map_inline:Nn \g_@@_used_prop
 %<latexrelease>          {
 %<latexrelease>            \iow_term:x
-%<latexrelease>              { ^^J ~ ##1 ~ -> ~ \cs_replacement_spec:c { @@~##1 } ~ }
+%<latexrelease>              { ^^J ~ ##1 ~ -> ~
+%<latexrelease>                \cs_replacement_spec:c { @@~##1 } ~ }
 %<latexrelease>          }
 %<latexrelease>      }
 %<latexrelease>    \cs_gset_eq:NN \hook_use:n \@@_use_initialized:n
@@ -5375,8 +5412,10 @@
 %   after the \verb|_next| and \verb|_toplevel| macros, so that the
 %   arguments passed to the hook are forwarded to them.
 %    \begin{macrocode}
-                \exp_not:c { @@_toplevel~#1 } \@@_braced_parameter:n {#1}
-                \exp_not:c { @@_next~#1 } \@@_braced_parameter:n {#1}
+                \exp_not:c { @@_toplevel~#1 }
+                \@@_braced_parameter:n {#1}
+                \exp_not:c { @@_next~#1 }
+                \@@_braced_parameter:n {#1}
               }
           }
           {
@@ -5425,7 +5464,8 @@
 %<latexrelease>\cs_gset_protected:Npn \@@_initialize_hook_code:n #1
 %<latexrelease>  {
 %<latexrelease>    \@@_debug:n
-%<latexrelease>      { \iow_term:x { ^^J Update~code~for~hook~'#1' \on@line :^^J } }
+%<latexrelease>      { \iow_term:x { ^^J Update~code~for~hook~'#1'
+%<latexrelease>                      \on@line :^^J } }
 %<latexrelease>    \@@_include_legacy_code_chunk:n {#1}
 %<latexrelease>    \@@_if_usable:nT {#1}
 %<latexrelease>      {
@@ -5439,15 +5479,21 @@
 %<latexrelease>          }
 %<latexrelease>          {
 %<latexrelease>            \@@_if_reversed:nTF {#1}
-%<latexrelease>              { \cs_set_eq:NN \@@_tl_gput:Nn    \@@_tl_gput_left:Nn
-%<latexrelease>                \cs_set_eq:NN \@@_clist_gput:NV \clist_gput_left:NV  }
-%<latexrelease>              { \cs_set_eq:NN \@@_tl_gput:Nn    \@@_tl_gput_right:Nn
-%<latexrelease>                \cs_set_eq:NN \@@_clist_gput:NV \clist_gput_right:NV }
-%<latexrelease>            \prop_set_eq:Nc \l_@@_work_prop { g_@@_#1_code_prop }
+%<latexrelease>              { \cs_set_eq:NN \@@_tl_gput:Nn
+%<latexrelease>                              \@@_tl_gput_left:Nn
+%<latexrelease>                \cs_set_eq:NN \@@_clist_gput:NV
+%<latexrelease>                              \clist_gput_left:NV  }
+%<latexrelease>              { \cs_set_eq:NN \@@_tl_gput:Nn
+%<latexrelease>                              \@@_tl_gput_right:Nn
+%<latexrelease>                \cs_set_eq:NN \@@_clist_gput:NV
+%<latexrelease>                              \clist_gput_right:NV }
+%<latexrelease>            \prop_set_eq:Nc \l_@@_work_prop
+%<latexrelease>              { g_@@_#1_code_prop }
 %<latexrelease>            \@@_initialize_single:ccn
 %<latexrelease>              { @@~#1 } { g_@@_#1_labels_clist } {#1}
 %<latexrelease>            \@@_debug:n
-%<latexrelease>              { \exp_args:NNx \prop_gput:Nnn \g_@@_used_prop {#1} { } }
+%<latexrelease>              { \exp_args:NNx \prop_gput:Nnn \g_@@_used_prop
+%<latexrelease>                    {#1} { } }
 %<latexrelease>          }
 %<latexrelease>      }
 %<latexrelease>  }
@@ -5646,7 +5692,8 @@
             \int_compare:nNnT
                 { \cs:w \@@_tl_csname:n {##1} \cs_end: } = 0
                 {
-                  \tl_set:cn { \@@_tl_csname:n { \l_@@_rear_tl } } {##1}
+                  \tl_set:cn
+                    { \@@_tl_csname:n { \l_@@_rear_tl } } {##1}
                   \tl_set:Nn \l_@@_rear_tl            {##1}
                 }
           }
@@ -5728,42 +5775,49 @@
 %<latexrelease>                  {#3}
 %<latexrelease>          }
 %<latexrelease>      }
-%<latexrelease>    \@@_debug:n { \@@_debug_label_data:N \l_@@_work_prop }
+%<latexrelease>    \@@_debug:n
+%<latexrelease>      { \@@_debug_label_data:N \l_@@_work_prop }
 %<latexrelease>    \tl_set:Nn \l_@@_rear_tl { 0 }
 %<latexrelease>    \tl_set:cn { \@@_tl_csname:n { 0 } } { 0 }
 %<latexrelease>    \seq_map_inline:Nn \l_@@_labels_seq
 %<latexrelease>      {
-%<latexrelease>        \int_compare:nNnT { \cs:w \@@_tl_csname:n {##1} \cs_end: } = 0
-%<latexrelease>            {
-%<latexrelease>              \tl_set:cn { \@@_tl_csname:n { \l_@@_rear_tl } }{##1}
-%<latexrelease>              \tl_set:Nn \l_@@_rear_tl {##1}
-%<latexrelease>            }
+%<latexrelease>        \int_compare:nNnT
+%<latexrelease>          { \cs:w \@@_tl_csname:n {##1} \cs_end: } = 0
+%<latexrelease>          {
+%<latexrelease>            \tl_set:cn { \@@_tl_csname:n 
+%<latexrelease>                           { \l_@@_rear_tl } } {##1}
+%<latexrelease>            \tl_set:Nn \l_@@_rear_tl           {##1}
+%<latexrelease>          }
 %<latexrelease>      }
 %<latexrelease>    \tl_set_eq:Nc \l_@@_front_tl { \@@_tl_csname:n { 0 } }
 %<latexrelease>    \@@_tl_gclear:N #1
 %<latexrelease>    \clist_gclear:N #2
-%<latexrelease>    \bool_while_do:nn { ! \str_if_eq_p:Vn \l_@@_front_tl { 0 } }
+%<latexrelease>    \bool_while_do:nn { ! \str_if_eq_p:Vn \l_@@_front_tl { 0 }}
 %<latexrelease>      {
 %<latexrelease>        \int_decr:N \l_@@_labels_int
-%<latexrelease>        \prop_get:NVN \l_@@_work_prop \l_@@_front_tl \l_@@_return_tl
+%<latexrelease>        \prop_get:NVN \l_@@_work_prop
+%<latexrelease>            \l_@@_front_tl \l_@@_return_tl
 %<latexrelease>        \exp_args:NNV \@@_tl_gput:Nn #1 \l_@@_return_tl
 %<latexrelease>        \@@_clist_gput:NV #2 \l_@@_front_tl
-%<latexrelease>        \@@_debug:n{ \iow_term:x{Handled~ code~ for~ \l_@@_front_tl} }
-%<latexrelease>        \seq_map_inline:cn { \@@_seq_csname:n { \l_@@_front_tl } }
+%<latexrelease>        \@@_debug:n{ \iow_term:x
+%<latexrelease>              {Handled~ code~ for~ \l_@@_front_tl} }
+%<latexrelease>        \seq_map_inline:cn
+%<latexrelease>              { \@@_seq_csname:n { \l_@@_front_tl } }
 %<latexrelease>          {
 %<latexrelease>            \tl_set:cx { \@@_tl_csname:n {##1} }
-%<latexrelease>                       { \int_eval:n
-%<latexrelease>                           { \cs:w \@@_tl_csname:n {##1} \cs_end: - 1 }
-%<latexrelease>                       }
+%<latexrelease>              { \int_eval:n
+%<latexrelease>                { \cs:w \@@_tl_csname:n {##1} \cs_end: - 1 }
+%<latexrelease>              }
 %<latexrelease>            \int_compare:nNnT
-%<latexrelease>                { \cs:w \@@_tl_csname:n {##1} \cs_end: } = 0
-%<latexrelease>                {
-%<latexrelease>                  \tl_set:cn { \@@_tl_csname:n { \l_@@_rear_tl } } {##1}
-%<latexrelease>                  \tl_set:Nn \l_@@_rear_tl            {##1}
-%<latexrelease>                }
+%<latexrelease>              { \cs:w \@@_tl_csname:n {##1} \cs_end: } = 0
+%<latexrelease>              {
+%<latexrelease>                \tl_set:cn { \@@_tl_csname:n
+%<latexrelease>                               { \l_@@_rear_tl } } {##1}
+%<latexrelease>                \tl_set:Nn \l_@@_rear_tl           {##1}
+%<latexrelease>              }
 %<latexrelease>          }
 %<latexrelease>        \tl_set_eq:Nc \l_@@_front_tl
-%<latexrelease>                      { \@@_tl_csname:n { \l_@@_front_tl } }
+%<latexrelease>          { \@@_tl_csname:n { \l_@@_front_tl } }
 %<latexrelease>      }
 %<latexrelease>    \int_compare:nNnF \l_@@_labels_int = 0
 %<latexrelease>      {
@@ -5772,7 +5826,8 @@
 %<latexrelease>        \@@_debug_label_data:N \l_@@_work_prop
 %<latexrelease>        \iow_term:x{====================}
 %<latexrelease>      }
-%<latexrelease>    \exp_args:NNo \@@_tl_gput:Nn #1 { \cs:w @@_toplevel~#3 \cs_end: }
+%<latexrelease>    \exp_args:NNo \@@_tl_gput:Nn #1
+%<latexrelease>                    { \cs:w @@_toplevel~#3 \cs_end: }
 %<latexrelease>    \@@_tl_gput_right:No #1 { \cs:w @@_next~#3 \cs_end: }
 %<latexrelease>  }
 %<latexrelease>\cs_generate_variant:Nn \@@_tl_gput_right:Nn { No }
@@ -6191,7 +6246,8 @@
 %<latexrelease>      }
 %<latexrelease>    \@@_preamble_hook:n {#1}
 %<latexrelease>    \@@_log_cmd:x
-%<latexrelease>      { ^^J ->~The~ \@@_if_generic:nT {#1} { generic~ } hook~'#1': }
+%<latexrelease>      { ^^J ->~The~ \@@_if_generic:nT
+%<latexrelease>                      {#1} { generic~ } hook~'#1': }
 %<latexrelease>    \@@_if_usable:nF {#1}
 %<latexrelease>      { \@@_log_line:x { The~hook~is~not~declared. } }
 %<latexrelease>    \@@_if_disabled:nT {#1}
@@ -6204,26 +6260,30 @@
 %<latexrelease>          { \@@_log_line_indent:x { --- } }
 %<latexrelease>          {
 %<latexrelease>            \prop_map_inline:cn { g_@@_#1_code_prop }
-%<latexrelease>              { \@@_log_line_indent:x { ##1~->~\tl_to_str:n {##2} } }
+%<latexrelease>              { \@@_log_line_indent:x
+%<latexrelease>                  { ##1~->~\tl_to_str:n {##2} } }
 %<latexrelease>          }
 %<latexrelease>        \@@_log_line:x
 %<latexrelease>          {
 %<latexrelease>            Document-level~(top-level)~code
 %<latexrelease>            \@@_if_usable:nT {#1}
-%<latexrelease>              { ~(executed~\@@_if_reversed:nTF {#1} {first} {last} ) } :
+%<latexrelease>              { ~(executed~
+%<latexrelease>                \@@_if_reversed:nTF {#1} {first} {last} ) } :
 %<latexrelease>          }
 %<latexrelease>        \@@_log_line_indent:x
 %<latexrelease>          {
 %<latexrelease>            \tl_if_empty:cTF { @@_toplevel~#1 }
 %<latexrelease>              { --- }
-%<latexrelease>              { -> ~ \exp_args:Nv \tl_to_str:n { @@_toplevel~#1 } }
+%<latexrelease>              { -> ~ \exp_args:Nv \tl_to_str:n
+%<latexrelease>                                  { @@_toplevel~#1 } }
 %<latexrelease>          }
 %<latexrelease>        \@@_log_line:x { Extra~code~for~next~invocation: }
 %<latexrelease>        \@@_log_line_indent:x
 %<latexrelease>          {
 %<latexrelease>            \tl_if_empty:cTF { @@_next~#1 }
 %<latexrelease>              { --- }
-%<latexrelease>              { ->~ \exp_args:Nv \@@_log_next_code:n { @@_next~#1 } }
+%<latexrelease>              { ->~ \exp_args:Nv \@@_log_next_code:n
+%<latexrelease>                                   { @@_next~#1 } }
 %<latexrelease>          }
 %<latexrelease>        \@@_log_line:x { Rules: }
 %<latexrelease>        \bool_set_true:N \l_@@_tmpa_bool
@@ -6247,7 +6307,8 @@
 %<latexrelease>              {
 %<latexrelease>                Execution~order
 %<latexrelease>                \bool_if:NTF \l_@@_tmpa_bool
-%<latexrelease>                  { \@@_if_reversed:nT {#1} { ~(after~reversal) } }
+%<latexrelease>                  { \@@_if_reversed:nT
+%<latexrelease>                       {#1}{ ~(after~reversal) } }
 %<latexrelease>                  { ~(after~
 %<latexrelease>                    \@@_if_reversed:nT {#1} { reversal~and~ }
 %<latexrelease>                    applying~rules)
@@ -6258,16 +6319,19 @@
 %<latexrelease>                \@spaces
 %<latexrelease>                \clist_if_empty:cTF { g_@@_#1_labels_clist }
 %<latexrelease>                  { --- }
-%<latexrelease>                  { \clist_use:cn { g_@@_#1_labels_clist } { ,~ } }
+%<latexrelease>                  { \clist_use:cn
+%<latexrelease>                      { g_@@_#1_labels_clist } { ,~ } }
 %<latexrelease>              }
 %<latexrelease>          }
 %<latexrelease>          {
 %<latexrelease>            \@@_log_line:x { Execution~order: }
 %<latexrelease>            #2
 %<latexrelease>              {
-%<latexrelease>                \@spaces Not~set~because~the~hook~ \@@_if_usable:nTF {#1}
+%<latexrelease>                \@spaces Not~set~because~the~hook~
+%<latexrelease>                    \@@_if_usable:nTF {#1}
 %<latexrelease>                  { code~pool~is~empty }
-%<latexrelease>                  { is~\@@_if_disabled:nTF {#1} {disabled} {undeclared} }
+%<latexrelease>                  { is~\@@_if_disabled:nTF
+%<latexrelease>                      {#1} {disabled} {undeclared} }
 %<latexrelease>              }
 %<latexrelease>          }
 %<latexrelease>      }
@@ -6415,7 +6479,7 @@
 %<latexrelease>\IncludeInRelease{2020/10/01}{\hook_gput_next_code:nn}
 %<latexrelease>                 {Hooks~with~args}
 %<latexrelease>\cs_gset_protected:Npn \hook_gput_next_code:nn #1
-%<latexrelease>  { \@@_normalize_hook_args:Nn \@@_gput_next_code:nn {#1} }
+%<latexrelease>  { \@@_normalize_hook_args:Nn \@@_gput_next_code:nn {#1}}
 %<latexrelease>\cs_gset_protected:Npn \hook_gput_next_code_with_args:nn #1 #2 { }
 %<latexrelease>\EndIncludeInRelease
 %    \end{macrocode}
@@ -6607,7 +6671,7 @@
 %<latexrelease>    \fi:
 %<latexrelease>    \cs:w @@~#1 \@@_use_end:
 %<latexrelease>  }
-%<latexrelease>\cs_new:Npn \@@_use_undefined:w #1 #2 @@~#3 \@@_use_end:
+%<latexrelease>\cs_new:Npn \@@_use_undefined:w #1#2 @@~#3\@@_use_end:
 %<latexrelease>  {
 %<latexrelease>    #1 % fi
 %<latexrelease>    \@@_use:wn #3 / \s_@@_mark {#3}
@@ -6715,7 +6779,8 @@
 %<latexrelease>        \exp_args:Ne \@@_if_usable_use:n
 %<latexrelease>          { \exp_args:Ne \@@_file_hook_normalize:n {#1} }
 %<latexrelease>      }
-%<latexrelease>      { \@@_if_usable_use:n {#1} } % file/ generic hook (e.g. file/before)
+%<latexrelease>      { \@@_if_usable_use:n {#1} }
+%<latexrelease>            % file/ generic hook (e.g. file/before)
 %<latexrelease>  }
 %    \end{macrocode}
 %
@@ -6753,12 +6818,14 @@
 \cs_new_protected:Npn \hook_use_once:n #1
   {
     \@@_if_execute_immediately:nF {#1}
-      { \@@_normalize_hook_args:Nn \@@_use_once:nn { \use:n {#1} } { 0 } }
+      { \@@_normalize_hook_args:Nn \@@_use_once:nn
+          { \use:n {#1} } { 0 } }
   }
 \cs_new_protected:Npn \hook_use_once:nnw #1 #2
   {
     \@@_if_execute_immediately:nF {#1}
-      { \@@_normalize_hook_args:Nn \@@_use_once:nn { \use:n {#1} } {#2} }
+      { \@@_normalize_hook_args:Nn \@@_use_once:nn
+          { \use:n {#1} } {#2} }
   }
 %<latexrelease>\EndIncludeInRelease
 %    \end{macrocode}
@@ -6770,7 +6837,8 @@
 %<latexrelease>\cs_gset_protected:Npn \hook_use_once:n #1
 %<latexrelease>  {
 %<latexrelease>    \@@_if_execute_immediately:nF {#1}
-%<latexrelease>      { \@@_normalize_hook_args:Nn \@@_use_once:n { \use:n {#1} } }
+%<latexrelease>      { \@@_normalize_hook_args:Nn \@@_use_once:n
+%<latexrelease>          { \use:n {#1} } }
 %<latexrelease>  }
 %<latexrelease>\cs_gset:Npn \hook_use_once:nnw #1 #2
 %<latexrelease>  { \use:c { use_none: \prg_replicate:nn {#2} { n } } }
@@ -6795,7 +6863,8 @@
 %   along with the next execution code.
 %    \begin{macrocode}
     \@@_replacing_args_false:
-    \@@_cs_gput_right:nnn { _next } {#1} { \@@_use_once_clear:n {#1} }
+    \@@_cs_gput_right:nnn { _next } {#1}
+      { \@@_use_once_clear:n {#1} }
     \@@_replacing_args_reset:
     \@@_if_usable:nTF {#1}
       { \@@_use_initialized:n {#1} }
@@ -7242,7 +7311,8 @@
   { Cannot~add~code~to~disabled~hook~'#1'. }
   {
     The~hook~'#1'~you~tried~to~add~code~to~was~previously~disabled~
-    with~\iow_char:N\\hook_disable_generic:n~or~\iow_char:N\\DisableGenericHook,~so~
+    with~\iow_char:N\\hook_disable_generic:n~or~
+    \iow_char:N\\DisableGenericHook,~so~
     it~cannot~have~code~added~to~it.
   }
 %    \end{macrocode}
@@ -7410,7 +7480,7 @@
 %<latexrelease>                 {Hooks~with~args}
 %<latexrelease>\cs_new_protected:Npn \NewHookWithArguments #1 #2 { }
 %<latexrelease>\cs_new_protected:Npn \NewReversedHookWithArguments #1 #2 { }
-%<latexrelease>\cs_new_protected:Npn \NewMirroredHookPairWithArguments #1 #2 #3 { }
+%<latexrelease>\cs_new_protected:Npn \NewMirroredHookPairWithArguments #1 #2 #3{}
 %<latexrelease>\EndIncludeInRelease
 %    \end{macrocode}
 %  \end{macro}
@@ -7862,7 +7932,8 @@
 %<latexrelease>            \exp_args:No \exp_not:o
 %<latexrelease>              {
 %<latexrelease>                \cs:w @@#1~#2 \exp_last_unbraced:Ne \cs_end:
-%<latexrelease>                  { \@@_braced_cs_parameter:n { @@#1~#2 } }
+%<latexrelease>                  { \@@_braced_cs_parameter:n
+%<latexrelease>                      { @@#1~#2 } }
 %<latexrelease>              }
 %<latexrelease>          }
 %<latexrelease>      }


### PR DESCRIPTION
In order to improve the documentation, we do not want to add new warnings. This is why we try to remove as many of them. Some code has been reformatted by
- line breaking
- removing spaces
- reseting the indentation
Overfull hboxes essentially come from docstrip's `<latexrelease>` The documentation is not modified yet.

All checks passed.

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [X ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
