### PR TITLE
Unprotect usesocket

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,10 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
+2024-02-09 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
+	* ltsockets.dtx: move unprotected definition of \socket_use:nw
+	from latex-lab 
+
 2024-01-30  David Carlisle  <David.Carlisle@latex-project.org>
 	* ltclass.dtx: check that \RequirePackage, \documentclass, \usepackage
 	  and related commands are at top level (gh/1185)

--- a/base/ltsockets.dtx
+++ b/base/ltsockets.dtx
@@ -31,8 +31,8 @@
 %%% From File: ltsockets.dtx
 %
 %    \begin{macrocode}
-\def\ltsocketsversion{0.9a}
-\def\ltsocketsdate{2024-02-04}
+\def\ltsocketsversion{0.9b}
+\def\ltsocketsdate{2024-02-09}
 %    \end{macrocode}
 %
 %<*driver>
@@ -603,7 +603,8 @@
 %   the only command that would appear inside macro code in packages.
 %
 %   For performance reasons there is no explicit check that the socket
-%   was declared!
+%   was declared! The command is not defined as a protected command so
+%   that it works for example also at the end of a tabular.
 %
 %   The different L3 programming layer commands are really doing the
 %   same thing: they grab as many arguments as defined as inputs for the socket
@@ -907,7 +908,7 @@
 %  
 %  
 %  \begin{macro}{\socket_use:nw,\socket_use:n,\socket_use:nn,\socket_use:nnn,\socket_use:nnnn}
-%    
+%  \changes{v0.9b}{2022/02/09}{unprotect definition}
 %    And using it is more or less a \cs{use:c} so very lightweight. We do not
 %    add a runtime check for speed reasons!
 %
@@ -919,7 +920,7 @@
 %    arguments (socket inputs plus one) in the L3 layer code.
 %
 %    \begin{macrocode}
-\cs_new_protected:Npn \socket_use:nw #1 {
+\cs_new:Npn \socket_use:nw #1 {
   \@@_debug_term:n
     { Socket~ '#1'~ containing~ plug~
       '\str_use:c { l_@@_#1_plug_str }'~ used. }
@@ -1064,6 +1065,3 @@
 ^^A  mode: latex
 ^^A  coding: utf-8-unix
 ^^A  End: 
-
-
-

--- a/base/ltsockets.dtx
+++ b/base/ltsockets.dtx
@@ -835,7 +835,7 @@
           {
             \cs_generate_from_arg_count:cNnn
               { @@_#1_plug_#2:w }
-              \cs_new_protected:Npn
+              \cs_new:Npn
               { \int_use:c { c_@@_#1_args_int } }
               {#3}
 %    \end{macrocode}
@@ -863,7 +863,7 @@
           {
             \cs_generate_from_arg_count:cNnn
               { @@_#1_plug_#2:w }
-              \cs_set_protected:Npn
+              \cs_set:Npn
               { \int_use:c { c_@@_#1_args_int } }
               {#3}
             \@@_debug_term:n
@@ -921,9 +921,9 @@
 %
 %    \begin{macrocode}
 \cs_new:Npn \socket_use:nw #1 {
-  \@@_debug_term:n
-    { Socket~ '#1'~ containing~ plug~
-      '\str_use:c { l_@@_#1_plug_str }'~ used. }
+%  \@@_debug_term:n
+%    { Socket~ '#1'~ containing~ plug~
+%      '\str_use:c { l_@@_#1_plug_str }'~ used. }
   \use:c { @@_#1_plug_ \str_use:c { l_@@_#1_plug_str } :w }
 }
 %    \end{macrocode}

--- a/required/latex-lab/latex-lab-table.dtx
+++ b/required/latex-lab/latex-lab-table.dtx
@@ -16,8 +16,8 @@
 %
 % for those people who are interested or want to report an issue.
 %
-\def\ltlabtbldate{2023-12-16}
-\def\ltlabtblversion{0.85f}
+\def\ltlabtbldate{2024-02-09}
+\def\ltlabtblversion{0.85g}
 %<*driver>
 \documentclass{l3doc}
 \EnableCrossrefs
@@ -1011,33 +1011,6 @@
 }
 %    \end{macrocode}
 %  \end{macro}
-%
-%
-%
-%
-%
-%  \begin{macro}{\socket_use:nw}
-%
-%    \begin{macrocode}
-
-% this should not be protected
-
-\cs_set:Npn \socket_use:nw #1 {   
-  \__socket_debug_term:n
-    { Socket~ '#1'~ containing~ plug~
-      '\str_use:c { l__socket_#1_plug_str }'~ used. }
-  \use:c { __socket_#1_plug_ \str_use:c { l__socket_#1_plug_str } :w }
-}
-\cs_set_eq:NN \UseSocket         \socket_use:nw
-
-\cs_set:Npn \UseAlignSocket #1 {   
-  \use:c { __socket_#1_plug_ \str_use:c { l__socket_#1_plug_str } :w }
-}
-
-%    \end{macrocode}
-%  \end{macro}
-%
-%
 %
 %  \begin{macro}{\@@_add_missing_cells:}
 %    The storing and use of the number of missing cells must happen at


### PR DESCRIPTION
This moves the unprotected version of \socket_use:nw from latex-lab to ltsockets.

**Edit** Needs some more thoughts: the plugs must be unprotected too, and the debug message must be removed.

# Internal housekeeping

## Status of pull request

X Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added (not needed imho)
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)? (imho unneeded)
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated (imho unneeded)
