### PR TITLE
Drop redundant l3doc patches to `\DocInclude` and `\@docinclude`

### DIFF
--- a/base/source2edoc.cls
+++ b/base/source2edoc.cls
@@ -2,7 +2,7 @@
 % This class is buggy and needs fixing
 
 \ProvidesClass{source2edoc}
-              [2024/02/12 v0.2d Quick hack to typeset source2.tex
+              [2024/02/14 v0.2d Quick hack to typeset source2.tex
                (not usable for anything else and buggy -- will vanish again)!]
 
 
@@ -47,84 +47,6 @@
          }
       }
     \seq_gclear:N \g__codedoc_nested_names_seq
-  }
-
-
-  
-% some l3doc's def are buggy (already fixed there but not distributed yet)
-
-\RenewDocumentCommand \DocInclude { m }
-  {
-    \relax\clearpage
-    \docincludeaux
-    \IfFileExists{#1.fdd}
-      { \cs_set:Npn \currentfile{#1.fdd} }
-      { \cs_set:Npn \currentfile{#1.dtx} }
-    \int_compare:nNnTF \@auxout = \@partaux
-      { \@latexerr{\string\include\space cannot~be~nested}\@eha }
-      { \@docinclude {#1} }  % <--- braces needed!
-    \int_compare:nNnF { \tex_currentgrouplevel:D } = { 0 }
-      {
-        \int_compare:nNnT { \tex_interactionmode:D } = { 0 }
-          { \int_set:Nn \tex_interactionmode:D { 1 } }
-        \msg_fatal:nnn { source2edoc } { missing-endgroup } {#1}
-      }
-  }
-\msg_new:nnn { source2edoc } { missing-endgroup }
-  {
-    \str_if_eq:VnTF \@currenvir { document }
-      {
-        There~are~\int_use:N \tex_currentgrouplevel:D
-        \c_space_tl unclosed~groups~in~#1.dtx.
-      }
-      {
-        The~\@currenvir \c_space_tl environment~on~line~\@currenvline
-        \c_space_tl doesn't~have~a~matching~\iow_char:N\\end{\@currenvir}.
-      }
-  }
-\cs_gset:Npn \@docinclude #1
-  {
-    \clearpage
-    \immediate\write\@mainaux{\string\@input{#1.aux}}
-    \@tempswatrue
-    \if@partsw
-      \@tempswafalse
-      \cs_set:Npx \@tempb {#1}
-      \clist_map_inline:Nn \@partlist
-        {
-          \if_meaning:w \@tempa \@tempb
-            \@tempswatrue
-          \fi:
-        }
-    \fi
-    \if@tempswa
-      \cs_set_eq:NN \@auxout                 \@partaux
-      \immediate\openout\@partaux #1.aux
-      \immediate\write\@partaux{\relax}
-      \cs_set_eq:NN \@ltxdoc@PrintIndex      \PrintIndex
-      \cs_set_eq:NN \PrintIndex              \relax
-      \cs_set_eq:NN \@ltxdoc@PrintChanges    \PrintChanges
-      \cs_set_eq:NN \PrintChanges            \relax
-      \cs_set_eq:NN \@ltxdoc@theglossary     \theglossary
-      \cs_set_eq:NN \@ltxdoc@endtheglossary  \endtheglossary
-      \part{\currentfile}
-      {
-        \cs_set_eq:NN \ttfamily\relax
-        \cs_gset:Npx \filekey
-          { \filekey,~ \thepart = { \ttfamily \currentfile } } % <-- mising spaces considered harmful
-      }
-      \DocInput{\currentfile}
-      \cs_set_eq:NN \PrintIndex              \@ltxdoc@PrintIndex
-      \cs_set_eq:NN \PrintChanges            \@ltxdoc@PrintChanges
-      \cs_set_eq:NN \theglossary             \@ltxdoc@theglossary
-      \cs_set_eq:NN \endtheglossary          \@ltxdoc@endtheglossary
-      \clearpage
-      \@writeckpt{#1}
-      \immediate \closeout \@partaux
-    \else
-      \@nameuse{cp@#1}
-    \fi
-    \cs_set_eq:NN \@auxout \@mainaux
   }
 
 


### PR DESCRIPTION
They are all shipped with l3kernel 2024-02-13. See commits

- latex3/latex3@34338536 (\DocInclude never worked (because in 2e the argument was space delimited) ..., 2020-08-21)
- latex3/latex3@8d816cf5 (and another missing space ..., 2020-08-21)
- latex3/latex3@2e1ff83c (Check missing `\endgroup` at the end of `\DocInclude`, 2024-02-12)

**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] <s>Version and</s> date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
