### PR TITLE
Improve formatting of usrguide.tex

### DIFF
--- a/base/doc/usrguide.tex
+++ b/base/doc/usrguide.tex
@@ -801,7 +801,7 @@ comprised of |m| or |+m| entries (or is entirely empty), the internal structure
 created by \cs{NewDocumentCommand} is essentially as efficient 
 as provided by |\newcommand(*)|. As such, document commands may replace
 constructs arising from \cs{newcommand}, etc., without a need to be concerned
-about performance. Note that \cs{newcommand(*)} produces expandable
+about performance. It should be noted that \cs{newcommand(*)} produces expandable
 results, so the direct replacement is \cs{NewExpandableDocumentCommand};
 in most cases, however, it is better to use \cs{NewDocumentCommand} to
 give more robust structures.
@@ -1198,13 +1198,13 @@ Titlecasing here follows the definition given by the Unicode Consortium: the
 first character of the input will be converted to (broadly) uppercase, and the
 rest of the input to lowercase. The full range of Unicode UTF-8 input can be
 supported.
-\begin{quote}
-  \begin{tabular}{rl}
+\begin{flushleft}
+  \begin{tabular}{@{}ll}
     |\MakeUppercase{hello WORLD ßüé}| & \MakeUppercase{hello WORLD ßüé} \\
     |\MakeLowercase{hello WORLD ßüé}| & \MakeLowercase{hello WORLD ßüé} \\
     |\MakeTitlecase{hello WORLD ßüé}| & \MakeTitlecase{hello WORLD ßüé} \\
   \end{tabular}
-\end{quote}
+\end{flushleft}
 
 The case-changing commands take an optional argument which can be used to
 tailor the output. This optional argument accepts the key \texttt{locale},
@@ -1220,14 +1220,14 @@ are the arguments to the commands \cs{label}, \cs{ref}, \cs{cite}, \cs{begin}
 and \cs{end}. Additional exclusions can be added using the command
 \cs{AddToNoCaseChangeList}. Input can be excluded from case changing using the
 command \cs{NoCaseChange}.
-\begin{quote}
-  \begin{tabular}{rl}
+\begin{flushleft}
+  \begin{tabular}{@{}ll}
     |\MakeUppercase{Some text $y = mx + c$}|
       & \MakeUppercase{Some text $y = mx + c$} \\
     |\MakeUppercase{\NoCaseChange{iPhone}}|
       & \MakeLowercase{\NoCaseChange{iPhone}} \\
   \end{tabular}
-\end{quote}
+\end{flushleft}
 
 To allow robust commands to be used within case changing \emph{and} to produce
 the expected output, two additional control commands are available.
@@ -1256,19 +1256,19 @@ apply to a specific one: this is given in BCP-47 format
 (\url{https://en.wikipedia.org/wiki/IETF_language_tag}). For example,
 the kernel customises the mapping for U+01F0 (\v{j}) when uppercasing in
 8-bit engines:
-\begin{quote}
-  |\DeclareUppercaseMapping{"01F0}{\v{J}}|
-\end{quote}
+\begin{verbatim}
+\DeclareUppercaseMapping{"01F0}{\v{J}}
+\end{verbatim}
 as there is no pre-composed \v{J} character, and this is problematic if
 the engine does not support Unicode natively. Similarly, to set a locale
 \texttt{xx} to behave in the same way as Turkish and retain the difference
 between dotted- and dotless-i, one could use for example
-\begin{quote}
-  |\DeclareLowercaseMapping[xx]{"0049}{\i}|\\
-  |\DeclareLowercaseMapping[xx]{"0130}{i}|\\
-  |\DeclareUppercaseMapping[xx]{"0069}{\.{I}}|\\
-  |\DeclareUppercaseMapping[xx]{"0131}{I}|
-\end{quote}
+\begin{verbatim}
+\DeclareLowercaseMapping[xx]{"0049}{\i}
+\DeclareLowercaseMapping[xx]{"0130}{i}
+\DeclareUppercaseMapping[xx]{"0069}{\.{I}}
+\DeclareUppercaseMapping[xx]{"0131}{I}
+\end{verbatim}
 
 \section{Support for problem solving}
 


### PR DESCRIPTION
* base/doc/usrguide.tex (subsection{Performance}): Slightly rephrase in order to get better linebreaks.
(section{Case changing}): Typeset the code snippets "flush left" like in the rest of the document.