### PR TITLE
Fix inconsistent behavior of expansion of key-value package options

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -7,6 +7,12 @@ not part of the distribution.
 ================================================================================
 
 
+2024-03-22  Yukai Chou <muzimuzhi@gmail.com>
+	* ltfilehook.dtx
+	Apply one-step expansion to raw option list, when a package
+	providing key-value options is loaded the second time. The same
+	expansion for first-time loading was requested in gh/580. (gh/1298)
+
 2024-03-16  David Carlisle  <David.Carlisle@latex-project.org>
 	* ifthen.dtx guard against active <=> (gh/756)
 

--- a/base/doc/ltnews39.tex
+++ b/base/doc/ltnews39.tex
@@ -538,7 +538,22 @@ revised \texttt{fntguide} as well to reflect the changes and macros
 added to the kernel over the last years of development.  Note that the
 file name hasn't changed and there is no \texttt{fntguide-historic}.
 
-%\section{Bug fixes}
+\section{Bug fixes}
+
+\subsection{Fix inconsistent expansion on package option list}
+
+\LaTeX{} applies one-step expansion to raw option list of packages and
+classes so constructions like
+\begin{verbatim}
+  \def\myoptions{opt1,opt2}
+  \usepackage[\myoptions]{foo}
+\end{verbatim}
+are supported. But when a package declares its options with the new
+key/value approach~\cite{39:ltnews35} and was loaded a second time,
+its raw option list was not expanded and an error might be raised.
+This has now been corrected.
+%
+\githubissue{1298}
 
 \section{Changes to packages in the \pkg{amsmath} category}
 
@@ -659,6 +674,10 @@ didn't get this treatment. This oversight has now been corrected.
 \bibitem{39:ltnews33} \LaTeX{} Project Team.
   \emph{\LaTeXe{} news 33}. June 2021.\\
   \url{https://latex-project.org/news/latex2e-news/ltnews33.pdf}
+
+\bibitem{39:ltnews35} \LaTeX{} Project Team.
+  \emph{\LaTeXe{} news 35}. June 2022.\\
+  \url{https://latex-project.org/news/latex2e-news/ltnews35.pdf}
 
 \bibitem{39:ltnews37} \LaTeX{} Project Team.
   \emph{\LaTeXe{} news 37}. June 2023.\\

--- a/base/ltclass.dtx
+++ b/base/ltclass.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltclass.dtx}
-             [2024/02/14 v1.5i LaTeX Kernel (Class & Package Interface)]
+             [2024/03/22 v1.5j LaTeX Kernel (Class & Package Interface)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltclass.dtx}
@@ -2243,9 +2243,17 @@
 %    \end{macrocode}
 % \changes{v1.5d}{2022/10/10}{Use \cs{protected@edef}.}
 %    \begin{macrocode}
-          \expandafter\protected@edef\csname opt@\@currname.\@currext\endcsname
+          \expandafter\protected@edef
+            \csname opt@\@currname.\@currext\endcsname
             {\zap@space#2 \@empty}%
-          \@namedef{@raw@opt@\@currname.\@currext}{#2}%
+%    \end{macrocode}
+% \changes{v1.5j}{2024/03/22}
+%         {Apply one-step expansion to raw option list,
+%          to be consistent with change for gh/580 (gh/1298).}
+%    \begin{macrocode}
+          \expandafter\def
+            \csname @raw@opt@\@currname.\@currext\expandafter\endcsname
+            \expandafter{#2}%
           \@nameuse{opt@handler@\@currname.\@currext}%
         }%
     }%

--- a/base/ltclass.dtx
+++ b/base/ltclass.dtx
@@ -1327,11 +1327,11 @@
 % \changes{v1.4c}{2021/06/06}
 %         {apply \cs{expandafter} to raw options for gh/580}
 %    \begin{macrocode}
-    \@ifundefined{@raw@opt@#3.#1}%
-      {\expandafter\gdef\csname @raw@opt@#3.#1\expandafter\endcsname
-                \expandafter{#2}}%
-      {\expandafter\g@addto@macro\csname @raw@opt@#3.#1\expandafter\endcsname
-                \expandafter{\expandafter,#2}}%
+  \@ifundefined{@raw@opt@#3.#1}%
+    {\expandafter\gdef\csname @raw@opt@#3.#1\expandafter\endcsname
+              \expandafter{#2}}%
+    {\expandafter\g@addto@macro\csname @raw@opt@#3.#1\expandafter\endcsname
+              \expandafter{\expandafter,#2}}%
 }
 %</2ekernel|latexrelease>
 %<latexrelease>\EndIncludeInRelease

--- a/base/testfiles/github-1298.lvt
+++ b/base/testfiles/github-1298.lvt
@@ -1,3 +1,4 @@
+% quite similar to github-0862.lvt
 \documentclass{article}
 
 \begin{filecontents}[force]{\jobname.sty}
@@ -10,7 +11,8 @@
 
 \START
 
-\RequirePackage[foo=\empty]{\jobname}\relax
-\RequirePackage[foo=\empty]{\jobname}\relax
+\def\myoption{foo=\empty}
+\RequirePackage[\myoption]{\jobname}\relax
+\RequirePackage[\myoption]{\jobname}\relax
 
 \END

--- a/base/testfiles/github-1298.tlg
+++ b/base/testfiles/github-1298.tlg
@@ -1,0 +1,7 @@
+This is a generated file for the LaTeX2e validation system.
+Don't change this file in any respect.
+(github-1298.sty
+Package: github-1298 
+Foo was given: \empty 
+)
+Foo was given: \empty 


### PR DESCRIPTION
When a package is loaded the first time, its option list is first expanded by one step then stored as raw option list. This PR makes the expansion behavior consistent for second loading.

Fixes #1298.

The change is similar to those in https://github.com/latex3/latex2e/commit/5a5f6a68922183271d460cb9006fa2b1ea27a718, which was requested in #580.

https://github.com/latex3/latex2e/blob/9c5023c97d3658530f7bb0635c5fcd84b87d89c3/base/ltclass.dtx#L1327-L1334

Is rollback needed?

# Internal housekeeping

## Status of pull request

- Feedback wanted 
- Ready to merge

## Checklist of required changes before merge will be approved
- [x] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
