### PR TITLE
lthooks: new show related tests to fix issue #1243

### DIFF
--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -6786,8 +6786,6 @@
 %
 % \changes{v1.0s}{2021/09/28}
 %                {Correct usage of older \cs{@@_if_file_hook:wTF} (gh/675)}
-% \changes{v1.1h}{2024/01/24}
-%                {Correct usage of older \cs{@@_if_file_hook:wTF} (gh/1243)}
 %    \begin{macrocode}
 %<latexrelease>\cs_new_protected:Npn \@@_try_file_hook:n #1
 %<latexrelease>  {

--- a/base/testfiles-lthooks/helpers/lthooks-show.sty
+++ b/base/testfiles-lthooks/helpers/lthooks-show.sty
@@ -1,0 +1,111 @@
+% This is a library of commands used by various `lthooks*.lvt`
+
+\IncludeInRelease{2020-10-01}{\TESTBlockHook}{Message}
+
+\def\DebugShowHookEnv#1{
+  \ShowHook{env/#1/before}
+  \ShowHook{env/#1/begin}
+  \ShowHook{env/#1/end}
+  \ShowHook{env/#1/after}
+}
+
+\def\DebugShowHookCmd#1{
+  \ShowHook{cmd/#1/before}
+  \ShowHook{cmd/#1/after}
+}
+
+\def\TESTBlockHookEnv#1#2{
+% run at the top level
+% #1: the title of the block
+% #2: the name of the environment
+  \BEGINTEST{Environment: #2}
+    \DebugShowHookEnv{#2}
+    \AddToHook{env/#2/before}{\TYPE{<#2 BEFORE>}}
+    \AddToHook{env/#2/begin}{\TYPE{<#2 BEGIN>}}
+    \AddToHook{env/#2/end}{\TYPE{<#2 END>}}
+    \AddToHook{env/#2/after}{\TYPE{<#2 AFTER>}}
+    \DebugShowHookEnv{#2}
+  \ENDTEST
+}
+
+\def\TESTBlockHookCmd#1#2{
+% run at the top level
+% #1: the title of the block
+% #2: the csname of the command
+  \BEGINTEST{Command: #1}
+    \DebugShowHookCmd{#2}
+    \AddToHook{cmd/#2/before}{\TYPE{<#2 BEFORE>}}
+    \AddToHook{cmd/#2/after}{\TYPE{<#2 AFTER>}}
+    \DebugShowHookCmd{#2}
+  \ENDTEST
+}
+\def\TESTBlockHookCustomGeneric#1#2{
+% run at the top level
+% #1: the title of the block
+% #2: the name of the hook
+  \BEGINTEST{Custom generic hook: #1}
+    \def\TEST{
+      \UseHook{#2}
+      \ShowHook{#2}
+    }
+    \BEGINTEST{Raw: #2}
+      \AddToHook{#2}[LABEL]{\TYPE{<#2 CODE>}}
+      \TEST
+    \ENDTEST
+    \BEGINTEST{Activated: #2}
+      \ActivateGenericHook{#2}
+      \TEST
+    \ENDTEST
+    \BEGINTEST{Disabled: #2}
+      \DisableGenericHook{#2}
+      \TEST
+    \ENDTEST
+  \ENDTEST
+}
+\def\TESTBlockHook#1#2{
+% run at the top level
+% #1: the title of the block
+% #2: the name of the hook
+  \BEGINTEST{#1}
+    \def\TEST{
+      \UseHook{#2}
+      \ShowHook{#2}
+    }
+    \BEGINTEST{Undeclared #2}
+    \TEST
+    \ENDTEST
+    \BEGINTEST{#2 + TOP LEVEL}
+      \AddToHook{#2}{\TYPE{<#2 TOP-LEVEL>}}
+      \TEST
+    \ENDTEST
+    \BEGINTEST{#2 + A LABEL}
+      \AddToHook{#2}[A LABEL]{\TYPE{<#2 A CODE>}}
+      \TEST
+    \ENDTEST
+    \BEGINTEST{#2 + B LABEL}
+      \AddToHook{#2}[B LABEL]{\TYPE{<#2 B CODE>}}
+      \TEST
+    \ENDTEST
+    \BEGINTEST{#2 + C LABEL}
+      \AddToHook{#2}[C LABEL]{\TYPE{<#2 C CODE>}}
+      \TEST
+    \ENDTEST
+    \BEGINTEST{#2 + NEXT}
+      \AddToHookNext{#2}{\TYPE{<NEXT-ONLY>}}
+      \ShowHook{#2}
+      \TEST
+    \ENDTEST
+    \BEGINTEST{#2 + C LABEL < A LABEL}
+      \DeclareHookRule{#2}{C LABEL}{before}{A LABEL}
+      \TEST
+    \ENDTEST
+    \BEGINTEST{#2 + DEFAULT: B LABEL > C LABEL}
+      \DeclareDefaultHookRule{B LABEL}{after}{C LABEL}
+      \TEST
+    \ENDTEST
+  \ENDTEST
+}
+\EndIncludeInRelease%{2020-10-01}{\TESTBlockHookOneArg}{Message}
+
+\IncludeInRelease{0000-00-00}{\whatever}{Message}
+\EndIncludeInRelease

--- a/base/testfiles-lthooks/lthooks-show-2020-10-01.lvt
+++ b/base/testfiles-lthooks/lthooks-show-2020-10-01.lvt
@@ -1,0 +1,86 @@
+% This is somehow `lthooks-show.lvt` frozen to the 2020-10-01 release
+% before hooks with arguments were introduced.
+
+\input{regression-test}
+\RequirePackage[2020-10-01]{latexrelease}
+\TYPE{********* RequirePackage[2020-10-01]{latexrelease}}
+
+\RequirePackage{./lthooks-show}
+
+\ExplSyntaxOn
+\debug_on:n { check-declarations , deprecation }
+\ExplSyntaxOff
+
+\documentclass{article}
+
+% There are many different hook profiles.
+
+\START
+
+\TESTBlockHookEnv
+  {Undefined environment envA}
+  {envA}
+\NewDocumentEnvironment
+  {envA}{}
+  {\TYPE{<BEGIN{envA}>}}
+  {\TYPE{<END{envA}>}}
+\begin{envA}\TYPE{<envA BODY>}\end{envA}
+
+\NewDocumentEnvironment
+  {envB}{}
+  {\TYPE{<BEGIN{envB}>}}
+  {\TYPE{<END{envB}>}}
+\TESTBlockHookEnv
+  {Defined environment envB}
+  {envB}
+\begin{envB}\TYPE{<envB BODY>}\end{envB}
+
+\TESTBlockHookCmd
+  {Undefined command with no arguments}
+  {cmdA}
+\NewDocumentCommand\cmdA{}{\TYPE{<cmdA BODY>}}
+\cmdA
+
+\NewDocumentCommand\cmdB{}{\TYPE{<cmdB BODY>}}
+\TESTBlockHookCmd
+  {Defined command with no arguments}
+  {cmdB}
+\cmdB
+
+\TESTBlockHookCustomGeneric
+  {CUSTOM GENERIC HOOK}
+  {CUSTOM GENERIC HOOK}
+
+\TESTBlockHook
+  {OTHER HOOK: Undeclared}
+  {UNDECLARED HOOK}
+
+\NewHook{DECLARED HOOK}
+
+\TESTBlockHook
+  {OTHER HOOK: declared}
+  {DECLARED HOOK}
+
+\NewReversedHook{DECLARED REVERSED}
+
+\TESTBlockHook
+  {OTHER HOOK: declared reversed}
+  {DECLARED REVERSED}
+
+\OMIT
+\begin{document}
+\TIMO
+
+\BEGINTEST{After \begin{document}}
+
+  \BEGINTEST{Commands}
+    \cmdA
+    \SEPARATOR
+    \cmdB
+  \ENDTEST
+
+\ENDTEST
+
+\TYPE{!!!! If this test changes the documentation needs updating !!!!}
+
+\END

--- a/base/testfiles-lthooks/lthooks-show-2020-10-01.tlg
+++ b/base/testfiles-lthooks/lthooks-show-2020-10-01.tlg
@@ -1,0 +1,845 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: Environment: envA
+============================================================
+-> The generic hook 'env/envA/before':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {envA}
+-> The generic hook 'env/envA/begin':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {envA}
+-> The generic hook 'env/envA/end':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {envA}
+-> The generic hook 'env/envA/after':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {envA}
+-> The generic hook 'env/envA/before':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<envA BEFORE>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {envA}
+-> The generic hook 'env/envA/begin':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<envA BEGIN>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {envA}
+-> The generic hook 'env/envA/end':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<envA END>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {envA}
+-> The generic hook 'env/envA/after':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<envA AFTER>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     ---.
+<recently read> }
+l. ...  {envA}
+============================================================
+<envA BEFORE>
+<envA BEGIN>
+<BEGIN{envA}>
+<envA BODY>
+<envA END>
+<END{envA}>
+<envA AFTER>
+============================================================
+TEST 2: Environment: envB
+============================================================
+-> The generic hook 'env/envB/before':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {envB}
+-> The generic hook 'env/envB/begin':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {envB}
+-> The generic hook 'env/envB/end':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {envB}
+-> The generic hook 'env/envB/after':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {envB}
+-> The generic hook 'env/envB/before':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<envB BEFORE>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {envB}
+-> The generic hook 'env/envB/begin':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<envB BEGIN>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {envB}
+-> The generic hook 'env/envB/end':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<envB END>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {envB}
+-> The generic hook 'env/envB/after':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<envB AFTER>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     ---.
+<recently read> }
+l. ...  {envB}
+============================================================
+<envB BEFORE>
+<envB BEGIN>
+<BEGIN{envB}>
+<envB BODY>
+<envB END>
+<END{envB}>
+<envB AFTER>
+============================================================
+TEST 3: Command: Undefined command with no arguments
+============================================================
+-> The generic hook 'cmd/cmdA/before':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {cmdA}
+-> The generic hook 'cmd/cmdA/after':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {cmdA}
+-> The generic hook 'cmd/cmdA/before':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<cmdA BEFORE>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {cmdA}
+-> The generic hook 'cmd/cmdA/after':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<cmdA AFTER>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     ---.
+<recently read> }
+l. ...  {cmdA}
+============================================================
+<cmdA BODY>
+============================================================
+TEST 4: Command: Defined command with no arguments
+============================================================
+-> The generic hook 'cmd/cmdB/before':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {cmdB}
+-> The generic hook 'cmd/cmdB/after':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {cmdB}
+-> The generic hook 'cmd/cmdB/before':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<cmdB BEFORE>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {cmdB}
+-> The generic hook 'cmd/cmdB/after':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<cmdB AFTER>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     ---.
+<recently read> }
+l. ...  {cmdB}
+============================================================
+<cmdB BODY>
+============================================================
+TEST 5: Custom generic hook: CUSTOM GENERIC HOOK
+============================================================
+============================================================
+TEST 6: Raw: CUSTOM GENERIC HOOK
+============================================================
+-> The hook 'CUSTOM GENERIC HOOK':
+> The hook is not declared.
+> Code chunks:
+>     LABEL -> \TYPE {<CUSTOM GENERIC HOOK CODE>}
+> Document-level (top-level) code:
+>     ---
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {CUSTOM GENERIC HOOK}
+============================================================
+============================================================
+TEST 7: Activated: CUSTOM GENERIC HOOK
+============================================================
+-> The hook 'CUSTOM GENERIC HOOK':
+> The hook is not declared.
+> Code chunks:
+>     LABEL -> \TYPE {<CUSTOM GENERIC HOOK CODE>}
+> Document-level (top-level) code:
+>     ---
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {CUSTOM GENERIC HOOK}
+============================================================
+============================================================
+TEST 8: Disabled: CUSTOM GENERIC HOOK
+============================================================
+-> The hook 'CUSTOM GENERIC HOOK':
+> The hook is not declared.
+> Code chunks:
+>     LABEL -> \TYPE {<CUSTOM GENERIC HOOK CODE>}
+> Document-level (top-level) code:
+>     ---
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {CUSTOM GENERIC HOOK}
+============================================================
+============================================================
+============================================================
+TEST 9: OTHER HOOK: Undeclared
+============================================================
+============================================================
+TEST 10: Undeclared UNDECLARED HOOK
+============================================================
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
+============================================================
+============================================================
+TEST 11: UNDECLARED HOOK + TOP LEVEL
+============================================================
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> Code chunks:
+>     ---
+> Document-level (top-level) code:
+>     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
+============================================================
+============================================================
+TEST 12: UNDECLARED HOOK + A LABEL
+============================================================
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> Code chunks:
+>     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
+> Document-level (top-level) code:
+>     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
+============================================================
+============================================================
+TEST 13: UNDECLARED HOOK + B LABEL
+============================================================
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> Code chunks:
+>     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<UNDECLARED HOOK B CODE>}
+> Document-level (top-level) code:
+>     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
+============================================================
+============================================================
+TEST 14: UNDECLARED HOOK + C LABEL
+============================================================
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> Code chunks:
+>     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<UNDECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<UNDECLARED HOOK C CODE>}
+> Document-level (top-level) code:
+>     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
+============================================================
+============================================================
+TEST 15: UNDECLARED HOOK + NEXT
+============================================================
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> Code chunks:
+>     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<UNDECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<UNDECLARED HOOK C CODE>}
+> Document-level (top-level) code:
+>     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     -> \TYPE {<NEXT-ONLY>}
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> Code chunks:
+>     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<UNDECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<UNDECLARED HOOK C CODE>}
+> Document-level (top-level) code:
+>     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     -> \TYPE {<NEXT-ONLY>}
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
+============================================================
+============================================================
+TEST 16: UNDECLARED HOOK + C LABEL < A LABEL
+============================================================
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> Code chunks:
+>     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<UNDECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<UNDECLARED HOOK C CODE>}
+> Document-level (top-level) code:
+>     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     -> \TYPE {<NEXT-ONLY>}
+> Rules:
+>     C LABEL|A LABEL with relation <
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
+============================================================
+============================================================
+TEST 17: UNDECLARED HOOK + DEFAULT: B LABEL > C LABEL
+============================================================
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> Code chunks:
+>     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<UNDECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<UNDECLARED HOOK C CODE>}
+> Document-level (top-level) code:
+>     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     -> \TYPE {<NEXT-ONLY>}
+> Rules:
+>     C LABEL|A LABEL with relation <
+>     C LABEL|B LABEL with default relation <
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
+============================================================
+============================================================
+============================================================
+TEST 18: OTHER HOOK: declared
+============================================================
+============================================================
+TEST 19: Undeclared DECLARED HOOK
+============================================================
+-> The hook 'DECLARED HOOK':
+> The hook is empty.
+<recently read> }
+l. ...  {DECLARED HOOK}
+============================================================
+============================================================
+TEST 20: DECLARED HOOK + TOP LEVEL
+============================================================
+<DECLARED HOOK TOP-LEVEL>
+-> The hook 'DECLARED HOOK':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<DECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {DECLARED HOOK}
+============================================================
+============================================================
+TEST 21: DECLARED HOOK + A LABEL
+============================================================
+<DECLARED HOOK A CODE>
+<DECLARED HOOK TOP-LEVEL>
+-> The hook 'DECLARED HOOK':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED HOOK A CODE>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<DECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     A LABEL.
+<recently read> }
+l. ...  {DECLARED HOOK}
+============================================================
+============================================================
+TEST 22: DECLARED HOOK + B LABEL
+============================================================
+<DECLARED HOOK A CODE>
+<DECLARED HOOK B CODE>
+<DECLARED HOOK TOP-LEVEL>
+-> The hook 'DECLARED HOOK':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<DECLARED HOOK B CODE>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<DECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     A LABEL, B LABEL.
+<recently read> }
+l. ...  {DECLARED HOOK}
+============================================================
+============================================================
+TEST 23: DECLARED HOOK + C LABEL
+============================================================
+<DECLARED HOOK A CODE>
+<DECLARED HOOK C CODE>
+<DECLARED HOOK B CODE>
+<DECLARED HOOK TOP-LEVEL>
+-> The hook 'DECLARED HOOK':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<DECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<DECLARED HOOK C CODE>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<DECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     A LABEL, C LABEL, B LABEL.
+<recently read> }
+l. ...  {DECLARED HOOK}
+============================================================
+============================================================
+TEST 24: DECLARED HOOK + NEXT
+============================================================
+-> The hook 'DECLARED HOOK':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<DECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<DECLARED HOOK C CODE>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<DECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     -> \TYPE {<NEXT-ONLY>}
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     A LABEL, C LABEL, B LABEL.
+<recently read> }
+l. ...  {DECLARED HOOK}
+<DECLARED HOOK A CODE>
+<DECLARED HOOK C CODE>
+<DECLARED HOOK B CODE>
+<DECLARED HOOK TOP-LEVEL>
+<NEXT-ONLY>
+-> The hook 'DECLARED HOOK':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<DECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<DECLARED HOOK C CODE>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<DECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     A LABEL, C LABEL, B LABEL.
+<recently read> }
+l. ...  {DECLARED HOOK}
+============================================================
+============================================================
+TEST 25: DECLARED HOOK + C LABEL < A LABEL
+============================================================
+<DECLARED HOOK C CODE>
+<DECLARED HOOK A CODE>
+<DECLARED HOOK B CODE>
+<DECLARED HOOK TOP-LEVEL>
+-> The hook 'DECLARED HOOK':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<DECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<DECLARED HOOK C CODE>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<DECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|A LABEL with relation <
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     C LABEL, A LABEL, B LABEL.
+<recently read> }
+l. ...  {DECLARED HOOK}
+============================================================
+============================================================
+TEST 26: DECLARED HOOK + DEFAULT: B LABEL > C LABEL
+============================================================
+<DECLARED HOOK C CODE>
+<DECLARED HOOK A CODE>
+<DECLARED HOOK B CODE>
+<DECLARED HOOK TOP-LEVEL>
+-> The hook 'DECLARED HOOK':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<DECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<DECLARED HOOK C CODE>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<DECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|A LABEL with relation <
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     C LABEL, A LABEL, B LABEL.
+<recently read> }
+l. ...  {DECLARED HOOK}
+============================================================
+============================================================
+============================================================
+TEST 27: OTHER HOOK: declared reversed
+============================================================
+============================================================
+TEST 28: Undeclared DECLARED REVERSED
+============================================================
+-> The hook 'DECLARED REVERSED':
+> The hook is empty.
+<recently read> }
+l. ...  {DECLARED REVERSED}
+============================================================
+============================================================
+TEST 29: DECLARED REVERSED + TOP LEVEL
+============================================================
+<DECLARED REVERSED TOP-LEVEL>
+-> The hook 'DECLARED REVERSED':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<DECLARED REVERSED TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     ---.
+<recently read> }
+l. ...  {DECLARED REVERSED}
+============================================================
+============================================================
+TEST 30: DECLARED REVERSED + A LABEL
+============================================================
+<DECLARED REVERSED TOP-LEVEL>
+<DECLARED REVERSED A CODE>
+-> The hook 'DECLARED REVERSED':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED REVERSED A CODE>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<DECLARED REVERSED TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     A LABEL.
+<recently read> }
+l. ...  {DECLARED REVERSED}
+============================================================
+============================================================
+TEST 31: DECLARED REVERSED + B LABEL
+============================================================
+<DECLARED REVERSED TOP-LEVEL>
+<DECLARED REVERSED B CODE>
+<DECLARED REVERSED A CODE>
+-> The hook 'DECLARED REVERSED':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED REVERSED A CODE>}
+>     B LABEL -> \TYPE {<DECLARED REVERSED B CODE>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<DECLARED REVERSED TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     B LABEL, A LABEL.
+<recently read> }
+l. ...  {DECLARED REVERSED}
+============================================================
+============================================================
+TEST 32: DECLARED REVERSED + C LABEL
+============================================================
+<DECLARED REVERSED TOP-LEVEL>
+<DECLARED REVERSED B CODE>
+<DECLARED REVERSED C CODE>
+<DECLARED REVERSED A CODE>
+-> The hook 'DECLARED REVERSED':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED REVERSED A CODE>}
+>     B LABEL -> \TYPE {<DECLARED REVERSED B CODE>}
+>     C LABEL -> \TYPE {<DECLARED REVERSED C CODE>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<DECLARED REVERSED TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {DECLARED REVERSED}
+============================================================
+============================================================
+TEST 33: DECLARED REVERSED + NEXT
+============================================================
+-> The hook 'DECLARED REVERSED':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED REVERSED A CODE>}
+>     B LABEL -> \TYPE {<DECLARED REVERSED B CODE>}
+>     C LABEL -> \TYPE {<DECLARED REVERSED C CODE>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<DECLARED REVERSED TOP-LEVEL>}
+> Extra code for next invocation:
+>     -> \TYPE {<NEXT-ONLY>}
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {DECLARED REVERSED}
+<DECLARED REVERSED TOP-LEVEL>
+<DECLARED REVERSED B CODE>
+<DECLARED REVERSED C CODE>
+<DECLARED REVERSED A CODE>
+<NEXT-ONLY>
+-> The hook 'DECLARED REVERSED':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED REVERSED A CODE>}
+>     B LABEL -> \TYPE {<DECLARED REVERSED B CODE>}
+>     C LABEL -> \TYPE {<DECLARED REVERSED C CODE>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<DECLARED REVERSED TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {DECLARED REVERSED}
+============================================================
+============================================================
+TEST 34: DECLARED REVERSED + C LABEL < A LABEL
+============================================================
+<DECLARED REVERSED TOP-LEVEL>
+<DECLARED REVERSED B CODE>
+<DECLARED REVERSED C CODE>
+<DECLARED REVERSED A CODE>
+-> The hook 'DECLARED REVERSED':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED REVERSED A CODE>}
+>     B LABEL -> \TYPE {<DECLARED REVERSED B CODE>}
+>     C LABEL -> \TYPE {<DECLARED REVERSED C CODE>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<DECLARED REVERSED TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|A LABEL with relation <
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {DECLARED REVERSED}
+============================================================
+============================================================
+TEST 35: DECLARED REVERSED + DEFAULT: B LABEL > C LABEL
+============================================================
+<DECLARED REVERSED TOP-LEVEL>
+<DECLARED REVERSED B CODE>
+<DECLARED REVERSED C CODE>
+<DECLARED REVERSED A CODE>
+-> The hook 'DECLARED REVERSED':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED REVERSED A CODE>}
+>     B LABEL -> \TYPE {<DECLARED REVERSED B CODE>}
+>     C LABEL -> \TYPE {<DECLARED REVERSED C CODE>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<DECLARED REVERSED TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|A LABEL with relation <
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {DECLARED REVERSED}
+============================================================
+============================================================
+============================================================
+TEST 36: After \begin {document}
+============================================================
+============================================================
+TEST 37: Commands
+============================================================
+<cmdA BODY>
+============================================================
+<cmdB BODY>
+============================================================
+============================================================
+!!!! If this test changes the documentation needs updating !!!!

--- a/base/update-lthooks-tests.sh
+++ b/base/update-lthooks-tests.sh
@@ -95,6 +95,7 @@ l3build save -cconfig-lthooks \
    lthooks-legacy \
    lthooks-doc-examples \
    lthooks-rollback-args \
+   lthooks-show-2020-10-01 \
    shipout-000 \
    shipout-002 \
    shipout-004 \


### PR DESCRIPTION
- `lthooks-show_2020-10-01.lvt` is frozen at the 2020-10-01 release, no arguments in hooks
- `update-lthooks-tests.sh` includes the above test
- `lthooks-show.sty` is a library of test helpers. They will be used by forthcoming tests, as well as completed.

This is a fix in the 2020-10-01 rollback, tagged as `\changed{1.0w}`. No actual version change though.

All the config-lthooks and config-lthooks2 checks passed.

**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
- Ready to merge

## Checklist of required changes before merge will be approved
- [ X] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
