### PR TITLE
small markup correction in ltproperties.dtx

### DIFF
--- a/base/ltproperties.dtx
+++ b/base/ltproperties.dtx
@@ -23,7 +23,7 @@
 % for those people who are interested.
 %    \begin{macrocode}
 \def\ltpropertiesversion{1.0d}
-\def\ltpropertiesdate{2024-01-17}
+\def\ltpropertiesdate{2024-02-01}
 %    \end{macrocode}
 
 %<*driver>

--- a/base/ltproperties.dtx
+++ b/base/ltproperties.dtx
@@ -180,7 +180,7 @@
 %     \property_record:nn, \property_record:nV, \property_record:ee
 %   }
 %   \begin{syntax}
-%      \cs{property_record:nN} \Arg{label} \Arg{clist var}
+%      \cs{property_record:nN} \Arg{label} \meta{clist var}
 %      \cs{property_record:nn} \Arg{label} \Arg{clist}
 %   \end{syntax}
 %   \LaTeXe{}-interface: see \cs{RecordProperties}.\\  


### PR DESCRIPTION
Just changes an `\Arg{clist var}` to `\meta{clist var}` since this is an `N`-type argument. I know file dates are usually changed for doc updates but this is so small I wanted to check before doing that.

### Edit
Per @muzimuzhi's suggestion, I went ahead and updated the file date.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
