### PR TITLE
Lthooks new showhook 2

### DIFF
--- a/base/testfiles-lthooks/helpers/lthooks-show.sty
+++ b/base/testfiles-lthooks/helpers/lthooks-show.sty
@@ -1,0 +1,111 @@
+% This is a library of commands used by various `lthooks*.lvt`
+
+\IncludeInRelease{2020-10-01}{\TESTBlockHook}{Message}
+
+\def\DebugShowHookEnv#1{
+  \ShowHook{env/#1/before}
+  \ShowHook{env/#1/begin}
+  \ShowHook{env/#1/end}
+  \ShowHook{env/#1/after}
+}
+
+\def\DebugShowHookCmd#1{
+  \ShowHook{cmd/#1/before}
+  \ShowHook{cmd/#1/after}
+}
+
+\def\TESTBlockHookEnv#1#2{
+% run at the top level
+% #1: the title of the block
+% #2: the name of the environment
+  \BEGINTEST{Environment: #2}
+    \DebugShowHookEnv{#2}
+    \AddToHook{env/#2/before}{\TYPE{<#2 BEFORE>}}
+    \AddToHook{env/#2/begin}{\TYPE{<#2 BEGIN>}}
+    \AddToHook{env/#2/end}{\TYPE{<#2 END>}}
+    \AddToHook{env/#2/after}{\TYPE{<#2 AFTER>}}
+    \DebugShowHookEnv{#2}
+  \ENDTEST
+}
+
+\def\TESTBlockHookCmd#1#2{
+% run at the top level
+% #1: the title of the block
+% #2: the csname of the command
+  \BEGINTEST{Command: #1}
+    \DebugShowHookCmd{#2}
+    \AddToHook{cmd/#2/before}{\TYPE{<#2 BEFORE>}}
+    \AddToHook{cmd/#2/after}{\TYPE{<#2 AFTER>}}
+    \DebugShowHookCmd{#2}
+  \ENDTEST
+}
+\def\TESTBlockHookCustomGeneric#1#2{
+% run at the top level
+% #1: the title of the block
+% #2: the name of the hook
+  \BEGINTEST{Custom generic hook: #1}
+    \def\TEST{
+      \UseHook{#2}
+      \ShowHook{#2}
+    }
+    \BEGINTEST{Raw: #2}
+      \AddToHook{#2}[LABEL]{\TYPE{<#2 CODE>}}
+      \TEST
+    \ENDTEST
+    \BEGINTEST{Activated: #2}
+      \ActivateGenericHook{#2}
+      \TEST
+    \ENDTEST
+    \BEGINTEST{Disabled: #2}
+      \DisableGenericHook{#2}
+      \TEST
+    \ENDTEST
+  \ENDTEST
+}
+\def\TESTBlockHook#1#2{
+% run at the top level
+% #1: the title of the block
+% #2: the name of the hook
+  \BEGINTEST{#1}
+    \def\TEST{
+      \UseHook{#2}
+      \ShowHook{#2}
+    }
+    \BEGINTEST{Undeclared #2}
+    \TEST
+    \ENDTEST
+    \BEGINTEST{#2 + TOP LEVEL}
+      \AddToHook{#2}{\TYPE{<#2 TOP-LEVEL>}}
+      \TEST
+    \ENDTEST
+    \BEGINTEST{#2 + A LABEL}
+      \AddToHook{#2}[A LABEL]{\TYPE{<#2 A CODE>}}
+      \TEST
+    \ENDTEST
+    \BEGINTEST{#2 + B LABEL}
+      \AddToHook{#2}[B LABEL]{\TYPE{<#2 B CODE>}}
+      \TEST
+    \ENDTEST
+    \BEGINTEST{#2 + C LABEL}
+      \AddToHook{#2}[C LABEL]{\TYPE{<#2 C CODE>}}
+      \TEST
+    \ENDTEST
+    \BEGINTEST{#2 + NEXT}
+      \AddToHookNext{#2}{\TYPE{<NEXT-ONLY>}}
+      \ShowHook{#2}
+      \TEST
+    \ENDTEST
+    \BEGINTEST{#2 + C LABEL < A LABEL}
+      \DeclareHookRule{#2}{C LABEL}{before}{A LABEL}
+      \TEST
+    \ENDTEST
+    \BEGINTEST{#2 + DEFAULT: B LABEL > C LABEL}
+      \DeclareDefaultHookRule{B LABEL}{after}{C LABEL}
+      \TEST
+    \ENDTEST
+  \ENDTEST
+}
+\EndIncludeInRelease%{2020-10-01}{\TESTBlockHookOneArg}{Message}
+
+\IncludeInRelease{0000-00-00}{\whatever}{Message}
+\EndIncludeInRelease

--- a/base/testfiles-lthooks/helpers/lthooks-show.sty
+++ b/base/testfiles-lthooks/helpers/lthooks-show.sty
@@ -1,5 +1,100 @@
 % This is a library of commands used by various `lthooks*.lvt`
 
+\ExplSyntaxOn
+\tl_new:N \l__TESTHookShow_tl
+
+\IncludeInRelease{2023-06-01}{\WithArgs}{With arguments}
+  \cs_new:Npn \TESTHookWithArgs:Nnn #1 #2 #3
+  % #1 the local tl variable holding the result
+  % #2 the template
+  % #3 the number of arguments
+    {
+      \tl_clear:N #1
+      \int_step_inline:nn { #3 } { \tl_put_right:Nn #1 { #2 } }
+    }
+  \def\TESTBlockHookCmdWithArgs#1#2#3{
+  % run at the top level
+  % #1: the title of the block
+  % #2: the csname of the command
+    \BEGINTEST{Command:~#1}
+      \DebugShowHookCmd{#2}
+      \TESTHookWithArgs:Nnn \l__TESTHookShow_tl { ######1/ } { #3 }
+      \exp_args:Nnx
+      \AddToHookWithArguments { cmd/#2/before }
+        { \exp_not:N \TYPE { <#2~BEFORE:~/\exp_not:V \l__TESTHookShow_tl> } }
+      \exp_args:Nnx
+      \AddToHookWithArguments { cmd/#2/after }
+        { \exp_not:N \TYPE { <#2~AFTER :~/\exp_not:V \l__TESTHookShow_tl> } }
+      \DebugShowHookCmd{#2}
+    \ENDTEST
+  }
+  \def\TESTBlockHookWithArgs#1#2#3{
+  % run at the top level
+  % #1: the title of the block
+  % #2: the name of the hook
+  % #3: the number of arguments
+  % Not in the 2020-10-01 release
+    \BEGINTEST{#1}
+      \def\TEST{
+        \TESTHookWithArgs:Nnn \l__TESTHookShow_tl { { arg_####1 } } { #3 }
+        \TYPE{\token_to_str:N \UseHookWithArguments {#2} {#3} \l__TESTHookShow_tl =>}
+        \exp_last_unbraced:Nno
+        \use:n { \UseHookWithArguments {#2} {#3} } \l__TESTHookShow_tl
+        \ShowHook{#2}
+      }
+      \BEGINTEST{Undeclared~#2}
+      \TEST
+      \ENDTEST
+      \BEGINTEST{#2~+~TOP-LEVEL}
+        \TESTHookWithArgs:Nnn \l__TESTHookShow_tl { arg~######1 / } { #3 }
+        \exp_args:Nnx
+        \use:n { \AddToHookWithArguments { #2 } }
+          { \exp_not:N \TYPE { <#2~TOP-LEVEL:~/\exp_not:V \l__TESTHookShow_tl> } }
+        \TEST
+      \ENDTEST
+      \BEGINTEST{#2~+~A~LABEL}
+        \TESTHookWithArgs:Nnn \l__TESTHookShow_tl { arg~######1 / } { #3 }
+        \exp_args:Nnx
+        \use:n { \AddToHookWithArguments { #2 }[A~LABEL] }
+          { \exp_not:N \TYPE { <#2~A~CODE:~/\exp_not:V \l__TESTHookShow_tl> } }
+        \TEST
+      \ENDTEST
+      \BEGINTEST{#2~+~B~LABEL}
+        \TESTHookWithArgs:Nnn \l__TESTHookShow_tl { arg~######1 / } { #3 }
+        \exp_args:Nnx
+        \use:n { \AddToHookWithArguments { #2 }[B~LABEL] }
+          { \exp_not:N \TYPE { <#2~B~CODE:~/\exp_not:V \l__TESTHookShow_tl> } }
+        \TEST
+      \ENDTEST
+      \BEGINTEST{#2~+~C~LABEL}
+        \TESTHookWithArgs:Nnn \l__TESTHookShow_tl { arg~######1 / } { #3 }
+        \exp_args:Nnx
+        \use:n { \AddToHookWithArguments { #2 }[C~LABEL] }
+          { \exp_not:N \TYPE { <#2~C~CODE:~/\exp_not:V \l__TESTHookShow_tl> } }
+        \TEST
+      \ENDTEST
+      \BEGINTEST{#2~+~NEXT}
+        \TESTHookWithArgs:Nnn \l__TESTHookShow_tl { arg~######1 / } { #3 }
+        \exp_args:Nnx
+        \use:n { \AddToHookNextWithArguments { #2 } }
+          { \exp_not:N \TYPE { <#2~NEXT-ONLY~CODE:~/\exp_not:V \l__TESTHookShow_tl> } }
+        \ShowHook{#2}
+        \TEST
+      \ENDTEST
+      \BEGINTEST{#2~+~C~LABEL~<~A~LABEL}
+        \DeclareHookRule{#2}{C~LABEL}{before}{A~LABEL}
+        \TEST
+      \ENDTEST
+      \BEGINTEST{#2~+~DEFAULT:~B~LABEL~>~C~LABEL}
+        \DeclareDefaultHookRule{B~LABEL}{after}{C~LABEL}
+        \TEST
+      \ENDTEST
+    \ENDTEST
+  }
+\EndIncludeInRelease
+\ExplSyntaxOff
+% 
+
 \IncludeInRelease{2020-10-01}{\TESTBlockHook}{Message}
 
 \def\DebugShowHookEnv#1{
@@ -74,7 +169,7 @@
     \BEGINTEST{Undeclared #2}
     \TEST
     \ENDTEST
-    \BEGINTEST{#2 + TOP LEVEL}
+    \BEGINTEST{#2 + TOP-LEVEL}
       \AddToHook{#2}{\TYPE{<#2 TOP-LEVEL>}}
       \TEST
     \ENDTEST

--- a/base/testfiles-lthooks/lthooks-show-2020-10-01.lvt
+++ b/base/testfiles-lthooks/lthooks-show-2020-10-01.lvt
@@ -1,0 +1,86 @@
+% This is somehow `lthooks-show.lvt` frozen to the 2020-10-01 release
+% before hooks with arguments were introduced.
+
+\input{regression-test}
+\RequirePackage[2020-10-01]{latexrelease}
+\TYPE{********* RequirePackage[2020-10-01]{latexrelease}}
+
+\RequirePackage{./lthooks-show}
+
+\ExplSyntaxOn
+\debug_on:n { check-declarations , deprecation }
+\ExplSyntaxOff
+
+\documentclass{article}
+
+% There are many different hook profiles.
+
+\START
+
+\TESTBlockHookEnv
+  {Undefined environment envA}
+  {envA}
+\NewDocumentEnvironment
+  {envA}{}
+  {\TYPE{<BEGIN{envA}>}}
+  {\TYPE{<END{envA}>}}
+\begin{envA}\TYPE{<envA BODY>}\end{envA}
+
+\NewDocumentEnvironment
+  {envB}{}
+  {\TYPE{<BEGIN{envB}>}}
+  {\TYPE{<END{envB}>}}
+\TESTBlockHookEnv
+  {Defined environment envB}
+  {envB}
+\begin{envB}\TYPE{<envB BODY>}\end{envB}
+
+\TESTBlockHookCmd
+  {Undefined command with no arguments}
+  {cmdA}
+\NewDocumentCommand\cmdA{}{\TYPE{<cmdA BODY>}}
+\cmdA
+
+\NewDocumentCommand\cmdB{}{\TYPE{<cmdB BODY>}}
+\TESTBlockHookCmd
+  {Defined command with no arguments}
+  {cmdB}
+\cmdB
+
+\TESTBlockHookCustomGeneric
+  {CUSTOM GENERIC HOOK}
+  {CUSTOM GENERIC HOOK}
+
+\TESTBlockHook
+  {OTHER HOOK: Undeclared}
+  {UNDECLARED HOOK}
+
+\NewHook{DECLARED HOOK}
+
+\TESTBlockHook
+  {OTHER HOOK: declared}
+  {DECLARED HOOK}
+
+\NewReversedHook{DECLARED REVERSED}
+
+\TESTBlockHook
+  {OTHER HOOK: declared reversed}
+  {DECLARED REVERSED}
+
+\OMIT
+\begin{document}
+\TIMO
+
+\BEGINTEST{After \begin{document}}
+
+  \BEGINTEST{Commands}
+    \cmdA
+    \SEPARATOR
+    \cmdB
+  \ENDTEST
+
+\ENDTEST
+
+\TYPE{!!!! If this test changes the documentation needs updating !!!!}
+
+\END

--- a/base/testfiles-lthooks/lthooks-show-2020-10-01.tlg
+++ b/base/testfiles-lthooks/lthooks-show-2020-10-01.tlg
@@ -1,0 +1,845 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: Environment: envA
+============================================================
+-> The generic hook 'env/envA/before':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {envA}
+-> The generic hook 'env/envA/begin':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {envA}
+-> The generic hook 'env/envA/end':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {envA}
+-> The generic hook 'env/envA/after':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {envA}
+-> The generic hook 'env/envA/before':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<envA BEFORE>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {envA}
+-> The generic hook 'env/envA/begin':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<envA BEGIN>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {envA}
+-> The generic hook 'env/envA/end':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<envA END>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {envA}
+-> The generic hook 'env/envA/after':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<envA AFTER>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     ---.
+<recently read> }
+l. ...  {envA}
+============================================================
+<envA BEFORE>
+<envA BEGIN>
+<BEGIN{envA}>
+<envA BODY>
+<envA END>
+<END{envA}>
+<envA AFTER>
+============================================================
+TEST 2: Environment: envB
+============================================================
+-> The generic hook 'env/envB/before':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {envB}
+-> The generic hook 'env/envB/begin':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {envB}
+-> The generic hook 'env/envB/end':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {envB}
+-> The generic hook 'env/envB/after':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {envB}
+-> The generic hook 'env/envB/before':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<envB BEFORE>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {envB}
+-> The generic hook 'env/envB/begin':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<envB BEGIN>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {envB}
+-> The generic hook 'env/envB/end':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<envB END>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {envB}
+-> The generic hook 'env/envB/after':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<envB AFTER>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     ---.
+<recently read> }
+l. ...  {envB}
+============================================================
+<envB BEFORE>
+<envB BEGIN>
+<BEGIN{envB}>
+<envB BODY>
+<envB END>
+<END{envB}>
+<envB AFTER>
+============================================================
+TEST 3: Command: Undefined command with no arguments
+============================================================
+-> The generic hook 'cmd/cmdA/before':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {cmdA}
+-> The generic hook 'cmd/cmdA/after':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {cmdA}
+-> The generic hook 'cmd/cmdA/before':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<cmdA BEFORE>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {cmdA}
+-> The generic hook 'cmd/cmdA/after':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<cmdA AFTER>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     ---.
+<recently read> }
+l. ...  {cmdA}
+============================================================
+<cmdA BODY>
+============================================================
+TEST 4: Command: Defined command with no arguments
+============================================================
+-> The generic hook 'cmd/cmdB/before':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {cmdB}
+-> The generic hook 'cmd/cmdB/after':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {cmdB}
+-> The generic hook 'cmd/cmdB/before':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<cmdB BEFORE>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {cmdB}
+-> The generic hook 'cmd/cmdB/after':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<cmdB AFTER>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     ---.
+<recently read> }
+l. ...  {cmdB}
+============================================================
+<cmdB BODY>
+============================================================
+TEST 5: Custom generic hook: CUSTOM GENERIC HOOK
+============================================================
+============================================================
+TEST 6: Raw: CUSTOM GENERIC HOOK
+============================================================
+-> The hook 'CUSTOM GENERIC HOOK':
+> The hook is not declared.
+> Code chunks:
+>     LABEL -> \TYPE {<CUSTOM GENERIC HOOK CODE>}
+> Document-level (top-level) code:
+>     ---
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {CUSTOM GENERIC HOOK}
+============================================================
+============================================================
+TEST 7: Activated: CUSTOM GENERIC HOOK
+============================================================
+-> The hook 'CUSTOM GENERIC HOOK':
+> The hook is not declared.
+> Code chunks:
+>     LABEL -> \TYPE {<CUSTOM GENERIC HOOK CODE>}
+> Document-level (top-level) code:
+>     ---
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {CUSTOM GENERIC HOOK}
+============================================================
+============================================================
+TEST 8: Disabled: CUSTOM GENERIC HOOK
+============================================================
+-> The hook 'CUSTOM GENERIC HOOK':
+> The hook is not declared.
+> Code chunks:
+>     LABEL -> \TYPE {<CUSTOM GENERIC HOOK CODE>}
+> Document-level (top-level) code:
+>     ---
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {CUSTOM GENERIC HOOK}
+============================================================
+============================================================
+============================================================
+TEST 9: OTHER HOOK: Undeclared
+============================================================
+============================================================
+TEST 10: Undeclared UNDECLARED HOOK
+============================================================
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
+============================================================
+============================================================
+TEST 11: UNDECLARED HOOK + TOP LEVEL
+============================================================
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> Code chunks:
+>     ---
+> Document-level (top-level) code:
+>     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
+============================================================
+============================================================
+TEST 12: UNDECLARED HOOK + A LABEL
+============================================================
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> Code chunks:
+>     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
+> Document-level (top-level) code:
+>     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
+============================================================
+============================================================
+TEST 13: UNDECLARED HOOK + B LABEL
+============================================================
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> Code chunks:
+>     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<UNDECLARED HOOK B CODE>}
+> Document-level (top-level) code:
+>     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
+============================================================
+============================================================
+TEST 14: UNDECLARED HOOK + C LABEL
+============================================================
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> Code chunks:
+>     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<UNDECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<UNDECLARED HOOK C CODE>}
+> Document-level (top-level) code:
+>     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
+============================================================
+============================================================
+TEST 15: UNDECLARED HOOK + NEXT
+============================================================
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> Code chunks:
+>     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<UNDECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<UNDECLARED HOOK C CODE>}
+> Document-level (top-level) code:
+>     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     -> \TYPE {<NEXT-ONLY>}
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> Code chunks:
+>     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<UNDECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<UNDECLARED HOOK C CODE>}
+> Document-level (top-level) code:
+>     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     -> \TYPE {<NEXT-ONLY>}
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
+============================================================
+============================================================
+TEST 16: UNDECLARED HOOK + C LABEL < A LABEL
+============================================================
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> Code chunks:
+>     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<UNDECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<UNDECLARED HOOK C CODE>}
+> Document-level (top-level) code:
+>     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     -> \TYPE {<NEXT-ONLY>}
+> Rules:
+>     C LABEL|A LABEL with relation <
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
+============================================================
+============================================================
+TEST 17: UNDECLARED HOOK + DEFAULT: B LABEL > C LABEL
+============================================================
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> Code chunks:
+>     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<UNDECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<UNDECLARED HOOK C CODE>}
+> Document-level (top-level) code:
+>     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     -> \TYPE {<NEXT-ONLY>}
+> Rules:
+>     C LABEL|A LABEL with relation <
+>     C LABEL|B LABEL with default relation <
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
+============================================================
+============================================================
+============================================================
+TEST 18: OTHER HOOK: declared
+============================================================
+============================================================
+TEST 19: Undeclared DECLARED HOOK
+============================================================
+-> The hook 'DECLARED HOOK':
+> The hook is empty.
+<recently read> }
+l. ...  {DECLARED HOOK}
+============================================================
+============================================================
+TEST 20: DECLARED HOOK + TOP LEVEL
+============================================================
+<DECLARED HOOK TOP-LEVEL>
+-> The hook 'DECLARED HOOK':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<DECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {DECLARED HOOK}
+============================================================
+============================================================
+TEST 21: DECLARED HOOK + A LABEL
+============================================================
+<DECLARED HOOK A CODE>
+<DECLARED HOOK TOP-LEVEL>
+-> The hook 'DECLARED HOOK':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED HOOK A CODE>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<DECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     A LABEL.
+<recently read> }
+l. ...  {DECLARED HOOK}
+============================================================
+============================================================
+TEST 22: DECLARED HOOK + B LABEL
+============================================================
+<DECLARED HOOK A CODE>
+<DECLARED HOOK B CODE>
+<DECLARED HOOK TOP-LEVEL>
+-> The hook 'DECLARED HOOK':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<DECLARED HOOK B CODE>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<DECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     A LABEL, B LABEL.
+<recently read> }
+l. ...  {DECLARED HOOK}
+============================================================
+============================================================
+TEST 23: DECLARED HOOK + C LABEL
+============================================================
+<DECLARED HOOK A CODE>
+<DECLARED HOOK C CODE>
+<DECLARED HOOK B CODE>
+<DECLARED HOOK TOP-LEVEL>
+-> The hook 'DECLARED HOOK':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<DECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<DECLARED HOOK C CODE>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<DECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     A LABEL, C LABEL, B LABEL.
+<recently read> }
+l. ...  {DECLARED HOOK}
+============================================================
+============================================================
+TEST 24: DECLARED HOOK + NEXT
+============================================================
+-> The hook 'DECLARED HOOK':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<DECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<DECLARED HOOK C CODE>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<DECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     -> \TYPE {<NEXT-ONLY>}
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     A LABEL, C LABEL, B LABEL.
+<recently read> }
+l. ...  {DECLARED HOOK}
+<DECLARED HOOK A CODE>
+<DECLARED HOOK C CODE>
+<DECLARED HOOK B CODE>
+<DECLARED HOOK TOP-LEVEL>
+<NEXT-ONLY>
+-> The hook 'DECLARED HOOK':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<DECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<DECLARED HOOK C CODE>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<DECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     A LABEL, C LABEL, B LABEL.
+<recently read> }
+l. ...  {DECLARED HOOK}
+============================================================
+============================================================
+TEST 25: DECLARED HOOK + C LABEL < A LABEL
+============================================================
+<DECLARED HOOK C CODE>
+<DECLARED HOOK A CODE>
+<DECLARED HOOK B CODE>
+<DECLARED HOOK TOP-LEVEL>
+-> The hook 'DECLARED HOOK':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<DECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<DECLARED HOOK C CODE>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<DECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|A LABEL with relation <
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     C LABEL, A LABEL, B LABEL.
+<recently read> }
+l. ...  {DECLARED HOOK}
+============================================================
+============================================================
+TEST 26: DECLARED HOOK + DEFAULT: B LABEL > C LABEL
+============================================================
+<DECLARED HOOK C CODE>
+<DECLARED HOOK A CODE>
+<DECLARED HOOK B CODE>
+<DECLARED HOOK TOP-LEVEL>
+-> The hook 'DECLARED HOOK':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<DECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<DECLARED HOOK C CODE>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<DECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|A LABEL with relation <
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     C LABEL, A LABEL, B LABEL.
+<recently read> }
+l. ...  {DECLARED HOOK}
+============================================================
+============================================================
+============================================================
+TEST 27: OTHER HOOK: declared reversed
+============================================================
+============================================================
+TEST 28: Undeclared DECLARED REVERSED
+============================================================
+-> The hook 'DECLARED REVERSED':
+> The hook is empty.
+<recently read> }
+l. ...  {DECLARED REVERSED}
+============================================================
+============================================================
+TEST 29: DECLARED REVERSED + TOP LEVEL
+============================================================
+<DECLARED REVERSED TOP-LEVEL>
+-> The hook 'DECLARED REVERSED':
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<DECLARED REVERSED TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     ---.
+<recently read> }
+l. ...  {DECLARED REVERSED}
+============================================================
+============================================================
+TEST 30: DECLARED REVERSED + A LABEL
+============================================================
+<DECLARED REVERSED TOP-LEVEL>
+<DECLARED REVERSED A CODE>
+-> The hook 'DECLARED REVERSED':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED REVERSED A CODE>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<DECLARED REVERSED TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     A LABEL.
+<recently read> }
+l. ...  {DECLARED REVERSED}
+============================================================
+============================================================
+TEST 31: DECLARED REVERSED + B LABEL
+============================================================
+<DECLARED REVERSED TOP-LEVEL>
+<DECLARED REVERSED B CODE>
+<DECLARED REVERSED A CODE>
+-> The hook 'DECLARED REVERSED':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED REVERSED A CODE>}
+>     B LABEL -> \TYPE {<DECLARED REVERSED B CODE>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<DECLARED REVERSED TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     B LABEL, A LABEL.
+<recently read> }
+l. ...  {DECLARED REVERSED}
+============================================================
+============================================================
+TEST 32: DECLARED REVERSED + C LABEL
+============================================================
+<DECLARED REVERSED TOP-LEVEL>
+<DECLARED REVERSED B CODE>
+<DECLARED REVERSED C CODE>
+<DECLARED REVERSED A CODE>
+-> The hook 'DECLARED REVERSED':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED REVERSED A CODE>}
+>     B LABEL -> \TYPE {<DECLARED REVERSED B CODE>}
+>     C LABEL -> \TYPE {<DECLARED REVERSED C CODE>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<DECLARED REVERSED TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {DECLARED REVERSED}
+============================================================
+============================================================
+TEST 33: DECLARED REVERSED + NEXT
+============================================================
+-> The hook 'DECLARED REVERSED':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED REVERSED A CODE>}
+>     B LABEL -> \TYPE {<DECLARED REVERSED B CODE>}
+>     C LABEL -> \TYPE {<DECLARED REVERSED C CODE>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<DECLARED REVERSED TOP-LEVEL>}
+> Extra code for next invocation:
+>     -> \TYPE {<NEXT-ONLY>}
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {DECLARED REVERSED}
+<DECLARED REVERSED TOP-LEVEL>
+<DECLARED REVERSED B CODE>
+<DECLARED REVERSED C CODE>
+<DECLARED REVERSED A CODE>
+<NEXT-ONLY>
+-> The hook 'DECLARED REVERSED':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED REVERSED A CODE>}
+>     B LABEL -> \TYPE {<DECLARED REVERSED B CODE>}
+>     C LABEL -> \TYPE {<DECLARED REVERSED C CODE>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<DECLARED REVERSED TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {DECLARED REVERSED}
+============================================================
+============================================================
+TEST 34: DECLARED REVERSED + C LABEL < A LABEL
+============================================================
+<DECLARED REVERSED TOP-LEVEL>
+<DECLARED REVERSED B CODE>
+<DECLARED REVERSED C CODE>
+<DECLARED REVERSED A CODE>
+-> The hook 'DECLARED REVERSED':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED REVERSED A CODE>}
+>     B LABEL -> \TYPE {<DECLARED REVERSED B CODE>}
+>     C LABEL -> \TYPE {<DECLARED REVERSED C CODE>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<DECLARED REVERSED TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|A LABEL with relation <
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {DECLARED REVERSED}
+============================================================
+============================================================
+TEST 35: DECLARED REVERSED + DEFAULT: B LABEL > C LABEL
+============================================================
+<DECLARED REVERSED TOP-LEVEL>
+<DECLARED REVERSED B CODE>
+<DECLARED REVERSED C CODE>
+<DECLARED REVERSED A CODE>
+-> The hook 'DECLARED REVERSED':
+> Code chunks:
+>     A LABEL -> \TYPE {<DECLARED REVERSED A CODE>}
+>     B LABEL -> \TYPE {<DECLARED REVERSED B CODE>}
+>     C LABEL -> \TYPE {<DECLARED REVERSED C CODE>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<DECLARED REVERSED TOP-LEVEL>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|A LABEL with relation <
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {DECLARED REVERSED}
+============================================================
+============================================================
+============================================================
+TEST 36: After \begin {document}
+============================================================
+============================================================
+TEST 37: Commands
+============================================================
+<cmdA BODY>
+============================================================
+<cmdB BODY>
+============================================================
+============================================================
+!!!! If this test changes the documentation needs updating !!!!

--- a/base/testfiles-lthooks/lthooks-show-2023-06-01.lvt
+++ b/base/testfiles-lthooks/lthooks-show-2023-06-01.lvt
@@ -1,0 +1,121 @@
+% Frozen to the 2023-06-01 release.
+
+\input{regression-test}
+\RequirePackage[2023-06-01]{latexrelease}
+\TYPE{********* RequirePackage[2023-06-01]{latexrelease}}
+\RequirePackage{./lthooks-show}
+
+\ExplSyntaxOn
+\debug_on:n { check-declarations , deprecation }
+\ExplSyntaxOff
+
+\documentclass{article}
+
+% There are many different hook profiles.
+
+\START
+
+\TESTBlockHookEnv
+  {Undefined environment envA}
+  {envA}
+\NewDocumentEnvironment
+  {envA}{}
+  {\TYPE{<BEGIN{envA}>}}
+  {\TYPE{<END{envA}>}}
+\begin{envA}\TYPE{<envA BODY>}\end{envA}
+
+\NewDocumentEnvironment
+  {envB}{}
+  {\TYPE{<BEGIN{envB}>}}
+  {\TYPE{<END{envB}>}}
+\TESTBlockHookEnv
+  {Defined environment envB}
+  {envB}
+\begin{envB}\TYPE{<envB BODY>}\end{envB}
+
+\TESTBlockHookCmd
+  {Undefined command with no arguments}
+  {cmdA}
+\NewDocumentCommand\cmdA{}{\TYPE{<cmdA BODY>}}
+\cmdA
+
+\NewDocumentCommand\cmdB{}{\TYPE{<cmdB BODY>}}
+\TESTBlockHookCmd
+  {Defined command with no arguments}
+  {cmdB}
+\cmdA
+
+\TESTBlockHookCmdWithArgs
+  {Undefined with two arguments}
+  {cmdTwoArgsA}
+  {2}
+\NewDocumentCommand\cmdTwoArgsA{mm}{\TYPE{<cmdTwoArgsA BODY: /#1/#2/>}}
+\cmdTwoArgsA{argA 1}{argA 2}
+
+\NewDocumentCommand\cmdTwoArgsB{mm}{\TYPE{<cmdTwoArgsB BODY: /#1/#2/>}}
+\TESTBlockHookCmdWithArgs
+  {Defined with two arguments}
+  {cmdTwoArgsB}
+  {2}
+\cmdTwoArgsB{argB 1}{argB 2}
+
+\TESTBlockHookCustomGeneric
+  {CUSTOM GENERIC HOOK}
+  {CUSTOM GENERIC HOOK}
+
+\TESTBlockHook
+  {OTHER HOOK: Undeclared}
+  {UNDECLARED HOOK}
+
+\NewHook{DECLARED HOOK}
+
+\TESTBlockHook
+  {OTHER HOOK: declared}
+  {DECLARED HOOK}
+
+\NewReversedHook{DECLARED REVERSED}
+
+\TESTBlockHook
+  {OTHER HOOK: declared reversed}
+  {DECLARED REVERSED}
+
+\NewHookWithArguments
+  {WITH TWO ARGUMENTS}
+  {2}
+
+\TESTBlockHookWithArgs
+  {OTHER HOOK: with two arguments}
+  {WITH TWO ARGUMENTS}
+  {2}
+
+\NewReversedHookWithArguments
+  {REVERSED WITH TWO ARGUMENTS}
+  {2}
+
+\TESTBlockHookWithArgs
+  {OTHER HOOK: reversed with two arguments}
+  {REVERSED WITH TWO ARGUMENTS}
+  {2}
+
+\OMIT
+\begin{document}
+\TIMO
+
+\BEGINTEST{After \begin{document}}
+
+  \BEGINTEST{Commands}
+    \cmdA
+    \SEPARATOR
+    \cmdB
+    \SEPARATOR
+    \cmdTwoArgsA{argA 1}{argA 2}
+    \SEPARATOR
+    \cmdTwoArgsB{argB 1}{argB 2}
+  \ENDTEST
+
+\ENDTEST
+
+
+\TYPE{!!!! If this test changes the documentation needs updating !!!!}
+
+\END

--- a/base/testfiles-lthooks/lthooks-show-2023-06-01.tlg
+++ b/base/testfiles-lthooks/lthooks-show-2023-06-01.tlg
@@ -179,7 +179,7 @@ l. ...  {cmdA}
 > The hook is empty.
 <recently read> }
 l. ...  {cmdA}
--> The generic hook 'cmd/cmdA/before':
+-> The generic hook 'cmd/cmdA/before' (unknown arguments):
 > Code chunks:
 >     ---
 > Document-level (top-level) code (executed last):
@@ -192,7 +192,7 @@ l. ...  {cmdA}
 >     ---.
 <recently read> }
 l. ...  {cmdA}
--> The generic hook 'cmd/cmdA/after':
+-> The generic hook 'cmd/cmdA/after' (unknown arguments):
 > Code chunks:
 >     ---
 > Document-level (top-level) code (executed first):
@@ -220,7 +220,7 @@ l. ...  {cmdB}
 > The hook is empty.
 <recently read> }
 l. ...  {cmdB}
--> The generic hook 'cmd/cmdB/before':
+-> The generic hook 'cmd/cmdB/before' (unknown arguments):
 > Code chunks:
 >     ---
 > Document-level (top-level) code (executed last):
@@ -233,7 +233,7 @@ l. ...  {cmdB}
 >     ---.
 <recently read> }
 l. ...  {cmdB}
--> The generic hook 'cmd/cmdB/after':
+-> The generic hook 'cmd/cmdB/after' (unknown arguments):
 > Code chunks:
 >     ---
 > Document-level (top-level) code (executed first):
@@ -247,12 +247,94 @@ l. ...  {cmdB}
 <recently read> }
 l. ...  {cmdB}
 ============================================================
-<cmdB BODY>
+<cmdA BODY>
 ============================================================
-TEST 5: Custom generic hook: CUSTOM GENERIC HOOK
+TEST 5: Command: Undefined with two arguments
+============================================================
+-> The generic hook 'cmd/cmdTwoArgsA/before':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {2}
+-> The generic hook 'cmd/cmdTwoArgsA/after':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {2}
+-> The generic hook 'cmd/cmdTwoArgsA/before' (unknown arguments):
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<cmdTwoArgsA BEFORE: /#1/#2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {2}
+-> The generic hook 'cmd/cmdTwoArgsA/after' (unknown arguments):
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<cmdTwoArgsA AFTER: /#1/#2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     ---.
+<recently read> }
+l. ...  {2}
+============================================================
+<cmdTwoArgsA BODY: /argA 1/argA 2/>
+============================================================
+TEST 6: Command: Defined with two arguments
+============================================================
+-> The generic hook 'cmd/cmdTwoArgsB/before':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {2}
+-> The generic hook 'cmd/cmdTwoArgsB/after':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {2}
+-> The generic hook 'cmd/cmdTwoArgsB/before' (unknown arguments):
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<cmdTwoArgsB BEFORE: /#1/#2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {2}
+-> The generic hook 'cmd/cmdTwoArgsB/after' (unknown arguments):
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<cmdTwoArgsB AFTER: /#1/#2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     ---.
+<recently read> }
+l. ...  {2}
+============================================================
+<cmdTwoArgsB BODY: /argB 1/argB 2/>
+============================================================
+TEST 7: Custom generic hook: CUSTOM GENERIC HOOK
 ============================================================
 ============================================================
-TEST 6: Raw: CUSTOM GENERIC HOOK
+TEST 8: Raw: CUSTOM GENERIC HOOK
 ============================================================
 -> The hook 'CUSTOM GENERIC HOOK':
 > The hook is not declared.
@@ -270,10 +352,29 @@ TEST 6: Raw: CUSTOM GENERIC HOOK
 l. ...  {CUSTOM GENERIC HOOK}
 ============================================================
 ============================================================
-TEST 7: Activated: CUSTOM GENERIC HOOK
+TEST 9: Activated: CUSTOM GENERIC HOOK
+============================================================
+<CUSTOM GENERIC HOOK CODE>
+-> The hook 'CUSTOM GENERIC HOOK':
+> Code chunks:
+>     LABEL -> \TYPE {<CUSTOM GENERIC HOOK CODE>}
+> Document-level (top-level) code (executed last):
+>     ---
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     LABEL.
+<recently read> }
+l. ...  {CUSTOM GENERIC HOOK}
+============================================================
+============================================================
+TEST 10: Disabled: CUSTOM GENERIC HOOK
 ============================================================
 -> The hook 'CUSTOM GENERIC HOOK':
 > The hook is not declared.
+> The hook is disabled.
 > Code chunks:
 >     LABEL -> \TYPE {<CUSTOM GENERIC HOOK CODE>}
 > Document-level (top-level) code:
@@ -283,34 +384,16 @@ TEST 7: Activated: CUSTOM GENERIC HOOK
 > Rules:
 >     ---
 > Execution order:
->     Not set because the hook is undeclared.
-<recently read> }
-l. ...  {CUSTOM GENERIC HOOK}
-============================================================
-============================================================
-TEST 8: Disabled: CUSTOM GENERIC HOOK
-============================================================
--> The hook 'CUSTOM GENERIC HOOK':
-> The hook is not declared.
-> Code chunks:
->     LABEL -> \TYPE {<CUSTOM GENERIC HOOK CODE>}
-> Document-level (top-level) code:
->     ---
-> Extra code for next invocation:
->     ---
-> Rules:
->     ---
-> Execution order:
->     Not set because the hook is undeclared.
+>     Not set because the hook is disabled.
 <recently read> }
 l. ...  {CUSTOM GENERIC HOOK}
 ============================================================
 ============================================================
 ============================================================
-TEST 9: OTHER HOOK: Undeclared
+TEST 11: OTHER HOOK: Undeclared
 ============================================================
 ============================================================
-TEST 10: Undeclared UNDECLARED HOOK
+TEST 12: Undeclared UNDECLARED HOOK
 ============================================================
 -> The hook 'UNDECLARED HOOK':
 > The hook is not declared.
@@ -319,7 +402,7 @@ TEST 10: Undeclared UNDECLARED HOOK
 l. ...  {UNDECLARED HOOK}
 ============================================================
 ============================================================
-TEST 11: UNDECLARED HOOK + TOP-LEVEL
+TEST 13: UNDECLARED HOOK + TOP-LEVEL
 ============================================================
 -> The hook 'UNDECLARED HOOK':
 > The hook is not declared.
@@ -337,31 +420,12 @@ TEST 11: UNDECLARED HOOK + TOP-LEVEL
 l. ...  {UNDECLARED HOOK}
 ============================================================
 ============================================================
-TEST 12: UNDECLARED HOOK + A LABEL
-============================================================
--> The hook 'UNDECLARED HOOK':
-> The hook is not declared.
-> Code chunks:
->     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
-> Document-level (top-level) code:
->     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
-> Extra code for next invocation:
->     ---
-> Rules:
->     ---
-> Execution order:
->     Not set because the hook is undeclared.
-<recently read> }
-l. ...  {UNDECLARED HOOK}
-============================================================
-============================================================
-TEST 13: UNDECLARED HOOK + B LABEL
+TEST 14: UNDECLARED HOOK + A LABEL
 ============================================================
 -> The hook 'UNDECLARED HOOK':
 > The hook is not declared.
 > Code chunks:
 >     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
->     B LABEL -> \TYPE {<UNDECLARED HOOK B CODE>}
 > Document-level (top-level) code:
 >     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
 > Extra code for next invocation:
@@ -374,14 +438,13 @@ TEST 13: UNDECLARED HOOK + B LABEL
 l. ...  {UNDECLARED HOOK}
 ============================================================
 ============================================================
-TEST 14: UNDECLARED HOOK + C LABEL
+TEST 15: UNDECLARED HOOK + B LABEL
 ============================================================
 -> The hook 'UNDECLARED HOOK':
 > The hook is not declared.
 > Code chunks:
 >     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
 >     B LABEL -> \TYPE {<UNDECLARED HOOK B CODE>}
->     C LABEL -> \TYPE {<UNDECLARED HOOK C CODE>}
 > Document-level (top-level) code:
 >     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
 > Extra code for next invocation:
@@ -394,7 +457,7 @@ TEST 14: UNDECLARED HOOK + C LABEL
 l. ...  {UNDECLARED HOOK}
 ============================================================
 ============================================================
-TEST 15: UNDECLARED HOOK + NEXT
+TEST 16: UNDECLARED HOOK + C LABEL
 ============================================================
 -> The hook 'UNDECLARED HOOK':
 > The hook is not declared.
@@ -405,13 +468,17 @@ TEST 15: UNDECLARED HOOK + NEXT
 > Document-level (top-level) code:
 >     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
 > Extra code for next invocation:
->     -> \TYPE {<NEXT-ONLY>}
+>     ---
 > Rules:
 >     ---
 > Execution order:
 >     Not set because the hook is undeclared.
 <recently read> }
 l. ...  {UNDECLARED HOOK}
+============================================================
+============================================================
+TEST 17: UNDECLARED HOOK + NEXT
+============================================================
 -> The hook 'UNDECLARED HOOK':
 > The hook is not declared.
 > Code chunks:
@@ -428,9 +495,25 @@ l. ...  {UNDECLARED HOOK}
 >     Not set because the hook is undeclared.
 <recently read> }
 l. ...  {UNDECLARED HOOK}
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> Code chunks:
+>     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<UNDECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<UNDECLARED HOOK C CODE>}
+> Document-level (top-level) code:
+>     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     -> \TYPE {<NEXT-ONLY>}
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
 ============================================================
 ============================================================
-TEST 16: UNDECLARED HOOK + C LABEL < A LABEL
+TEST 18: UNDECLARED HOOK + C LABEL < A LABEL
 ============================================================
 -> The hook 'UNDECLARED HOOK':
 > The hook is not declared.
@@ -450,7 +533,7 @@ TEST 16: UNDECLARED HOOK + C LABEL < A LABEL
 l. ...  {UNDECLARED HOOK}
 ============================================================
 ============================================================
-TEST 17: UNDECLARED HOOK + DEFAULT: B LABEL > C LABEL
+TEST 19: UNDECLARED HOOK + DEFAULT: B LABEL > C LABEL
 ============================================================
 -> The hook 'UNDECLARED HOOK':
 > The hook is not declared.
@@ -472,10 +555,10 @@ l. ...  {UNDECLARED HOOK}
 ============================================================
 ============================================================
 ============================================================
-TEST 18: OTHER HOOK: declared
+TEST 20: OTHER HOOK: declared
 ============================================================
 ============================================================
-TEST 19: Undeclared DECLARED HOOK
+TEST 21: Undeclared DECLARED HOOK
 ============================================================
 -> The hook 'DECLARED HOOK':
 > The hook is empty.
@@ -483,7 +566,7 @@ TEST 19: Undeclared DECLARED HOOK
 l. ...  {DECLARED HOOK}
 ============================================================
 ============================================================
-TEST 20: DECLARED HOOK + TOP-LEVEL
+TEST 22: DECLARED HOOK + TOP-LEVEL
 ============================================================
 <DECLARED HOOK TOP-LEVEL>
 -> The hook 'DECLARED HOOK':
@@ -501,7 +584,7 @@ TEST 20: DECLARED HOOK + TOP-LEVEL
 l. ...  {DECLARED HOOK}
 ============================================================
 ============================================================
-TEST 21: DECLARED HOOK + A LABEL
+TEST 23: DECLARED HOOK + A LABEL
 ============================================================
 <DECLARED HOOK A CODE>
 <DECLARED HOOK TOP-LEVEL>
@@ -520,7 +603,7 @@ TEST 21: DECLARED HOOK + A LABEL
 l. ...  {DECLARED HOOK}
 ============================================================
 ============================================================
-TEST 22: DECLARED HOOK + B LABEL
+TEST 24: DECLARED HOOK + B LABEL
 ============================================================
 <DECLARED HOOK A CODE>
 <DECLARED HOOK B CODE>
@@ -541,7 +624,7 @@ TEST 22: DECLARED HOOK + B LABEL
 l. ...  {DECLARED HOOK}
 ============================================================
 ============================================================
-TEST 23: DECLARED HOOK + C LABEL
+TEST 25: DECLARED HOOK + C LABEL
 ============================================================
 <DECLARED HOOK A CODE>
 <DECLARED HOOK C CODE>
@@ -564,7 +647,7 @@ TEST 23: DECLARED HOOK + C LABEL
 l. ...  {DECLARED HOOK}
 ============================================================
 ============================================================
-TEST 24: DECLARED HOOK + NEXT
+TEST 26: DECLARED HOOK + NEXT
 ============================================================
 -> The hook 'DECLARED HOOK':
 > Code chunks:
@@ -603,7 +686,7 @@ l. ...  {DECLARED HOOK}
 l. ...  {DECLARED HOOK}
 ============================================================
 ============================================================
-TEST 25: DECLARED HOOK + C LABEL < A LABEL
+TEST 27: DECLARED HOOK + C LABEL < A LABEL
 ============================================================
 <DECLARED HOOK C CODE>
 <DECLARED HOOK A CODE>
@@ -627,7 +710,7 @@ TEST 25: DECLARED HOOK + C LABEL < A LABEL
 l. ...  {DECLARED HOOK}
 ============================================================
 ============================================================
-TEST 26: DECLARED HOOK + DEFAULT: B LABEL > C LABEL
+TEST 28: DECLARED HOOK + DEFAULT: B LABEL > C LABEL
 ============================================================
 <DECLARED HOOK C CODE>
 <DECLARED HOOK A CODE>
@@ -652,10 +735,10 @@ l. ...  {DECLARED HOOK}
 ============================================================
 ============================================================
 ============================================================
-TEST 27: OTHER HOOK: declared reversed
+TEST 29: OTHER HOOK: declared reversed
 ============================================================
 ============================================================
-TEST 28: Undeclared DECLARED REVERSED
+TEST 30: Undeclared DECLARED REVERSED
 ============================================================
 -> The hook 'DECLARED REVERSED':
 > The hook is empty.
@@ -663,7 +746,7 @@ TEST 28: Undeclared DECLARED REVERSED
 l. ...  {DECLARED REVERSED}
 ============================================================
 ============================================================
-TEST 29: DECLARED REVERSED + TOP-LEVEL
+TEST 31: DECLARED REVERSED + TOP-LEVEL
 ============================================================
 <DECLARED REVERSED TOP-LEVEL>
 -> The hook 'DECLARED REVERSED':
@@ -681,7 +764,7 @@ TEST 29: DECLARED REVERSED + TOP-LEVEL
 l. ...  {DECLARED REVERSED}
 ============================================================
 ============================================================
-TEST 30: DECLARED REVERSED + A LABEL
+TEST 32: DECLARED REVERSED + A LABEL
 ============================================================
 <DECLARED REVERSED TOP-LEVEL>
 <DECLARED REVERSED A CODE>
@@ -700,7 +783,7 @@ TEST 30: DECLARED REVERSED + A LABEL
 l. ...  {DECLARED REVERSED}
 ============================================================
 ============================================================
-TEST 31: DECLARED REVERSED + B LABEL
+TEST 33: DECLARED REVERSED + B LABEL
 ============================================================
 <DECLARED REVERSED TOP-LEVEL>
 <DECLARED REVERSED B CODE>
@@ -721,7 +804,7 @@ TEST 31: DECLARED REVERSED + B LABEL
 l. ...  {DECLARED REVERSED}
 ============================================================
 ============================================================
-TEST 32: DECLARED REVERSED + C LABEL
+TEST 34: DECLARED REVERSED + C LABEL
 ============================================================
 <DECLARED REVERSED TOP-LEVEL>
 <DECLARED REVERSED B CODE>
@@ -744,7 +827,7 @@ TEST 32: DECLARED REVERSED + C LABEL
 l. ...  {DECLARED REVERSED}
 ============================================================
 ============================================================
-TEST 33: DECLARED REVERSED + NEXT
+TEST 35: DECLARED REVERSED + NEXT
 ============================================================
 -> The hook 'DECLARED REVERSED':
 > Code chunks:
@@ -783,7 +866,7 @@ l. ...  {DECLARED REVERSED}
 l. ...  {DECLARED REVERSED}
 ============================================================
 ============================================================
-TEST 34: DECLARED REVERSED + C LABEL < A LABEL
+TEST 36: DECLARED REVERSED + C LABEL < A LABEL
 ============================================================
 <DECLARED REVERSED TOP-LEVEL>
 <DECLARED REVERSED B CODE>
@@ -807,7 +890,7 @@ TEST 34: DECLARED REVERSED + C LABEL < A LABEL
 l. ...  {DECLARED REVERSED}
 ============================================================
 ============================================================
-TEST 35: DECLARED REVERSED + DEFAULT: B LABEL > C LABEL
+TEST 37: DECLARED REVERSED + DEFAULT: B LABEL > C LABEL
 ============================================================
 <DECLARED REVERSED TOP-LEVEL>
 <DECLARED REVERSED B CODE>
@@ -832,14 +915,402 @@ l. ...  {DECLARED REVERSED}
 ============================================================
 ============================================================
 ============================================================
-TEST 36: After \begin {document}
+TEST 38: OTHER HOOK: with two arguments
 ============================================================
 ============================================================
-TEST 37: Commands
+TEST 39: Undeclared WITH TWO ARGUMENTS
 ============================================================
+\UseHookWithArguments{WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+-> The hook 'WITH TWO ARGUMENTS' (2 arguments):
+> The hook is empty.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 40: WITH TWO ARGUMENTS + TOP-LEVEL
+============================================================
+\UseHookWithArguments{WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+-> The hook 'WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 41: WITH TWO ARGUMENTS + A LABEL
+============================================================
+\UseHookWithArguments{WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+-> The hook 'WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     A LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 42: WITH TWO ARGUMENTS + B LABEL
+============================================================
+\UseHookWithArguments{WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+-> The hook 'WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     A LABEL, B LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 43: WITH TWO ARGUMENTS + C LABEL
+============================================================
+\UseHookWithArguments{WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS C CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+-> The hook 'WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     A LABEL, C LABEL, B LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 44: WITH TWO ARGUMENTS + NEXT
+============================================================
+-> The hook 'WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     -> \TYPE {<WITH TWO ARGUMENTS NEXT-ONLY CODE: /arg #1/arg #2/>}
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     A LABEL, C LABEL, B LABEL.
+<recently read> }
+l. ...  {2}
+\UseHookWithArguments{WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS C CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS NEXT-ONLY CODE: /arg arg_1/arg arg_2/>
+-> The hook 'WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     A LABEL, C LABEL, B LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 45: WITH TWO ARGUMENTS + C LABEL < A LABEL
+============================================================
+\UseHookWithArguments{WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<WITH TWO ARGUMENTS C CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+-> The hook 'WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|A LABEL with relation <
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     C LABEL, A LABEL, B LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 46: WITH TWO ARGUMENTS + DEFAULT: B LABEL > C LABEL
+============================================================
+\UseHookWithArguments{WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<WITH TWO ARGUMENTS C CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+-> The hook 'WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|A LABEL with relation <
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     C LABEL, A LABEL, B LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+============================================================
+TEST 47: OTHER HOOK: reversed with two arguments
+============================================================
+============================================================
+TEST 48: Undeclared REVERSED WITH TWO ARGUMENTS
+============================================================
+\UseHookWithArguments{REVERSED WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+-> The hook 'REVERSED WITH TWO ARGUMENTS' (2 arguments):
+> The hook is empty.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 49: REVERSED WITH TWO ARGUMENTS + TOP-LEVEL
+============================================================
+\UseHookWithArguments{REVERSED WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+-> The hook 'REVERSED WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     ---.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 50: REVERSED WITH TWO ARGUMENTS + A LABEL
+============================================================
+\UseHookWithArguments{REVERSED WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+-> The hook 'REVERSED WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     A LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 51: REVERSED WITH TWO ARGUMENTS + B LABEL
+============================================================
+\UseHookWithArguments{REVERSED WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+-> The hook 'REVERSED WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     B LABEL, A LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 52: REVERSED WITH TWO ARGUMENTS + C LABEL
+============================================================
+\UseHookWithArguments{REVERSED WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS C CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+-> The hook 'REVERSED WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 53: REVERSED WITH TWO ARGUMENTS + NEXT
+============================================================
+-> The hook 'REVERSED WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     -> \TYPE {<REVERSED WITH TWO ARGUMENTS NEXT-ONLY CODE: /arg #1/arg #2/>}
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {2}
+\UseHookWithArguments{REVERSED WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS C CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS NEXT-ONLY CODE: /arg arg_1/arg arg_2/>
+-> The hook 'REVERSED WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 54: REVERSED WITH TWO ARGUMENTS + C LABEL < A LABEL
+============================================================
+\UseHookWithArguments{REVERSED WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS C CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+-> The hook 'REVERSED WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|A LABEL with relation <
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 55: REVERSED WITH TWO ARGUMENTS + DEFAULT: B LABEL > C LABEL
+============================================================
+\UseHookWithArguments{REVERSED WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS C CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+-> The hook 'REVERSED WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|A LABEL with relation <
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+============================================================
+TEST 56: After \begin {document}
+============================================================
+============================================================
+TEST 57: Commands
+============================================================
+<cmdA BEFORE>
 <cmdA BODY>
+<cmdA AFTER>
 ============================================================
+<cmdB BEFORE>
 <cmdB BODY>
+<cmdB AFTER>
+============================================================
+<cmdTwoArgsA BEFORE: /argA 1/argA 2/>
+<cmdTwoArgsA BODY: /argA 1/argA 2/>
+<cmdTwoArgsA AFTER: /argA 1/argA 2/>
+============================================================
+<cmdTwoArgsB BEFORE: /argB 1/argB 2/>
+<cmdTwoArgsB BODY: /argB 1/argB 2/>
+<cmdTwoArgsB AFTER: /argB 1/argB 2/>
 ============================================================
 ============================================================
 !!!! If this test changes the documentation needs updating !!!!

--- a/base/testfiles-lthooks/lthooks-show.lvt
+++ b/base/testfiles-lthooks/lthooks-show.lvt
@@ -1,0 +1,121 @@
+% This corresponds to the latest release.
+% Other `lthooks-show_????-??-??.lvt` files are frozen to
+% the ????-??-?? release.
+
+\input{regression-test}
+\RequirePackage{./lthooks-show}
+
+\ExplSyntaxOn
+\debug_on:n { check-declarations , deprecation }
+\ExplSyntaxOff
+
+\documentclass{article}
+
+% There are many different hook profiles.
+
+\START
+
+\TESTBlockHookEnv
+  {Undefined environment envA}
+  {envA}
+\NewDocumentEnvironment
+  {envA}{}
+  {\TYPE{<BEGIN{envA}>}}
+  {\TYPE{<END{envA}>}}
+\begin{envA}\TYPE{<envA BODY>}\end{envA}
+
+\NewDocumentEnvironment
+  {envB}{}
+  {\TYPE{<BEGIN{envB}>}}
+  {\TYPE{<END{envB}>}}
+\TESTBlockHookEnv
+  {Defined environment envB}
+  {envB}
+\begin{envB}\TYPE{<envB BODY>}\end{envB}
+
+\TESTBlockHookCmd
+  {Undefined command with no arguments}
+  {cmdA}
+\NewDocumentCommand\cmdA{}{\TYPE{<cmdA BODY>}}
+\cmdA
+
+\NewDocumentCommand\cmdB{}{\TYPE{<cmdB BODY>}}
+\TESTBlockHookCmd
+  {Defined command with no arguments}
+  {cmdB}
+\cmdA
+
+\TESTBlockHookCmdWithArgs
+  {Undefined with two arguments}
+  {cmdTwoArgsA}
+  {2}
+\NewDocumentCommand\cmdTwoArgsA{mm}{\TYPE{<cmdTwoArgsA BODY: /#1/#2/>}}
+\cmdTwoArgsA{argA 1}{argA 2}
+
+\NewDocumentCommand\cmdTwoArgsB{mm}{\TYPE{<cmdTwoArgsB BODY: /#1/#2/>}}
+\TESTBlockHookCmdWithArgs
+  {Defined with two arguments}
+  {cmdTwoArgsB}
+  {2}
+\cmdTwoArgsB{argB 1}{argB 2}
+
+\TESTBlockHookCustomGeneric
+  {CUSTOM GENERIC HOOK}
+  {CUSTOM GENERIC HOOK}
+
+\TESTBlockHook
+  {OTHER HOOK: Undeclared}
+  {UNDECLARED HOOK}
+
+\NewHook{DECLARED HOOK}
+
+\TESTBlockHook
+  {OTHER HOOK: declared}
+  {DECLARED HOOK}
+
+\NewReversedHook{DECLARED REVERSED}
+
+\TESTBlockHook
+  {OTHER HOOK: declared reversed}
+  {DECLARED REVERSED}
+
+\NewHookWithArguments
+  {WITH TWO ARGUMENTS}
+  {2}
+
+\TESTBlockHookWithArgs
+  {OTHER HOOK: with two arguments}
+  {WITH TWO ARGUMENTS}
+  {2}
+
+\NewReversedHookWithArguments
+  {REVERSED WITH TWO ARGUMENTS}
+  {2}
+
+\TESTBlockHookWithArgs
+  {OTHER HOOK: reversed with two arguments}
+  {REVERSED WITH TWO ARGUMENTS}
+  {2}
+
+\OMIT
+\begin{document}
+\TIMO
+
+\BEGINTEST{After \begin{document}}
+
+  \BEGINTEST{Commands}
+    \cmdA
+    \SEPARATOR
+    \cmdB
+    \SEPARATOR
+    \cmdTwoArgsA{argA 1}{argA 2}
+    \SEPARATOR
+    \cmdTwoArgsB{argB 1}{argB 2}
+  \ENDTEST
+
+\ENDTEST
+
+
+\TYPE{!!!! If this test changes the documentation needs updating !!!!}
+
+\END

--- a/base/testfiles-lthooks/lthooks-show.tlg
+++ b/base/testfiles-lthooks/lthooks-show.tlg
@@ -179,7 +179,7 @@ l. ...  {cmdA}
 > The hook is empty.
 <recently read> }
 l. ...  {cmdA}
--> The generic hook 'cmd/cmdA/before':
+-> The generic hook 'cmd/cmdA/before' (unknown arguments):
 > Code chunks:
 >     ---
 > Document-level (top-level) code (executed last):
@@ -192,7 +192,7 @@ l. ...  {cmdA}
 >     ---.
 <recently read> }
 l. ...  {cmdA}
--> The generic hook 'cmd/cmdA/after':
+-> The generic hook 'cmd/cmdA/after' (unknown arguments):
 > Code chunks:
 >     ---
 > Document-level (top-level) code (executed first):
@@ -220,7 +220,7 @@ l. ...  {cmdB}
 > The hook is empty.
 <recently read> }
 l. ...  {cmdB}
--> The generic hook 'cmd/cmdB/before':
+-> The generic hook 'cmd/cmdB/before' (unknown arguments):
 > Code chunks:
 >     ---
 > Document-level (top-level) code (executed last):
@@ -233,7 +233,7 @@ l. ...  {cmdB}
 >     ---.
 <recently read> }
 l. ...  {cmdB}
--> The generic hook 'cmd/cmdB/after':
+-> The generic hook 'cmd/cmdB/after' (unknown arguments):
 > Code chunks:
 >     ---
 > Document-level (top-level) code (executed first):
@@ -247,12 +247,94 @@ l. ...  {cmdB}
 <recently read> }
 l. ...  {cmdB}
 ============================================================
-<cmdB BODY>
+<cmdA BODY>
 ============================================================
-TEST 5: Custom generic hook: CUSTOM GENERIC HOOK
+TEST 5: Command: Undefined with two arguments
+============================================================
+-> The generic hook 'cmd/cmdTwoArgsA/before':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {2}
+-> The generic hook 'cmd/cmdTwoArgsA/after':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {2}
+-> The generic hook 'cmd/cmdTwoArgsA/before' (unknown arguments):
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<cmdTwoArgsA BEFORE: /#1/#2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {2}
+-> The generic hook 'cmd/cmdTwoArgsA/after' (unknown arguments):
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<cmdTwoArgsA AFTER: /#1/#2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     ---.
+<recently read> }
+l. ...  {2}
+============================================================
+<cmdTwoArgsA BODY: /argA 1/argA 2/>
+============================================================
+TEST 6: Command: Defined with two arguments
+============================================================
+-> The generic hook 'cmd/cmdTwoArgsB/before':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {2}
+-> The generic hook 'cmd/cmdTwoArgsB/after':
+> The hook is not declared.
+> The hook is empty.
+<recently read> }
+l. ...  {2}
+-> The generic hook 'cmd/cmdTwoArgsB/before' (unknown arguments):
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<cmdTwoArgsB BEFORE: /#1/#2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {2}
+-> The generic hook 'cmd/cmdTwoArgsB/after' (unknown arguments):
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<cmdTwoArgsB AFTER: /#1/#2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     ---.
+<recently read> }
+l. ...  {2}
+============================================================
+<cmdTwoArgsB BODY: /argB 1/argB 2/>
+============================================================
+TEST 7: Custom generic hook: CUSTOM GENERIC HOOK
 ============================================================
 ============================================================
-TEST 6: Raw: CUSTOM GENERIC HOOK
+TEST 8: Raw: CUSTOM GENERIC HOOK
 ============================================================
 -> The hook 'CUSTOM GENERIC HOOK':
 > The hook is not declared.
@@ -270,10 +352,29 @@ TEST 6: Raw: CUSTOM GENERIC HOOK
 l. ...  {CUSTOM GENERIC HOOK}
 ============================================================
 ============================================================
-TEST 7: Activated: CUSTOM GENERIC HOOK
+TEST 9: Activated: CUSTOM GENERIC HOOK
+============================================================
+<CUSTOM GENERIC HOOK CODE>
+-> The hook 'CUSTOM GENERIC HOOK':
+> Code chunks:
+>     LABEL -> \TYPE {<CUSTOM GENERIC HOOK CODE>}
+> Document-level (top-level) code (executed last):
+>     ---
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     LABEL.
+<recently read> }
+l. ...  {CUSTOM GENERIC HOOK}
+============================================================
+============================================================
+TEST 10: Disabled: CUSTOM GENERIC HOOK
 ============================================================
 -> The hook 'CUSTOM GENERIC HOOK':
 > The hook is not declared.
+> The hook is disabled.
 > Code chunks:
 >     LABEL -> \TYPE {<CUSTOM GENERIC HOOK CODE>}
 > Document-level (top-level) code:
@@ -283,34 +384,16 @@ TEST 7: Activated: CUSTOM GENERIC HOOK
 > Rules:
 >     ---
 > Execution order:
->     Not set because the hook is undeclared.
-<recently read> }
-l. ...  {CUSTOM GENERIC HOOK}
-============================================================
-============================================================
-TEST 8: Disabled: CUSTOM GENERIC HOOK
-============================================================
--> The hook 'CUSTOM GENERIC HOOK':
-> The hook is not declared.
-> Code chunks:
->     LABEL -> \TYPE {<CUSTOM GENERIC HOOK CODE>}
-> Document-level (top-level) code:
->     ---
-> Extra code for next invocation:
->     ---
-> Rules:
->     ---
-> Execution order:
->     Not set because the hook is undeclared.
+>     Not set because the hook is disabled.
 <recently read> }
 l. ...  {CUSTOM GENERIC HOOK}
 ============================================================
 ============================================================
 ============================================================
-TEST 9: OTHER HOOK: Undeclared
+TEST 11: OTHER HOOK: Undeclared
 ============================================================
 ============================================================
-TEST 10: Undeclared UNDECLARED HOOK
+TEST 12: Undeclared UNDECLARED HOOK
 ============================================================
 -> The hook 'UNDECLARED HOOK':
 > The hook is not declared.
@@ -319,7 +402,7 @@ TEST 10: Undeclared UNDECLARED HOOK
 l. ...  {UNDECLARED HOOK}
 ============================================================
 ============================================================
-TEST 11: UNDECLARED HOOK + TOP-LEVEL
+TEST 13: UNDECLARED HOOK + TOP-LEVEL
 ============================================================
 -> The hook 'UNDECLARED HOOK':
 > The hook is not declared.
@@ -337,31 +420,12 @@ TEST 11: UNDECLARED HOOK + TOP-LEVEL
 l. ...  {UNDECLARED HOOK}
 ============================================================
 ============================================================
-TEST 12: UNDECLARED HOOK + A LABEL
-============================================================
--> The hook 'UNDECLARED HOOK':
-> The hook is not declared.
-> Code chunks:
->     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
-> Document-level (top-level) code:
->     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
-> Extra code for next invocation:
->     ---
-> Rules:
->     ---
-> Execution order:
->     Not set because the hook is undeclared.
-<recently read> }
-l. ...  {UNDECLARED HOOK}
-============================================================
-============================================================
-TEST 13: UNDECLARED HOOK + B LABEL
+TEST 14: UNDECLARED HOOK + A LABEL
 ============================================================
 -> The hook 'UNDECLARED HOOK':
 > The hook is not declared.
 > Code chunks:
 >     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
->     B LABEL -> \TYPE {<UNDECLARED HOOK B CODE>}
 > Document-level (top-level) code:
 >     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
 > Extra code for next invocation:
@@ -374,14 +438,13 @@ TEST 13: UNDECLARED HOOK + B LABEL
 l. ...  {UNDECLARED HOOK}
 ============================================================
 ============================================================
-TEST 14: UNDECLARED HOOK + C LABEL
+TEST 15: UNDECLARED HOOK + B LABEL
 ============================================================
 -> The hook 'UNDECLARED HOOK':
 > The hook is not declared.
 > Code chunks:
 >     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
 >     B LABEL -> \TYPE {<UNDECLARED HOOK B CODE>}
->     C LABEL -> \TYPE {<UNDECLARED HOOK C CODE>}
 > Document-level (top-level) code:
 >     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
 > Extra code for next invocation:
@@ -394,7 +457,7 @@ TEST 14: UNDECLARED HOOK + C LABEL
 l. ...  {UNDECLARED HOOK}
 ============================================================
 ============================================================
-TEST 15: UNDECLARED HOOK + NEXT
+TEST 16: UNDECLARED HOOK + C LABEL
 ============================================================
 -> The hook 'UNDECLARED HOOK':
 > The hook is not declared.
@@ -405,13 +468,17 @@ TEST 15: UNDECLARED HOOK + NEXT
 > Document-level (top-level) code:
 >     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
 > Extra code for next invocation:
->     -> \TYPE {<NEXT-ONLY>}
+>     ---
 > Rules:
 >     ---
 > Execution order:
 >     Not set because the hook is undeclared.
 <recently read> }
 l. ...  {UNDECLARED HOOK}
+============================================================
+============================================================
+TEST 17: UNDECLARED HOOK + NEXT
+============================================================
 -> The hook 'UNDECLARED HOOK':
 > The hook is not declared.
 > Code chunks:
@@ -428,9 +495,25 @@ l. ...  {UNDECLARED HOOK}
 >     Not set because the hook is undeclared.
 <recently read> }
 l. ...  {UNDECLARED HOOK}
+-> The hook 'UNDECLARED HOOK':
+> The hook is not declared.
+> Code chunks:
+>     A LABEL -> \TYPE {<UNDECLARED HOOK A CODE>}
+>     B LABEL -> \TYPE {<UNDECLARED HOOK B CODE>}
+>     C LABEL -> \TYPE {<UNDECLARED HOOK C CODE>}
+> Document-level (top-level) code:
+>     -> \TYPE {<UNDECLARED HOOK TOP-LEVEL>}
+> Extra code for next invocation:
+>     -> \TYPE {<NEXT-ONLY>}
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...  {UNDECLARED HOOK}
 ============================================================
 ============================================================
-TEST 16: UNDECLARED HOOK + C LABEL < A LABEL
+TEST 18: UNDECLARED HOOK + C LABEL < A LABEL
 ============================================================
 -> The hook 'UNDECLARED HOOK':
 > The hook is not declared.
@@ -450,7 +533,7 @@ TEST 16: UNDECLARED HOOK + C LABEL < A LABEL
 l. ...  {UNDECLARED HOOK}
 ============================================================
 ============================================================
-TEST 17: UNDECLARED HOOK + DEFAULT: B LABEL > C LABEL
+TEST 19: UNDECLARED HOOK + DEFAULT: B LABEL > C LABEL
 ============================================================
 -> The hook 'UNDECLARED HOOK':
 > The hook is not declared.
@@ -472,10 +555,10 @@ l. ...  {UNDECLARED HOOK}
 ============================================================
 ============================================================
 ============================================================
-TEST 18: OTHER HOOK: declared
+TEST 20: OTHER HOOK: declared
 ============================================================
 ============================================================
-TEST 19: Undeclared DECLARED HOOK
+TEST 21: Undeclared DECLARED HOOK
 ============================================================
 -> The hook 'DECLARED HOOK':
 > The hook is empty.
@@ -483,7 +566,7 @@ TEST 19: Undeclared DECLARED HOOK
 l. ...  {DECLARED HOOK}
 ============================================================
 ============================================================
-TEST 20: DECLARED HOOK + TOP-LEVEL
+TEST 22: DECLARED HOOK + TOP-LEVEL
 ============================================================
 <DECLARED HOOK TOP-LEVEL>
 -> The hook 'DECLARED HOOK':
@@ -501,7 +584,7 @@ TEST 20: DECLARED HOOK + TOP-LEVEL
 l. ...  {DECLARED HOOK}
 ============================================================
 ============================================================
-TEST 21: DECLARED HOOK + A LABEL
+TEST 23: DECLARED HOOK + A LABEL
 ============================================================
 <DECLARED HOOK A CODE>
 <DECLARED HOOK TOP-LEVEL>
@@ -520,7 +603,7 @@ TEST 21: DECLARED HOOK + A LABEL
 l. ...  {DECLARED HOOK}
 ============================================================
 ============================================================
-TEST 22: DECLARED HOOK + B LABEL
+TEST 24: DECLARED HOOK + B LABEL
 ============================================================
 <DECLARED HOOK A CODE>
 <DECLARED HOOK B CODE>
@@ -541,7 +624,7 @@ TEST 22: DECLARED HOOK + B LABEL
 l. ...  {DECLARED HOOK}
 ============================================================
 ============================================================
-TEST 23: DECLARED HOOK + C LABEL
+TEST 25: DECLARED HOOK + C LABEL
 ============================================================
 <DECLARED HOOK A CODE>
 <DECLARED HOOK C CODE>
@@ -564,7 +647,7 @@ TEST 23: DECLARED HOOK + C LABEL
 l. ...  {DECLARED HOOK}
 ============================================================
 ============================================================
-TEST 24: DECLARED HOOK + NEXT
+TEST 26: DECLARED HOOK + NEXT
 ============================================================
 -> The hook 'DECLARED HOOK':
 > Code chunks:
@@ -603,7 +686,7 @@ l. ...  {DECLARED HOOK}
 l. ...  {DECLARED HOOK}
 ============================================================
 ============================================================
-TEST 25: DECLARED HOOK + C LABEL < A LABEL
+TEST 27: DECLARED HOOK + C LABEL < A LABEL
 ============================================================
 <DECLARED HOOK C CODE>
 <DECLARED HOOK A CODE>
@@ -627,7 +710,7 @@ TEST 25: DECLARED HOOK + C LABEL < A LABEL
 l. ...  {DECLARED HOOK}
 ============================================================
 ============================================================
-TEST 26: DECLARED HOOK + DEFAULT: B LABEL > C LABEL
+TEST 28: DECLARED HOOK + DEFAULT: B LABEL > C LABEL
 ============================================================
 <DECLARED HOOK C CODE>
 <DECLARED HOOK A CODE>
@@ -652,10 +735,10 @@ l. ...  {DECLARED HOOK}
 ============================================================
 ============================================================
 ============================================================
-TEST 27: OTHER HOOK: declared reversed
+TEST 29: OTHER HOOK: declared reversed
 ============================================================
 ============================================================
-TEST 28: Undeclared DECLARED REVERSED
+TEST 30: Undeclared DECLARED REVERSED
 ============================================================
 -> The hook 'DECLARED REVERSED':
 > The hook is empty.
@@ -663,7 +746,7 @@ TEST 28: Undeclared DECLARED REVERSED
 l. ...  {DECLARED REVERSED}
 ============================================================
 ============================================================
-TEST 29: DECLARED REVERSED + TOP-LEVEL
+TEST 31: DECLARED REVERSED + TOP-LEVEL
 ============================================================
 <DECLARED REVERSED TOP-LEVEL>
 -> The hook 'DECLARED REVERSED':
@@ -681,7 +764,7 @@ TEST 29: DECLARED REVERSED + TOP-LEVEL
 l. ...  {DECLARED REVERSED}
 ============================================================
 ============================================================
-TEST 30: DECLARED REVERSED + A LABEL
+TEST 32: DECLARED REVERSED + A LABEL
 ============================================================
 <DECLARED REVERSED TOP-LEVEL>
 <DECLARED REVERSED A CODE>
@@ -700,7 +783,7 @@ TEST 30: DECLARED REVERSED + A LABEL
 l. ...  {DECLARED REVERSED}
 ============================================================
 ============================================================
-TEST 31: DECLARED REVERSED + B LABEL
+TEST 33: DECLARED REVERSED + B LABEL
 ============================================================
 <DECLARED REVERSED TOP-LEVEL>
 <DECLARED REVERSED B CODE>
@@ -721,7 +804,7 @@ TEST 31: DECLARED REVERSED + B LABEL
 l. ...  {DECLARED REVERSED}
 ============================================================
 ============================================================
-TEST 32: DECLARED REVERSED + C LABEL
+TEST 34: DECLARED REVERSED + C LABEL
 ============================================================
 <DECLARED REVERSED TOP-LEVEL>
 <DECLARED REVERSED B CODE>
@@ -744,7 +827,7 @@ TEST 32: DECLARED REVERSED + C LABEL
 l. ...  {DECLARED REVERSED}
 ============================================================
 ============================================================
-TEST 33: DECLARED REVERSED + NEXT
+TEST 35: DECLARED REVERSED + NEXT
 ============================================================
 -> The hook 'DECLARED REVERSED':
 > Code chunks:
@@ -783,7 +866,7 @@ l. ...  {DECLARED REVERSED}
 l. ...  {DECLARED REVERSED}
 ============================================================
 ============================================================
-TEST 34: DECLARED REVERSED + C LABEL < A LABEL
+TEST 36: DECLARED REVERSED + C LABEL < A LABEL
 ============================================================
 <DECLARED REVERSED TOP-LEVEL>
 <DECLARED REVERSED B CODE>
@@ -807,7 +890,7 @@ TEST 34: DECLARED REVERSED + C LABEL < A LABEL
 l. ...  {DECLARED REVERSED}
 ============================================================
 ============================================================
-TEST 35: DECLARED REVERSED + DEFAULT: B LABEL > C LABEL
+TEST 37: DECLARED REVERSED + DEFAULT: B LABEL > C LABEL
 ============================================================
 <DECLARED REVERSED TOP-LEVEL>
 <DECLARED REVERSED B CODE>
@@ -832,14 +915,402 @@ l. ...  {DECLARED REVERSED}
 ============================================================
 ============================================================
 ============================================================
-TEST 36: After \begin {document}
+TEST 38: OTHER HOOK: with two arguments
 ============================================================
 ============================================================
-TEST 37: Commands
+TEST 39: Undeclared WITH TWO ARGUMENTS
 ============================================================
+\UseHookWithArguments{WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+-> The hook 'WITH TWO ARGUMENTS' (2 arguments):
+> The hook is empty.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 40: WITH TWO ARGUMENTS + TOP-LEVEL
+============================================================
+\UseHookWithArguments{WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+-> The hook 'WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     ---.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 41: WITH TWO ARGUMENTS + A LABEL
+============================================================
+\UseHookWithArguments{WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+-> The hook 'WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     A LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 42: WITH TWO ARGUMENTS + B LABEL
+============================================================
+\UseHookWithArguments{WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+-> The hook 'WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order:
+>     A LABEL, B LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 43: WITH TWO ARGUMENTS + C LABEL
+============================================================
+\UseHookWithArguments{WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS C CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+-> The hook 'WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     A LABEL, C LABEL, B LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 44: WITH TWO ARGUMENTS + NEXT
+============================================================
+-> The hook 'WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     -> \TYPE {<WITH TWO ARGUMENTS NEXT-ONLY CODE: /arg #1/arg #2/>}
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     A LABEL, C LABEL, B LABEL.
+<recently read> }
+l. ...  {2}
+\UseHookWithArguments{WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS C CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS NEXT-ONLY CODE: /arg arg_1/arg arg_2/>
+-> The hook 'WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     A LABEL, C LABEL, B LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 45: WITH TWO ARGUMENTS + C LABEL < A LABEL
+============================================================
+\UseHookWithArguments{WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<WITH TWO ARGUMENTS C CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+-> The hook 'WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|A LABEL with relation <
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     C LABEL, A LABEL, B LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 46: WITH TWO ARGUMENTS + DEFAULT: B LABEL > C LABEL
+============================================================
+\UseHookWithArguments{WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<WITH TWO ARGUMENTS C CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+-> The hook 'WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed last):
+>     -> \TYPE {<WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|A LABEL with relation <
+>     C LABEL|B LABEL with default relation <
+> Execution order (after applying rules):
+>     C LABEL, A LABEL, B LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+============================================================
+TEST 47: OTHER HOOK: reversed with two arguments
+============================================================
+============================================================
+TEST 48: Undeclared REVERSED WITH TWO ARGUMENTS
+============================================================
+\UseHookWithArguments{REVERSED WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+-> The hook 'REVERSED WITH TWO ARGUMENTS' (2 arguments):
+> The hook is empty.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 49: REVERSED WITH TWO ARGUMENTS + TOP-LEVEL
+============================================================
+\UseHookWithArguments{REVERSED WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+-> The hook 'REVERSED WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     ---
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     ---.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 50: REVERSED WITH TWO ARGUMENTS + A LABEL
+============================================================
+\UseHookWithArguments{REVERSED WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+-> The hook 'REVERSED WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     A LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 51: REVERSED WITH TWO ARGUMENTS + B LABEL
+============================================================
+\UseHookWithArguments{REVERSED WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+-> The hook 'REVERSED WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     ---
+> Execution order (after reversal):
+>     B LABEL, A LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 52: REVERSED WITH TWO ARGUMENTS + C LABEL
+============================================================
+\UseHookWithArguments{REVERSED WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS C CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+-> The hook 'REVERSED WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 53: REVERSED WITH TWO ARGUMENTS + NEXT
+============================================================
+-> The hook 'REVERSED WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     -> \TYPE {<REVERSED WITH TWO ARGUMENTS NEXT-ONLY CODE: /arg #1/arg #2/>}
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {2}
+\UseHookWithArguments{REVERSED WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS C CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS NEXT-ONLY CODE: /arg arg_1/arg arg_2/>
+-> The hook 'REVERSED WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 54: REVERSED WITH TWO ARGUMENTS + C LABEL < A LABEL
+============================================================
+\UseHookWithArguments{REVERSED WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS C CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+-> The hook 'REVERSED WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|A LABEL with relation <
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+TEST 55: REVERSED WITH TWO ARGUMENTS + DEFAULT: B LABEL > C LABEL
+============================================================
+\UseHookWithArguments{REVERSED WITH TWO ARGUMENTS}{2}{arg_1}{arg_2}=>
+<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS B CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS C CODE: /arg arg_1/arg arg_2/>
+<REVERSED WITH TWO ARGUMENTS A CODE: /arg arg_1/arg arg_2/>
+-> The hook 'REVERSED WITH TWO ARGUMENTS' (2 arguments):
+> Code chunks:
+>     A LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS A CODE: /arg #1/arg #2/>}
+>     B LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS B CODE: /arg #1/arg #2/>}
+>     C LABEL -> \TYPE {<REVERSED WITH TWO ARGUMENTS C CODE: /arg #1/arg #2/>}
+> Document-level (top-level) code (executed first):
+>     -> \TYPE {<REVERSED WITH TWO ARGUMENTS TOP-LEVEL: /arg #1/arg #2/>}
+> Extra code for next invocation:
+>     ---
+> Rules:
+>     C LABEL|A LABEL with relation <
+>     C LABEL|B LABEL with default relation <
+> Execution order (after reversal and applying rules):
+>     B LABEL, C LABEL, A LABEL.
+<recently read> }
+l. ...  {2}
+============================================================
+============================================================
+============================================================
+TEST 56: After \begin {document}
+============================================================
+============================================================
+TEST 57: Commands
+============================================================
+<cmdA BEFORE>
 <cmdA BODY>
+<cmdA AFTER>
 ============================================================
+<cmdB BEFORE>
 <cmdB BODY>
+<cmdB AFTER>
+============================================================
+<cmdTwoArgsA BEFORE: /argA 1/argA 2/>
+<cmdTwoArgsA BODY: /argA 1/argA 2/>
+<cmdTwoArgsA AFTER: /argA 1/argA 2/>
+============================================================
+<cmdTwoArgsB BEFORE: /argB 1/argB 2/>
+<cmdTwoArgsB BODY: /argB 1/argB 2/>
+<cmdTwoArgsB AFTER: /argB 1/argB 2/>
 ============================================================
 ============================================================
 !!!! If this test changes the documentation needs updating !!!!

--- a/base/update-lthooks-tests.sh
+++ b/base/update-lthooks-tests.sh
@@ -95,6 +95,7 @@ l3build save -cconfig-lthooks \
    lthooks-legacy \
    lthooks-doc-examples \
    lthooks-rollback-args \
+   lthooks-show-2020-10-01 \
    shipout-000 \
    shipout-002 \
    shipout-004 \


### PR DESCRIPTION
- tests for arguments
- show test file frozen for the 2023-06-01 release
- show test file for the latest release, will be used to change `\ShowHook` in a forthcoming PR

No date change, no code change

2 commits, the first one is the same as in PR #1248

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
- Under development
- Ready to merge

## Checklist of required changes before merge will be approved
- [ X] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
