### PR TITLE
numeric file counter for #1271

### DIFF
--- a/base/doc/source2e.tex
+++ b/base/doc/source2e.tex
@@ -380,7 +380,7 @@ page_precedence "rnaA"
 \def\endash{--}
 \catcode`\-\active
 \def-{\futurelet\temp\indexdash}
-\def\indexdash{\ifx\temp-\endash\fi}
+\def\indexdash{\ifx\temp-\endash\else:\fi}
 
 \PrintIndex
 \endgroup

--- a/base/source2edoc.cls
+++ b/base/source2edoc.cls
@@ -2,7 +2,7 @@
 % This class is buggy and needs fixing
 
 \ProvidesClass{source2edoc}
-              [2022/04/03 v0.2c Quick hack to typeset source2.tex
+              [2024/02/12 v0.2d Quick hack to typeset source2.tex
                (not usable for anything else and buggy -- will vanish again)!]
 
 

--- a/base/source2edoc.cls
+++ b/base/source2edoc.cls
@@ -176,7 +176,7 @@
          dd%
          \else\@ctrerr\fi}
 \def\docincludeaux{%
-  \def\thepart{\aalph{part}}\def\filesep{\thepart-}%
+  \def\thepart{\ifnum\value{part}<10 0\fi\arabic{part}}\def\filesep{\thepart-}%
   \let\filekey\@gobble
   \g@addto@macro\index@prologue{%
     \gdef\@oddfoot{\parbox[t]{\textwidth}{\strut\footnotesize


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of 
## Status of pull request


- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [X] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated

A very minor change to source2e, to use two digit numeric file counter rather than a custom aalph.
I think it's more understandable in the toc and it gets correctly sorted in the index, eg the first entry 

for `\!` currently lists `cc`  (file 56) before b (file 2)

old

![image](https://github.com/latex3/latex2e/assets/1268738/c015dd68-5d9d-4fe9-ac4e-e3494e7f2ae1)

![image](https://github.com/latex3/latex2e/assets/1268738/970c1c20-9eb7-4f77-8440-e47926f8b2e3)


new

![image](https://github.com/latex3/latex2e/assets/1268738/06b0985d-8fcb-4ff3-a4fd-87da1cf0a8d9)

![image](https://github.com/latex3/latex2e/assets/1268738/8458f109-2a04-4dc8-a130-1f0195398d93)


