### PR TITLE
lthooks doc: unified code display

### DIFF
--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -32,7 +32,7 @@
 %
 %    \begin{macrocode}
 \def\lthooksversion{v1.1g}
-\def\lthooksdate{2024/01/17}
+\def\lthooksdate{2024/01/23}
 %    \end{macrocode}
 %
 %<*driver>
@@ -44,6 +44,7 @@
 
 \EnableCrossrefs
 \CodelineIndex
+
 \begin{document}
   \DocInput{lthooks.dtx}
 \end{document}
@@ -51,8 +52,508 @@
 %
 % \fi
 %
+% \iffalse
+% The documentation below is only for the authors of this very documentation.
+% \begin{function}
+%   {
+%     \lthooksCodeSetup
+%   }
+%   \begin{syntax}
+%     \cs{lthooksCodeSetup}\oarg{mode}\marg{options}
+%   \end{syntax}
+% This function sets up a state in which lines of code will be displayed.
+% Different levels are allowed: \enquote{|lthooksCode/DOC|},
+% \enquote{|lthooksCode/ENV|} and \enquote{|lthooksCode/ROW|}.
+% The \enquote{|lthooksCode/ROW|} inherits from \enquote{|lthooksCode/ENV|}
+% which in turn inherits from \enquote{|lthooksCode/DOC|}.
+% Some attributes override the inherited value, some are appended to the inherited value.
+% There are relationships defined below to model this behavior.
+% By default, the current value is appended to the inherited one
+%    \begin{macrocode}
+% \fi
+% \ExplSyntaxOn
+% \hook_gset_rule:nnnn { * } { lthooksCode/ENV } { after } { lthooksCode/DOC }
+% \hook_gset_rule:nnnn { * } { lthooksCode/ROW } { after } { lthooksCode/ENV }
+% \iffalse
+%    \end{macrocode}
+% Utility to define overriding in inheritance.
+%    \begin{macrocode}
+% \fi
+% \cs_new:Npn \__lthooksCode_labels_override:n #1
+%   {
+%     \hook_gset_rule:nnnn  { lthooksCodeROW/#1 }
+%       { lthooksCode/ROW } { voids } { lthooksCode/ENV }
+%     \hook_gset_rule:nnnn  { lthooksCodeROW/#1 }
+%       { lthooksCode/ROW } { voids } { lthooksCode/DOC }
+%     \hook_gset_rule:nnnn  { lthooksCodeROW/#1 }
+%       { lthooksCode/ENV } { voids } { lthooksCode/DOC }
+%   }
+% \iffalse
+%    \end{macrocode}
+% All hooks are private.
+% \begin{description}
+%   \item[lthooksCodeROW/.NL] hook to ensure that each row starts on a new line
+%    \begin{macrocode}
+% \fi
+% \hook_new:n { lthooksCodeROW/.NL }
+% \iffalse
+%    \end{macrocode}
+% \begin{description}
+%   \item[lthooksCodeROW/.indent] indentation of the code snippets,
+%     similar to \env{quote} and \env{verbatim}.
+%     Overrides the inherited value.
+%    \begin{macrocode}
+% \fi
+% \hook_new:n { lthooksCodeROW/.indent }
+% \__lthooksCode_labels_override:n { .indent }
+% \iffalse
+%    \end{macrocode}
+%   \item[lthooksCodeROW/.format] formatting commands for the whole
+%     \env{lthooksCode} environment.
+%     Appended to the inherited value.
+%    \begin{macrocode}
+% \fi
+% \hook_new:n { lthooksCodeROW/.format }
+% \iffalse
+%    \end{macrocode}
+%   \item[lthooksCodeROW/.lineno.after] commands executed between the line number
+%     and the code. Overrides the inherited value.
+%    \begin{macrocode}
+% \fi
+% \hook_new:n { lthooksCodeROW/.lineno.after }
+% \__lthooksCode_labels_override:n { .lineno.after }
+% \iffalse
+%    \end{macrocode}
+%   \item[lthooksCodeROW/.lineno.format] to format the line number.
+%     Appended to the inherited value.
+%    \begin{macrocode}
+% \fi
+% \hook_new:n { lthooksCodeROW/.lineno.format }
+% \iffalse
+%    \end{macrocode}
+%   \item[lthooksCodeROW/.lineno.format] commands to display a mark.
+%     Overrides the inherited value.
+%    \begin{macrocode}
+% \fi
+% \hook_new:n { lthooksCodeROW/.lineno.mark }
+% \__lthooksCode_labels_override:n { .lineno.mark }
+% \iffalse
+%    \end{macrocode}
+%   \item[lthooksCodeROW/.lineno.formatter] commands to format the line number and mark.
+%     Overrides the inherited value.
+%    \begin{macrocode}
+% \fi
+% \hook_new_with_args:nn { lthooksCodeROW/.lineno.formatter } { 2 }
+% \__lthooksCode_labels_override:n { .lineno.formatter }
+% \iffalse
+%    \end{macrocode}
+%   \item[lthooksCodeROW/.lineno.label] Definition of the label.
+%     Appended to the inherited value.
+%    \begin{macrocode}
+% \fi
+% \hook_new:n { lthooksCodeROW/.lineno.label }
+% \iffalse
+%    \end{macrocode}
+%   \item[lthooksCodeROW/.prefix] Definition of the prefix,
+%    which starts every line.
+%     Overrides the inherited value.
+%    \begin{macrocode}
+% \fi
+% \hook_new:n { lthooksCodeROW/.prefix }
+% \__lthooksCode_labels_override:n { .prefix }
+% \iffalse
+%    \end{macrocode}
+% \end{description}
+% Next command define an API frontend to these hooks.
+%    \begin{macrocode}
+% \fi
+% \cs_generate_variant:Nn \hook_gput_code:nnn { nnV }
+% \cs_new:Npn \__lthooks_gremove_code_silently:nn #1 #2
+%   {
+%     \msg_redirect_name:nnn { hooks } { cannot-remove } { none }
+%     \hook_gremove_code:nn  { #1 } { #2 }
+% \iffalse
+%    \end{macrocode}
+% We assume that we must switch back to \enquote{|warning|} but it might not
+% be the appropriate mode.
+%    \begin{macrocode}
+% \fi
+%     \msg_redirect_name:nnn { hooks } { cannot-remove } { warning }    
+%   }             
+% \cs_new:Npn \__lthooks_greplace_code_silently:nnn #1 #2
+%   {
+%     \__lthooks_gremove_code_silently:nn { #1 } { #2 }
+%     \hook_gput_code:nnn { #1 } { #2 }
+%   }             
+% \NewDocumentCommand\lthooksCodeSetup { O{ lthooksCode/DOC } m }
+%   {
+% \iffalse
+%    \end{macrocode}
+% Define the options.
+% \begin{arguments}
+%   \item[format=commands] adds formatting commands applied to the whole environment
+%     for example |\color{red}|, |\bfseries|... after the initial formatting,
+%     commands cumulate (|format=|\metatt{cmd_1}|, format=|\metatt{cmd_2} is
+%     equivalent to |format=|\metatt{cmd_1}\metatt{cmd_2}),
+%     |ttfamily| at the document level
+%   \item[first=number] number of the first line,
+%   \item[indent=command] spacing command for line indentation,
+%   \item[lineno=true\string|key-values] activate or deactivate line numbering,
+%     or defines subkeys
+%   \item[lineno/true]  activates line numbering,
+%   \item[lineno/false] deactivates line numbering,
+%   \item[lineno/first] first line number used,
+%   \item[lineno/label] The full label cumulates the ones at the |document| level,
+%     the |lthooksCode| level and the |lthooksCode/ROW| level,
+%   \item[lineno/first] first line number used,
+%   \item[lineno/mark=commands] code to display some marks,
+%     replaces the inherited value
+%   \item[lineno/format=commands] appended to the inherited values
+%   \item[lineno/formatter=commands] replace the inherited values,
+%     commands to display the mark (|#1|) and the line number (|#2|),
+%   \item[styles=key-value] the key is the style name, the value is managed by
+%   \pkg{l3keys}. Setting values with |styles/|\meta{subkey} is not supported.
+% \end{arguments}
+%    \begin{macrocode}
+% \fi
+%     \keys_define:nn { lthooksCode }
+%       {
+%         format  .code:n  =
+%           \hook_gput_code:nnn
+%             { lthooksCodeROW/.format } { #1 } { ##1 },
+%         indent  .tl_set:N  = \l__lthooksCodeROW_indent_tl,
+%         indent  .initial:n =,
+%         lineno  .code:n = \keys_set:nn { lthooksCode/lineno } { ##1 },
+%         lineno  .default:n  = true,
+%         styles  .code:n = \keys_set:nn { lthooksCode/styles } { ##1 },
+%         prefix  .code:n = \__lthooks_greplace_code_silently:nnn
+%           { lthooksCodeROW/.prefix } { #1 } { ##1 },
+%       }
+%     \keys_define:nn { lthooksCode/lineno }
+%       {
+%         true   .code:n  = \bool_set_true:N  \l__lthooksCodeROW_bool,
+%         false  .code:n  = \bool_set_false:N \l__lthooksCodeROW_bool,
+%         true   .value_forbidden:n = true,
+%         false  .value_forbidden:n = true,
+%         first  .int_set:N = \l__lthooksCodeROW_int,
+%         first  .initial:n = 1,
+%         label  .tl_set:N  = \l__lthooksCodeROW_label_tl,
+%         label  .initial:n =,
+%         mark   .code:n    = \tl_if_empty:nF { ##1 }
+%           {
+%             \__lthooks_greplace_code_silently:nnn
+%               { lthooksCodeROW/.lineno.mark } { #1 } { ##1 }
+%           },
+%         after  .tl_set:N  = \l__lthooksCodeROW_after_tl,
+%         after  .initial:n =,
+%         format .code:n  =
+%           \hook_gput_code:nnn
+%             { lthooksCodeROW/.lineno.format } { #1 } { ##1 },
+%         formatter .code:n  =
+%           \hook_gput_code_with_args:nnn
+%             { lthooksCodeROW/.lineno.formatter } { #1 } { ##1 },
+%       }
+%     \keys_define:nn { lthooksCode/styles }
+%       {
+%         unknown .code:n =
+%           \hook_activate_generic:n { lthooksCodeROW/.style/\l_keys_key_str }
+%           \hook_gput_code:nnn
+%             { lthooksCodeROW/.style/\l_keys_key_str }
+%             { #1 }
+%             { \keys_set:nn { lthooksCodeROW } { ##1 } }
+%           \exp_args:Nnx
+%           \hook_gput_next_code:nn { env/#1/after }
+%             {
+%               \exp_not:N \hook_gremove_code:nn
+%                 { lthooksCodeROW/.style/ \exp_not:V \l_keys_key_str } { #1 }
+%             },
+%       }
+% \iffalse
+%    \end{macrocode}
+% By default, the first line number is 1 and there is no line numbering,
+% the optional argument will override this.
+%    \begin{macrocode}
+% \fi
+%     \keys_set:nn { lthooksCode } { #2 }
+%     \tl_if_empty:NF \l__lthooksCodeROW_indent_tl
+%       {
+%         \hook_gput_code:nnV
+%           { lthooksCodeROW/.indent } { #1 } \l__lthooksCodeROW_indent_tl
+%       }    
+%     \tl_if_empty:NF \l__lthooksCodeROW_label_tl
+%       {
+%         \hook_gput_code:nnV
+%           { lthooksCodeROW/.lineno.label } { #1 } \l__lthooksCodeROW_label_tl
+%       }    
+%   }
+% \lthooksCodeSetup
+%   {
+%     format = \ttfamily,
+%     indent = \TAB\TAB,
+%     lineno/false,
+%     lineno/label = line:,
+%     lineno/formatter = #1 \hook_use:n { lthooksCodeROW/.lineno.after } #2,
+%     lineno/format = \color [ gray ] { 0.5 } \ttfamily\itshape \small,
+%     lineno/after = \hskip1em,
+%   }
+% \ExplSyntaxOff
+% \iffalse
+%    \end{macrocode}
+% \end{function}
+% \begin{function}
+%   {
+%     \begin{lthooksCode},
+%     \end{lthooksCode}
+%   }
+%   \begin{syntax}
+%     \cs{begin}\oarg{options}\{lthooksCode\}
+%     \cs{lthooksCode/ROW} ...
+%     \cs{lthooksCode/ROW} ...
+%     \cs{lthooksCode/ROW} ...
+%     \cs{lthooksCode/ROW} ...
+%     \cs{end}\{lthooksCode\}
+%   \end{syntax}
+% The |lthooksCode| is used to display code. It is based on
+% the |flushleft| environment and does not rely on any external package.
+% |lthooksCode| environments cannot be nested.
+% One optional argument that is a key-value comma separated list
+% managed by \pkg{l3keys}.
+% \end{function}
+%
+% Next private dedicated hook is used to insert a line break before
+% the second row.
+%    \begin{macrocode}
+% \fi
+% \ExplSyntaxOn
+% \makeatletter
+% \NewDocumentEnvironment { lthooksCode } { O{} }
+%   {
+% \iffalse
+%    \end{macrocode}
+% Clean the \hook{lthooksCodeROW/.NL} hook, then feed it to insert a \enquote{|\\|}
+% on second use.
+%    \begin{macrocode}
+% \fi
+%     \msg_redirect_name:nnn { hooks } { cannot-remove } { none }
+%     \hook_gremove_code:nn    { lthooksCodeROW/.NL } { * }
+%     \hook_gclear_next_code:n { lthooksCodeROW/.NL }
+%     \hook_gput_next_code:nn  { lthooksCodeROW/.NL }
+%       {
+%         \hook_gput_code:nnn  { lthooksCodeROW/.NL } { lthooksCode/ENV } { \\ }
+%       }
+%     \hook_gremove_code:nn { lthooksCodeROW/.prefix           } { lthooksCode/ENV }
+%     \hook_gremove_code:nn { lthooksCodeROW/.format           } { lthooksCode/ENV }
+%     \hook_gremove_code:nn { lthooksCodeROW/.lineno.label     } { lthooksCode/ENV }
+%     \hook_gremove_code:nn { lthooksCodeROW/.lineno.format    } { lthooksCode/ENV }
+%     \hook_gremove_code:nn { lthooksCodeROW/.lineno.formatter } { lthooksCode/ENV }
+%     \hook_gremove_code:nn { lthooksCodeROW/.lineno.mark      } { lthooksCode/ENV }
+% \iffalse
+%    \end{macrocode}
+% We assume that we must switch back to \enquote{|warning|} but it might not
+% be the appropriate mode.
+%    \begin{macrocode}
+% \fi
+%     \msg_redirect_name:nnn { hooks } { cannot-remove } { warning }
+%     \lthooksCodeSetup [ lthooksCode/ENV ] { #1 }
+%     \cs_set_nopar:Npn \TAB { \phantom { xx } }
+%     \cs_set_nopar:Npn \SEP { \rule[-\dp\strutbox] { 1pt } { \baselineskip } \TAB }
+%     \cs_set_eq:NN \IT \textit
+%     \cs_set_eq:NN  \ROW \lthooksCodeROW
+%     \setlength \parindent  { 5em }
+%     \hook_use:nnw { lthooksCode/.tool:width } { 1 } { 39 }
+%     \flushleft
+%     \group_begin:
+%   }
+%   {
+%     \group_end:
+%     \endflushleft
+%   }
+% \iffalse
+%    \end{macrocode}
+% Top level function that accepts an optional argument.
+% This is |\ROW| when numbering is on.
+%    \begin{macrocode}
+% \fi
+% \NewDocumentCommand \lthooksCodeROW { O{} }
+%   {
+%     \group_end:
+%     \UseHook { lthooksCodeROW/.NL }
+%     \mode_leave_vertical:
+% \iffalse
+%    \end{macrocode}
+% The optional argument is a key-value comma separated list managed by |l3keys|.
+% \begin{arguments}
+% \item[format=whatever] extra format applied to line numbers, formats cumulate
+% \item[mark=whatever] some mark that appears to the left of the line number,
+% void by default, override the mark inherited from the \env{lthooksCode} and the document
+% \item[label=whatever] if whatever is not empty, the line number can be retrieved by |\ref|, 
+% \item[style=clist] for each item in the clist, applies the eponym style
+% previously defined for the |styles| key in the optional argument of the
+% enclosing environment, 
+% \end{arguments}
+%    \begin{macrocode}
+% \fi
+% \iffalse
+%    \end{macrocode}
+% Without line  numbering, |\ROW| ignores the line numbering part of its optional argument.
+%    \begin{macrocode}
+% \fi
+%     \msg_redirect_name:nnn { hooks } { cannot-remove } { none }
+%     \hook_gremove_code:nn { lthooksCodeROW/.format           } { lthooksCode/ROW }
+%     \hook_gremove_code:nn { lthooksCodeROW/.prefix           } { lthooksCode/ROW }
+%     \hook_gremove_code:nn { lthooksCodeROW/.lineno.formatter } { lthooksCode/ROW }
+%     \hook_gremove_code:nn { lthooksCodeROW/.lineno.format    } { lthooksCode/ROW }
+%     \hook_gremove_code:nn { lthooksCodeROW/.lineno.mark      } { lthooksCode/ROW }
+%     \msg_redirect_name:nnn { hooks } { cannot-remove } { warning }
+%     \keys_define:nn { lthooksCodeROW }
+%       {
+%         line-format .code:n  =
+%             \hook_gput_code:nnn { lthooksCodeROW/.format } { lthooksCode/ROW } { ##1 },
+%         formatter .code:n    =
+%             \hook_gput_code_with_args:nnn
+%               { lthooksCodeROW/.lineno.formatter } { lthooksCode/ROW } { ##1 },
+%         format .code:n    =
+%             \hook_gput_code:nnn { lthooksCodeROW/.lineno.format } { lthooksCode/ROW } { ##1 },
+%         format .initial:n = ,
+%         mark   .code:n    = \tl_if_empty:nF { ##1 }
+%           {
+%             \__lthooks_greplace_code_silently:nnn
+%               { lthooksCodeROW/.lineno.mark }
+%               { lthooksCode/ROW }
+%               { ##1 }
+%           },
+%         label  .tl_set:N  = \l__lthooksCodeROW_label_tl,
+%         label  .initial:n = ,
+%         prefix .code:n    = \__lthooks_greplace_code_silently:nnn
+%           { lthooksCodeROW/.prefix }
+%           { lthooksCode/ROW }
+%           { ##1 },
+%         style  .code:n    =
+%           \clist_map_inline:nn
+%             { ##1 }
+%             { \hook_use:n { lthooksCodeROW/.style/####1 } },
+%       }
+% \iffalse
+%    \end{macrocode}
+% Each line starts with no label, and the optional argument
+%    \begin{macrocode}
+% \fi
+%     \keys_set:nn { lthooksCodeROW } { #1 }
+%     \bool_if:NT \l__lthooksCodeROW_bool
+%       {
+%         \llap
+%           { {
+%             \hook_use:n { lthooksCodeROW/.lineno.format }
+%             \hook_use:nnw
+%               { lthooksCodeROW/.lineno.formatter }
+%               { 2 }
+%               { \hook_use:n { lthooksCodeROW/.lineno.mark } }
+%               { \int_use:N \l__lthooksCodeROW_int }
+%             \hook_use:n { lthooksCodeROW/.lineno.after }
+%           } }
+%         \tl_if_empty:NF \l__lthooksCodeROW_label_tl
+%           {
+%             \tl_set:Nx \@currentlabel { \int_use:N \l__lthooksCodeROW_int }
+%             \phantomsection
+%             \label
+%               {
+%                 \hook_use:n { lthooksCodeROW/.lineno.label }
+%                 \l__lthooksCodeROW_label_tl
+%               }
+%           }
+%       }
+%     \int_incr:N \l__lthooksCodeROW_int
+%     \hook_use:n { lthooksCodeROW/.indent }
+%     \group_begin:
+%     \hook_use:n { lthooksCodeROW/.format }
+%     \hook_use:n { lthooksCodeROW/.prefix }
+%     \ignorespaces
+%   }
+% \iffalse
+%    \end{macrocode}
+% Two utility variables
+%    \begin{macrocode}
+% \fi
+% \tl_new:N  \l__lthooksCode_tl
+% \int_new:N \l__lthooksCode_int
+% \iffalse
+%    \end{macrocode}
+% Next hook defines some code formatting commands.
+% It is used by the \env{lthooksCode} environment.
+%    \begin{macrocode}
+% \fi
+% \hook_new_with_args:nn { lthooksCode/.tool:width } { 1 }^^A%  %width==39
+% \hook_gput_code_with_args:nnn { lthooksCode/.tool:width } { lthooksCode/ENV }
+%   {
+% \iffalse
+%    \end{macrocode}
+% |\SEP| displays a vertical separator, followed by a one character space.
+% We are supposed to be in a monospaced font environment.
+%    \begin{macrocode}
+% \fi
+%     \cs_set:Npn \SEP
+%       { \smash { \rule [ -\dp\strutbox ] { 1pt } { \baselineskip } }
+%         \hphantom { x } }
+% \iffalse
+%    \end{macrocode}
+% Default indentation: 2 spaces for compacity.
+%    \begin{macrocode}
+% \fi
+%     \cs_set:Npn \TAB { \phantom { xx } }
+% \iffalse
+%    \end{macrocode}
+% Default indentation: reserve space.
+%    \begin{macrocode}
+% \fi
+%     \cs_set:Npn \FILLER { \phantom { \prg_replicate:nn { #1 } { x } } } ^^A%#1==39
+% \iffalse
+%    \end{macrocode}
+% Usage: \cs{LEFT}|{left text}|\cs{RIGHT}|{right text}|, no par no line break
+%    \begin{macrocode}
+% \fi
+%     \cs_set_nopar:Npn \LEFT ##1
+%       {
+%         \rlap { ##1 }
+%         \phantom { \prg_replicate:nn { #1 } { x } }
+%       }
+%     \cs_set_nopar:Npn \RIGHT ##1 { \SEP ##1 }
+% \iffalse
+%    \end{macrocode}
+% In monospaced environments, |\meta{...}| is not wide enough because the delimters are
+% not typeset in the monospaced font. We fix this here such that \meta has exactly the width
+% of its argument + 2 characters
+%    \begin{macrocode}
+% \fi
+%     \cs_set_eq:NN \__lthooksCode_meta:n \meta
+%     \cs_set:Npn \meta ##1
+%       {
+%         \tl_set:Nn \l__lthooksCode_tl { ##1 }
+%         \hbox_set:Nn \l_tmpa_box { \__lthooksCode_meta:n { ##1 } }
+%         \hbox_set:Nn \l_tmpb_box { x }
+%         \int_set:Nn \l__lthooksCode_int { \int_div_truncate:nn
+%           { \box_wd:N \l_tmpa_box }
+%           { \box_wd:N \l_tmpb_box }
+%         }
+%         \fp_compare:nNnT
+%           { \l__lthooksCode_int * \box_wd:N \l_tmpb_box }
+%           < 
+%           { \box_wd:N \l_tmpa_box }
+%           { \int_incr:N \l__lthooksCode_int }
+%         \makebox[ \l__lthooksCode_int \box_wd:N \l_tmpb_box ][c]
+%           { \box_use:N \l_tmpa_box }
+%       }
+%   }
+% \makeatother
+% \ExplSyntaxOff
+% \iffalse
+%    \end{macrocode}
+% \fi
+%
 %
 % \providecommand\hook[1]{\texttt{#1}}
+% \providecommand\LHXLabel[1]{\texttt{#1}}
+% \providecommand\metatt[1]{\texttt{\meta{#1}}}
+%
 %
 % \providecommand\fmi[1]{\marginpar{\footnotesize FMi: #1}}
 % \providecommand\fmiinline[1]{\begin{quote}\itshape\footnotesize FMi: #1\end{quote}}
@@ -153,8 +654,10 @@
 %     \cs{NewMirroredHookPair} \Arg{hook-1} \Arg{hook-2}
 %   \end{syntax}
 %     A shorthand for
-%    \cs{NewHook}\Arg{hook-1}\cs{NewReversedHook}\Arg{hook-2}.
-%
+% \begin{lthooksCode}
+% \ROW\cs{NewHook}\Arg{hook-1}
+% \ROW\cs{NewReversedHook}\Arg{hook-2}
+% \end{lthooksCode}
 %    The \meta{hook} can be specified using the dot-syntax to denote
 %    the current package name. See section~\ref{sec:default-label}.
 % \end{function}
@@ -189,9 +692,11 @@
 %     \cs{NewMirroredHookPairWithArguments} \Arg{hook-1} \Arg{hook-2} \Arg{number}
 %   \end{syntax}
 %   A shorthand for
-%   \cs{NewHookWithArguments}\Arg{hook-1}\Arg{number}\\
-%   \cs{NewReversedHookWithArguments}\Arg{hook-2}\Arg{number}.
-%   Section~\ref{sec:hook-args} explains hooks with arguments.
+% \begin{lthooksCode}
+% \ROW\cs{NewHookWithArguments}\Arg{hook-1}\Arg{number}
+% \ROW\cs{NewReversedHookWithArguments}\Arg{hook-2}\Arg{number}
+% \end{lthooksCode}
+%%   Section~\ref{sec:hook-args} explains hooks with arguments.
 %
 %    The \meta{hook} can be specified using the dot-syntax to denote
 %    the current package name. See section~\ref{sec:default-label}.
@@ -379,14 +884,14 @@
 %    (\verb|#|) that are not supposed to be understood as the arguments
 %    of the hook, such tokens should be doubled.  For example, with
 %    \cs{AddToHook} one can write:
-%\begin{verbatim}
-%   \AddToHook{myhook}{\def\foo#1{Hello, #1!}}
-%\end{verbatim}
+% \begin{lthooksCode}
+% \ROW\cs{AddToHook}|{myhook}{\def\foo#1{Hello, #1!}}|
+% \end{lthooksCode}
 %    but to achieve the same with \cs{AddToHookWithArguments}, one should
 %    write:
-%\begin{verbatim}
-%   \AddToHookWithArguments{myhook}{\def\foo##1{Hello, ##1!}}
-%\end{verbatim}
+% \begin{lthooksCode}
+% \ROW\cs{AddToHookWithArguments}|{myhook}{\def\foo##1{Hello, ##1!}}|
+% \end{lthooksCode}
 %    because in the latter case, \verb|#1| refers to the first argument
 %    of the hook \hook{myhook}.
 %   Section~\ref{sec:hook-args} explains hooks with arguments.
@@ -434,19 +939,19 @@
 % A useful application for this declaration inside the document body
 % is when one wants to temporarily add code to hooks and later remove
 % it again, e.g.,
-%\begin{verbatim}
-%   \AddToHook{env/quote/before}{\small}
-%   \begin{quote}
-%     A quote set in a smaller typeface
-%   \end{quote}
-%   ...
-%   \RemoveFromHook{env/quote/before}
-%   ... now back to normal for further quotes
-%\end{verbatim}
+% \begin{lthooksCode}
+% \ROW\cs{AddToHook}|{env/quote/before}{\small}|
+% \ROW|\begin{quote}|
+% \ROW~~\meta{A quote set in a smaller typeface}
+% \ROW|\end{quote}|
+% \ROW...
+% \ROW\cs{RemoveFromHook}|{env/quote/before}|
+% \ROW...|%| \IT{now back to normal for further quotes}
+% \end{lthooksCode}
 % Note that you can't cancel the setting with
-%\begin{verbatim}
-%   \AddToHook{env/quote/before}{}
-%\end{verbatim}
+% \begin{lthooksCode}
+% \ROW\cs{AddToHook}|{env/quote/before}{}|
+% \end{lthooksCode}
 % because that only \enquote{adds} a further empty chunk of code to
 % the hook. Adding \cs{normalsize} would work but that means the hook
 % then contained \cs{small}\cs{normalsize} which means two font size
@@ -487,10 +992,10 @@
 %
 %    It is possible to nest this declaration using the same hook (or
 %    different hooks): e.g.,
-%   \begin{quote}
-%     \cs{AddToHookNext}\Arg{hook}\verb={=\meta{code-1}^^A
+%   \begin{lthooksCode}
+%     \ROW\cs{AddToHookNext}\Arg{hook}\verb={=\meta{code-1}^^A
 %     \cs{AddToHookNext}\Arg{hook}\Arg{code-2}\verb=}=
-%   \end{quote}
+%   \end{lthooksCode}
 %    will execute \meta{code-1} next time the \meta{hook} is used and at
 %    that point puts \meta{code-2} into  the \meta{hook} so that it gets
 %    executed on following time the hook is run.
@@ -586,21 +1091,21 @@
 % For example,
 % inside the package \texttt{mypackage.sty}, the default label is
 % \texttt{mypackage}, so the instructions:
-% \begin{verbatim}
-%   \NewHook   {./hook}
-%   \AddToHook {./hook}[.]{code}     % Same as \AddToHook{./hook}{code}
-%   \AddToHook {./hook}[./sub]{code}
-%   \DeclareHookRule{begindocument}{.}{before}{babel}
-%   \AddToHook {file/foo.tex/after}{code}
-% \end{verbatim}
+% \begin{lthooksCode}
+%   \ROW|\NewHook   {./hook}|
+%   \ROW|\AddToHook {./hook}[.]{code}     % |\IT{Same as }|\AddToHook{./hook}{code}|
+%   \ROW|\AddToHook {./hook}[./sub]{code}|
+%   \ROW|\DeclareHookRule{begindocument}{.}{before}{babel}|
+%   \ROW|\AddToHook {file/foo.tex/after}{code}|
+% \end{lthooksCode}
 %    are equivalent to:
-% \begin{verbatim}
-%   \NewHook   {mypackage/hook}
-%   \AddToHook {mypackage/hook}[mypackage]{code}
-%   \AddToHook {mypackage/hook}[mypackage/sub]{code}
-%   \DeclareHookRule{begindocument}{mypackage}{before}{babel}
-%   \AddToHook {file/foo.tex/after}{code}                  % unchanged
-% \end{verbatim}
+% \begin{lthooksCode}
+%   \ROW|\NewHook   {mypackage/hook}|
+%   \ROW|\AddToHook {mypackage/hook}[mypackage]{code}|
+%   \ROW|\AddToHook {mypackage/hook}[mypackage/sub]{code}|
+%   \ROW|\DeclareHookRule{begindocument}{mypackage}{before}{babel}|
+%   \ROW|\AddToHook {file/foo.tex/after}{code}                  % |\IT{unchanged}
+% \end{lthooksCode}
 %
 % The \meta{default label} is automatically set equal to the name of the
 % current package or class at the time the package is loaded.  If the
@@ -653,11 +1158,11 @@
 %   The effect of \cs{PushDefaultHookLabel} holds until the next
 %   \cs{PopDefaultHookLabel}.  \cs{usepackage} (and \cs{RequirePackage}
 %   and \cs{documentclass}) internally use
-%   \begin{quote}
-%     \cs{PushDefaultHookLabel}\Arg{package name} \\
-%     \null \quad  \meta{package code} \\
-%     \cs{PopDefaultHookLabel}
-%   \end{quote}
+%   \begin{lthooksCode}
+%     \ROW\cs{PushDefaultHookLabel}\Arg{package name}
+%     \ROW\TAB\meta{package code}
+%     \ROW\cs{PopDefaultHookLabel}
+%   \end{lthooksCode}
 %   to set the \meta{default label} for the package or class file.
 %   Inside the \meta{package code} the \meta{default label} can also be
 %   changed with \cs{SetDefaultHookLabel}.  \cs{input} and other
@@ -940,63 +1445,82 @@
 %   \bigskip
 %   Suppose a hook \texttt{example-hook} whose output of
 %   \cs{ShowHook}|{example-hook}| is:
-%   \begin{verbatim}[numbers=left]
-%   -> The hook 'example-hook':
-%   > Code chunks:
-%   >     foo -> [code from package 'foo']
-%   >     bar -> [from package 'bar']
-%   >     baz -> [package 'baz' is here]
-%   > Document-level (top-level) code (executed last):
-%   >     -> [code from 'top-level']
-%   > Extra code for next invocation:
-%   >     -> [one-time code]
-%   > Rules:
-%   >     foo|baz with relation >
-%   >     baz|bar with default relation <
-%   > Execution order (after applying rules):
-%   >     baz, foo, bar.
-%   \end{verbatim}
-%
-%   In the listing above, lines~3 to~5 show the three code chunks added
+%   \begin{lthooksCode}[
+%     lineno,
+%     styles={
+%       red={
+%         format=\bfseries\color{red},
+%         mark=$\to$\;,
+%       },
+%     },
+%     lineno/label=example-hook:,
+%     lineno/formatter=\llap{#1}\phantom{99}\llap{#2},
+%     prefix= {> },
+%   ]
+%   \ROW[prefix={-> },]|The hook 'example-hook':|
+%   \ROW|Code chunks:|
+%   \ROW[style=red,label=foo,
+%   ]|     foo -> [code from package 'foo']{}|
+%   \ROW[style=red,label=bar,
+%   ]|     bar -> [from package 'bar']{}|
+%   \ROW[style=red,label=baz,
+%   ]|     baz -> [package 'baz' is here]{}|
+%   \ROW|Document-level (top-level) code (executed last):|
+%   \ROW[style=red,label=top-level,
+%      ]|     -> [code from 'top-level']{}|
+%   \ROW|Extra code for next invocation:|
+%   \ROW[style=red,label=next-only,
+%      ]|     -> [one-time code]{}|
+%   \ROW|Rules:|
+%   \ROW[style=red,label=rule,
+%   ]{}|    foo|\string||baz with relation >|
+%   \ROW[style=red,label=default-rule,
+%   ]{}|    baz|\string||bar with default relation <|
+%   \ROW|Execution order (after applying rules):|
+%   \ROW[style=red,label=execution-order,
+%   ]|    baz, foo, bar.|
+%   \end{lthooksCode}
+%   In the listing above, lines~\ref{line:example-hook:foo}
+%   to~\ref{line:example-hook:baz} show the three code chunks added
 %   to the hook and their respective labels in the format
-%   \begin{quote}
-%   \quad \meta{label}\verb| -> |\meta{code}
-%   \end{quote}
+%   \begin{lthooksCode}
+%   \ROW\TAB\TAB\TAB\meta{label}| -> |\meta{code}
+%   \end{lthooksCode}
 %
-%   Line~7 shows the code chunk added by the user in the main document
+%   Line~\ref{line:example-hook:top-level} shows the code chunk added by the user in the main document
 %   (labeled |top-level|) in the format
-%   \begin{quote}
-%   \quad\verb|Document-level (top-level) code (executed |%^^A
-%              \meta{first\texttt{\string|}last}\verb|):|\\
-%   \quad\verb|    -> |\meta{\texttt{top-level} code}
-%   \end{quote}
+%   \begin{lthooksCode}
+%   \ROW\TAB Document-level (top-level) code (executed %^^A
+%              \meta{first\string|last}):
+%   \ROW\TAB|    -> |\meta{top-level code}
+%   \end{lthooksCode}
 %   This code will be either the first or last code executed by the hook
 %   (|last| if the hook is normal, |first| if it is reversed).  This
 %   chunk is not affected by rules and does not take part in sorting.
 %
-%   Line~9 shows the code chunk for the next execution of the hook in
+%   Line~\ref{line:example-hook:next-only} shows the code chunk for the next execution of the hook in
 %   the format
-%   \begin{quote}
-%   \quad \verb|-> |\meta{next-code}
-%   \end{quote}
+%   \begin{lthooksCode}
+%   \ROW\TAB\TAB|-> |\meta{next-code}
+%   \end{lthooksCode}
 %   This code will be used and disappear at the next
 %   \verb|\UseHook{example-hook}|, in contrast to the chunks mentioned
 %   earlier, which can only be removed from that hook by doing
-%   \verb|\RemoveFromHook{|\meta{label}|}[example-hook]|.
+%   \verb|\RemoveFromHook{|\meta{label}|}[example-hook]{}|.
 %
-%   Lines~11 and~12 show the rules declared that affect this hook in the
+%   Lines~\ref{line:example-hook:rule} and~\ref{line:example-hook:default-rule} show the rules declared that affect this hook in the
 %   format
-%   \begin{quote}
-%   \quad \meta{label-1}\verb+|+\meta{label-2}| with |%^^A
+%   \begin{lthooksCode}
+%\ROW\TAB \meta{label-1}\verb+|+\meta{label-2}| with|
 %         \meta{\texttt{default}?}| relation |\meta{relation}
-%   \end{quote}
+%   \end{lthooksCode}
 %   which means that the \meta{relation} applies to \meta{label-1} and
 %   \meta{label-2}, in that order, as detailed in \cs{DeclareHookRule}.
 %   If the relation is \texttt{default} it means that this rule applies
 %   to \meta{label-1} and \meta{label-2} in \emph{all} hooks, (unless
 %   overridden by a non-default relation).
 %
-%   Finally, line~14 lists the labels in the hook after sorting;
+%   Finally, line~\ref{line:example-hook:execution-order} lists the labels in the hook after sorting;
 %   that is, in the order they will be executed when the hook is used.
 %
 %
@@ -1319,32 +1843,32 @@
 %    make assumptions about the order of execution!
 %
 %    Suppose you have the following declarations:
-%\begin{verbatim}
-%    \NewHook{myhook}
-%    \AddToHook{myhook}[packageA]{\typeout{A}}
-%    \AddToHook{myhook}[packageB]{\typeout{B}}
-%    \AddToHook{myhook}[packageC]{\typeout{C}}
-%\end{verbatim}
+% \begin{lthooksCode}
+% \ROW|\NewHook{myhook}|
+% \ROW|\AddToHook{myhook}[packageA]{\typeout{A}}|
+% \ROW|\AddToHook{myhook}[packageB]{\typeout{B}}|
+% \ROW|\AddToHook{myhook}[packageC]{\typeout{C}}|
+% \end{lthooksCode}
 %    then executing the hook with \cs{UseHook} will produce the
 %    typeout \texttt{A} \texttt{B} \texttt{C} in that order.  In other
 %    words, the execution order is computed to be \texttt{packageA},
 %    \texttt{packageB}, \texttt{packageC} which you can verify with
 %    \cs{ShowHook}\texttt{\{myhook\}}:
-%\begin{verbatim}
-%    -> The hook 'myhook':
-%    > Code chunks:
-%    >     packageA -> \typeout {A}
-%    >     packageB -> \typeout {B}
-%    >     packageC -> \typeout {C}
-%    > Document-level (top-level) code (executed last):
-%    >     ---
-%    > Extra code for next invocation:
-%    >     ---
-%    > Rules:
-%    >     ---
-%    > Execution order:
-%    >     packageA, packageB, packageC.
-%\end{verbatim}
+%\begin{lthooksCode}[prefix={> },]
+%    \ROW[prefix={-> },]|The hook 'myhook':|
+%    \ROW|Code chunks:|
+%    \ROW|    packageA -> \typeout {A}|
+%    \ROW|    packageB -> \typeout {B}|
+%    \ROW|    packageC -> \typeout {C}|
+%    \ROW|Document-level (top-level) code (executed last):|
+%    \ROW|    ---|
+%    \ROW|Extra code for next invocation:|
+%    \ROW|    ---|
+%    \ROW|Rules:|
+%    \ROW|    ---|
+%    \ROW|Execution order:|
+%    \ROW|    packageA, packageB, packageC.|
+%\end{lthooksCode}
 %    The reason is that the code chunks are internally saved in a property list
 %    and the initial order of such a property list is the order in
 %    which key-value pairs got added. However, that is only true if
@@ -1352,37 +1876,37 @@
 %
 %    Suppose, for example, you want to replace the code chunk for
 %    \texttt{packageA}, e.g.,
-%\begin{verbatim}
-%    \RemoveFromHook{myhook}[packageA]
-%    \AddToHook{myhook}[packageA]{\typeout{A alt}}
-%\end{verbatim}
+%\begin{lthooksCode}
+%\ROW|\RemoveFromHook{myhook}[packageA]{}|
+%\ROW|\AddToHook{myhook}[packageA]{\typeout{A alt}}|
+%\end{lthooksCode}
 %    then your order becomes  \texttt{packageB},
 %    \texttt{packageC}, \texttt{packageA} because the label got removed
 %    from the property list and then re-added (at its end).
 %
 %    While that may not be too surprising,  the execution order is
 %    also sometimes altered if you add a redundant rule, e.g. if you specify
-%\begin{verbatim}
-%    \DeclareHookRule{myhook}{packageA}{before}{packageB}
-%\end{verbatim}
+%\begin{lthooksCode}
+%\ROW\cs{DeclareHookRule}|{myhook}{packageA}{before}{packageB}|
+%\end{lthooksCode}
 %    instead of the previous lines we get
-%\begin{verbatim}
-%    -> The hook 'myhook':
-%    > Code chunks:
-%    >     packageA -> \typeout {A}
-%    >     packageB -> \typeout {B}
-%    >     packageC -> \typeout {C}
-%    > Document-level (top-level) code (executed last):
-%    >     ---
-%    > Extra code for next invocation:
-%    >     ---
-%    > Rules:
-%    >     packageB|packageA with relation >
-%    > Execution order (after applying rules):
-%    >     packageA, packageC, packageB.
-%\end{verbatim}
+%\begin{lthooksCode}[prefix={> },]
+%\ROW[prefix={-> },]|The hook 'myhook':|
+%\ROW|Code chunks:|
+%\ROW|    packageA -> \typeout {A}|
+%\ROW|    packageB -> \typeout {B}|
+%\ROW|    packageC -> \typeout {C}|
+%\ROW|Document-level (top-level) code (executed last):|
+%\ROW|    ---|
+%\ROW|Extra code for next invocation:|
+%\ROW|    ---|
+%\ROW|Rules:|
+%\ROW|    packageB|\string||packageA with relation >|
+%\ROW|Execution order (after applying rules):|
+%\ROW|    packageA, packageC, packageB.|
+%\end{lthooksCode}
 %    As you can see the code chunks are still in the same order, but
-%    in the execution order for the labels \texttt{packageB} and
+%    in the execution order the labels \texttt{packageB} and
 %    \texttt{packageC} have
 %    swapped places.
 %    The reason is that, with the rule there are two orders that
@@ -1390,9 +1914,9 @@
 %    different one compared to the case without rules (where it
 %    doesn't run at all as there is nothing to resolve).
 %    Incidentally, if we had instead specified the redundant rule
-%\begin{verbatim}
-%    \DeclareHookRule{myhook}{packageB}{before}{packageC}
-%\end{verbatim}
+%\begin{lthooksCode}
+%\ROW|\DeclareHookRule{myhook}{packageB}{before}{packageC}|
+%\end{lthooksCode}
 %    the execution order would not have changed.
 %
 %    In summary: it is not possible to rely on the order of execution
@@ -1415,49 +1939,48 @@
 %    To give a somewhat contrived example\footnote{there are simpler
 %    ways to achieve the same effect.}, suppose there is a package
 %    adding the following:
-%\begin{verbatim}
-%    \AddToHook{env/quote/before}[package-1]{\begin{itshape}}
-%    \AddToHook{env/quote/after} [package-1]{\end{itshape}}
-%\end{verbatim}
+%\begin{lthooksCode}
+%\ROW|\AddToHook{env/quote/before}[package-1]{\begin{itshape}}|
+%\ROW|\AddToHook{env/quote/after} [package-1]{\end{itshape}}|
+%\end{lthooksCode}
 %    As a result, all quotes will be in italics.
 %    Now suppose further that another |package-too| makes the quotes
 %    also in blue and therefore adds:
-%\begin{verbatim}
-%    \usepackage{color}
-%    \AddToHook{env/quote/before}[package-too]{\begin{color}{blue}}
-%    \AddToHook{env/quote/after} [package-too]{\end{color}}
-%\end{verbatim}
+%\begin{lthooksCode}
+%\ROW|\usepackage{color}|
+%\ROW|\AddToHook{env/quote/before}[package-too]{\begin{color}{blue}}|
+%\ROW|\AddToHook{env/quote/after} [package-too]{\end{color}}|
+%\end{lthooksCode}
 %    Now if the \hook{env/quote/after} hook would be a normal hook we
 %    would get the same execution order in  both hooks, namely:
-%\begin{verbatim}
-%    package-1, package-too
-%\end{verbatim}
+%\begin{lthooksCode}
+%\ROW|package-1, package-too|
+%\end{lthooksCode}
 %    (or vice versa) and as a result, would get:
-%\begin{verbatim}
-%    \begin{itshape}\begin{color}{blue} ...
-%    \end{itshape}\end{color}
-%\end{verbatim}
+%\begin{lthooksCode}
+%\ROW|\begin{itshape}\begin{color}{blue} ...|
+%\ROW|\end{itshape}\end{color}|
+%\end{lthooksCode}
 %    and an error message saying that \verb=\begin{color}= was ended by
 %    \verb=\end{itshape}=.
 %    With \hook{env/quote/after} declared as a reversed hook the
 %    execution order is reversed and so all environments are closed in
 %    the correct sequence and \cs{ShowHook} would give us the
 %    following output:
-%\begin{verbatim}
-%    -> The hook 'env/quote/after':
-%    > Code chunks:
-%    >     package-1 -> \end {itshape}
-%    >     package-too -> \end {color}
-%    > Document-level (top-level) code (executed first):
-%    >     ---
-%    > Extra code for next invocation:
-%    >     ---
-%    > Rules:
-%    >     ---
-%    > Execution order (after reversal):
-%    >     package-too, package-1.
-%\end{verbatim}
-%
+%\begin{lthooksCode}[prefix={> },]
+%\ROW[prefix={-> },]|The hook 'env/quote/after':|
+%\ROW|Code chunks:|
+%\ROW|    package-1 -> \end {itshape}|
+%\ROW|    package-too -> \end {color}|
+%\ROW|Document-level (top-level) code (executed first):|
+%\ROW|    ---|
+%\ROW|Extra code for next invocation:|
+%\ROW|    ---|
+%\ROW|Rules:|
+%\ROW|    ---|
+%\ROW|Execution order (after reversal):|
+%\ROW|    package-too, package-1.|
+%\end{lthooksCode}
 %    The reversal of the execution order happens before applying any
 %    rules, so if you alter the order you will probably have to alter
 %    it in both hooks, not just in one, but that depends on the use case.
@@ -1499,12 +2022,12 @@
 %
 %    \end{itemize}
 %    In particular this means that construct such as
-%\begin{quote}
-%    \cs{AddToHook}\verb={myhook}=\\
-%    \phantom{\cs{AddToHook}}\verb={= \meta{code-1}
-%                                     \cs{AddToHook}\verb={myhook}=\Arg{code-2}
-%                                     \meta{code-3} \verb=}=
-%\end{quote}
+%\begin{lthooksCode}
+%\ROW\cs{AddToHook}\verb={myhook}=^^A
+%   \verb={=\meta{code-1}^^A
+%   \cs{AddToHook}|{myhook}|\Arg{code-2}^^A
+%   \meta{code-3}|}|
+%\end{lthooksCode}
 %    works for one-time hooks\footnote{This is sometimes used with
 %    \cs{AtBeginDocument} which is why it is supported.} (all three
 %    code chunks are executed one after another), but it makes little
@@ -1630,11 +2153,11 @@
 %    \cs{UseHookWithArguments}\Arg{hook}\Arg{number} followed by a
 %    braced list of the arguments.  For example, if the hook \hook{test}
 %    takes three arguments, write:
-%\begin{verbatim}
-%    \UseHookWithArguments{test}{3}{arg-1}{arg-2}{arg-3}
-%\end{verbatim}
+%\begin{lthooksCode}
+%\ROW|\UseHookWithArguments{test}{3}|\Arg{arg-1}\Arg{arg-2}\Arg{arg-3}
+%\end{lthooksCode}
 %    then, in the \meta{code} of the hook, all instances of \verb|#1|
-%    will be replaced by \verb|arg-1|, \verb|#2| by \verb|arg-2| and so
+%    will be replaced by \meta{arg-1}, \verb|#2| by \meta{arg-2} and so
 %    on.  If, at the point of usage, the programmer provides more
 %    arguments than the hook is declared to take, the excess arguments
 %    are simply ignored by the hook.  Behaviour is
@@ -1658,9 +2181,9 @@
 %    does for all other hooks. This allows a package developer to add
 %    arguments to a hook that otherwise had none without having to worry
 %    about compatibility.  This means that, for example:
-%\begin{verbatim}
-%    \AddToHook{test}{\def\foo#1{Hello, #1!}}
-%\end{verbatim}
+%\begin{lthooksCode}
+%\ROW|\AddToHook{test}{\def\foo#1{Hello, #1!}}|\\
+%\end{lthooksCode}
 %    will define the same macro \cs[no-index]{foo} regardless if the
 %    hook \hook{test} takes arguments or not.
 %
@@ -1671,28 +2194,28 @@
 %    \meta{code} that token must be doubled in the input.  The same
 %    definition from above, using \cs{AddToHookWithArguments}, needs to
 %    be rewritten:
-%\begin{verbatim}
-%    \AddToHookWithArguments{test}{\def\foo##1{Hello, ##1!}}
-%\end{verbatim}
+%\begin{lthooksCode}
+%\ROW|\AddToHookWithArguments{test}{\def\foo##1{Hello, ##1!}}|
+%\end{lthooksCode}
 %
 %    Extending the above example to use the hook arguments, we could
 %    rewrite something like (now from declaration to usage, to get the
 %    whole picture):
-%\begin{verbatim}
-%    \NewHookWithArguments{test}{1}
-%    \AddToHookWithArguments{test}{%
-%      \typeout{Defining foo with "#1"}
-%      \def\foo##1{Hello, ##1! Some text after: #1}%
-%    }
-%    \UseHook{test}{Howdy!}
-%    \ShowCommand\foo
-%\end{verbatim}
+%\begin{lthooksCode}
+%\ROW|\NewHookWithArguments{test}{1}|
+%\ROW|\AddToHookWithArguments{test}{%|
+%\ROW~~|\typeout{Defining foo with "#1"}|
+%\ROW~~|\def\foo##1{Hello, ##1! Some text after: #1}%|
+%\ROW|}|
+%\ROW|\UseHook{test}{Howdy!}|
+%\ROW|\ShowCommand\foo|
+%\end{lthooksCode}
 %    Running the code above prints in the terminal:
-%\begin{verbatim}
-%    Defining foo with "Howdy!"
-%    > \foo=macro:
-%    #1->Hello, #1! Some text after: Howdy!.
-%\end{verbatim}
+%\begin{lthooksCode}
+%\ROW|Defining foo with "Howdy!"|
+%\ROW|> \foo=macro:|
+%\ROW|#1->Hello, #1! Some text after: Howdy!.|
+%\end{lthooksCode}
 %    Note how \verb|##1| in the call to \cs{AddToHookWithArguments}
 %    became \verb|#1|, and the \verb|#1| was replaced by the argument
 %    passed to the hook.  Should the hook be used again, with a
@@ -1731,10 +2254,10 @@
 %    convention: \cs{@kernel@before@\meta{hook}} or
 %    \cs{@kernel@after@\meta{hook}}. For example, in
 %    \cs{enddocument} you find
-%\begin{verbatim}
-%   \UseHook{enddocument}%
-%   \@kernel@after@enddocument
-%\end{verbatim}
+%\begin{lthooksCode}
+%\ROW|\UseHook{enddocument}%|
+%\ROW|\@kernel@after@enddocument|
+%\end{lthooksCode}
 %    which means first the user/package-accessible \hook{enddocument}
 %    hook is executed and then the internal kernel hook. As their name
 %    indicates these kernel commands should not be altered by third-party
@@ -1925,11 +2448,11 @@
 %    (e.g., to avoid the environment grouping) they are not
 %    available. If you want them available in code using this method,
 %    you would need to add them yourself, i.e., write something like
-%\begin{verbatim}
-%  \UseHook{env/quote/before}\quote
-%      ...
-%  \endquote\UseHook{env/quote/after}
-%\end{verbatim}
+%\begin{lthooksCode}
+%\ROW|\UseHook{env/quote/before}\quote|
+%\ROW|...|
+%\ROW|\endquote\UseHook{env/quote/after}|
+%\end{lthooksCode}
 %    to add the outer hooks, etc.
 %
 %
@@ -4727,12 +5250,12 @@
 %    \end{macrocode}
 %   To start, we define two auxiliary token lists.
 %   \cs[no-index]{l_@@_tmpb_tl} contains:
-%\begin{verbatim}
-%   {\c__hook_hashes_tl 1}
-%   {\c__hook_hashes_tl 2}
-%   ...
-%   {\c__hook_hashes_tl 9}
-%\end{verbatim}
+%\begin{lthooksCode}
+%\ROW|{\c__hook_hashes_tl 1}|
+%\ROW|{\c__hook_hashes_tl 2}|
+%\ROW|...|
+%\ROW|{\c__hook_hashes_tl 9}|
+%\end{lthooksCode}
 %    \begin{macrocode}
     \cs_set:Npn \@@_tmp:w ##1##2##3##4##5##6##7##8##9 { }
     \tl_set:Ne \l_@@_tmpb_tl
@@ -4746,12 +5269,12 @@
         }
 %    \end{macrocode}
 %   And \cs[no-index]{l_@@_tmpa_tl} contains:
-%\begin{verbatim}
-%   {\c__hook_hash_tl 1}
-%   {\c__hook_hash_tl 2}
-%   ...
-%   {\c__hook_hash_tl <n>}
-%\end{verbatim}
+%\begin{lthooksCode}
+%\ROW|{\c__hook_hash_tl 1}|
+%\ROW|{\c__hook_hash_tl 2}|
+%\ROW|...|
+%\ROW|{\c__hook_hash_tl |\meta{n}|}|
+%\end{lthooksCode}
 %   with \meta{n} being the number of arguments declared for the hook.
 %    \begin{macrocode}
     \exp_last_unbraced:NNf
@@ -4773,12 +5296,12 @@
 %   nicely formatted.  For example, if the label \enquote{badpkg} adds
 %   some code that references argument \verb|#3| in the hook
 %   \enquote{foo}, which takes only two arguments, the error will be:
-%\begin{verbatim}
-%   ! Illegal parameter number in definition of hook 'foo'.
-%   (hooks)             Offending label: 'badpkg'.
-%   <to be read again> 
-%                      3
-%\end{verbatim}
+%\begin{lthooksCode}
+%\ROW|! Illegal parameter number in definition of hook 'foo'.|
+%\ROW|(hooks)             Offending label: 'badpkg'.|
+%\ROW|<to be read again> |
+%\ROW|                   3|
+%\end{lthooksCode}
 %   At the point of this definition, the error is raised if the code
 %   happens to reference an invalid argument.  If it was possible to
 %   detect that this definition raised no error, the next step would be


### PR DESCRIPTION
No `LaTeX` code change in this PR, only documentation is modified.

Actually, `verbatim` and `quote` environments are both used in `lthooks` documentation to display code chunks as well as terminal output. Both have pros and cons but the main fact is that they are not formatted in a consistent way.

The new environment `lthooksCode` aims to take the best of both worlds, and is consistent with the `syntax` environment.
The definition of `lthooksCode` makes heavy use of hooks, in many different aspects, which is interesting as a use case IMHO. However, the `lthooksCode/tool` hook may seem overkill at first glance, but this design anticipates forthcoming changes.

The main example of benefit is around line 1200 which corresponds to the explanation of the `\ShowHook` output at pages 13-14 of the [lthooks.pdf](https://filesender.renater.fr/?s=download&token=0fe38001-ecfb-402e-91dc-7797c173eab6) of this PR (available until 02/03). Notice that code line numbers are now links. In addition to the red color of line numbers, there is also an arrow mark  because some people are not sensitive to color changes.

This somehow reflects my personal tastes, suggestions are welcome.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ X] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
