### PR TITLE
Describe \DeclareFont(Series|Shape)ChangeRule macros

### DIFF
--- a/base/doc/fntguide.tex
+++ b/base/doc/fntguide.tex
@@ -2045,7 +2045,7 @@ A special value is |m| which is used to reset both weight and width.  In
 order to reset only one of them, the special values |?m| (reset width)
 and |m?| (reset weight) are provided, e.g.:
 \begin{verbatim}
-   \DeclareFontSeriesChangeRule{c}{m?}{c}{}
+   \DeclareFontSeriesChangeRule{bc}{m?}{c}{}
 \end{verbatim}
 
 The corresponding macro |\DeclareFontShapeChangeRule| is also provided
@@ -2063,6 +2063,16 @@ An example would be:
 If italics is the current shape and small caps is requested, switch to
 |scit| (small caps italics) and if that doesn't exist, try |scsl| (small
 caps slanted).
+
+Finally, it is also possible to overrule the entries in the lookup
+tables and forcibly select a series or shape with:
+\begin{decl}
+  |\fontseriesforce| \arg{series} \qquad |\fontshapeforce| \arg{shape}
+\end{decl}
+
+With the example above for the |c| series, issueing
+|\fontseriesforce{b}| means that series switches to |b| and not to |bc|.
+Same applies to |\fontshapeforce|.
 
 \subsection{Handling of nested emphasis}
 

--- a/base/doc/fntguide.tex
+++ b/base/doc/fntguide.tex
@@ -2028,8 +2028,10 @@ exist.  The example above now looks like this:
    \DeclareFontSeriesChangeRule{c}{b}{bc}{}
 \end{verbatim}
 which means: switch to the |bc| series if |c| is current and |b| is
-(additionally) requested, and do nothing if the current font doesn't
-have the combination.
+(additionally) requested, and if the current font doesn't have the
+combination, start the normal font substitution, i.e., switch back shape
+to |n| and if this combination doesn't succeed, switch back series to
+|m| as well, ending up with |m/n|.
 
 Another example is:
 \begin{verbatim}
@@ -2037,11 +2039,11 @@ Another example is:
 \end{verbatim}
 which means: if the current series is bold condensed (|bc|) and
 semi-condensed (|sc|) is requested (additionally), try bold
-semi-condensed (|bsc|) if available and stick to bold condensed if not.
+semi-condensed (|bsc|) if available but stay with bold condensed if not.
 
 A special value is |m| which is used to reset both weight and width.  In
-order to reset just the width, |?m| is provided and |m?| to reset just
-the weight, e.g.:
+order to reset only one of them, the special values |?m| (reset width)
+and |m?| (reset weight) are provided, e.g.:
 \begin{verbatim}
    \DeclareFontSeriesChangeRule{c}{m?}{c}{}
 \end{verbatim}
@@ -2051,8 +2053,16 @@ for setting database entries for font shapes:
 \begin{decl}
   |\DeclareFontShapeChangeRule| %
   \arg{current shape} \arg{requested shape} \\
-  \leavevmode\hfill    \arg{result} \arg{alternative result}
+  \leavevmode\hfill   \arg{result} \arg{alternative result}
 \end{decl}
+
+An example would be:
+\begin{verbatim}
+   \DeclareFontShapeChangeRule{it}{sc}{scit}{scsl}
+\end{verbatim}
+If italics is the current shape and small caps is requested, switch to
+|scit| (small caps italics) and if that doesn't exist, try |scsl| (small
+caps slanted).
 
 \subsection{Handling of nested emphasis}
 

--- a/base/doc/fntguide.tex
+++ b/base/doc/fntguide.tex
@@ -42,7 +42,7 @@
 
 \title{\LaTeXe{} font selection}
 
-\author{\copyright~Copyright 1995--2023, \LaTeX\ Project
+\author{\copyright~Copyright 1995--2024, \LaTeX\ Project
   Team.\thanks{Thanks to Arash Esbati for documenting the
     newer NFSS features of 2020}\\
   All rights reserved.%
@@ -52,7 +52,7 @@
    \texttt{fntguide.tex} for full details.}%
 }
 
-\date{October 2023}
+\date{March 2024}
 
 \begin{document}
 
@@ -1996,6 +1996,63 @@ For example,
 \end{verbatim}
 would use |sb| (semi-bold) when |\rmfamily\bfseries| is requested in
 document.
+
+\subsection{Handling of current and requested font series and shape}
+
+In the original NFSS implementation, the series was a single attribute
+stored in |\f@series| and so one always had to specify both weight and
+width together.  Hence, it was impossible to typeset a paragraph in a
+condensed font and inside have a few words in bold weight (but still
+condensed) without doing this manually by requesting
+|\fontseries{bc}\selectfont|.
+
+\NEWfeature{2020/02/02}
+The new implementation now works differently by looking both at the
+current value of |\f@series| and the requested new series and out of
+that combination selects a resulting series value.  Thus, if the current
+series is |c| and we ask for |b|, we now get |bc|.  This is done by
+consulting a simple lookup table where entries can be added or changed
+with |\DeclareFontSeriesChangeRule|:
+\begin{decl}
+  |\DeclareFontSeriesChangeRule| %
+  \arg{current series} \arg{requested series} \\
+  \leavevmode\hfill    \arg{result} \arg{alternative result}
+\end{decl}
+
+The \arg{current series} is the value currently stored in |\f@series|,
+\arg{requested series} is the new series requested, \arg{result} is the
+combined value if it exists for the given font family, and
+\arg{alternative result} is a fallback in case \arg{result} doesn't
+exist.  The example above now looks like this:
+\begin{verbatim}
+   \DeclareFontSeriesChangeRule{c}{b}{bc}{}
+\end{verbatim}
+which means: switch to the |bc| series if |c| is current and |b| is
+(additionally) requested, and do nothing if the current font doesn't
+have the combination.
+
+Another example is:
+\begin{verbatim}
+   \DeclareFontSeriesChangeRule{bc}{sc}{bsc}{bc}
+\end{verbatim}
+which means: if the current series is bold condensed (|bc|) and
+semi-condensed (|sc|) is requested (additionally), try bold
+semi-condensed (|bsc|) if available and stick to bold condensed if not.
+
+A special value is |m| which is used to reset both weight and width.  In
+order to reset just the width, |?m| is provided and |m?| to reset just
+the weight, e.g.:
+\begin{verbatim}
+   \DeclareFontSeriesChangeRule{c}{m?}{c}{}
+\end{verbatim}
+
+The corresponding macro |\DeclareFontShapeChangeRule| is also provided
+for setting database entries for font shapes:
+\begin{decl}
+  |\DeclareFontShapeChangeRule| %
+  \arg{current shape} \arg{requested shape} \\
+  \leavevmode\hfill    \arg{result} \arg{alternative result}
+\end{decl}
 
 \subsection{Handling of nested emphasis}
 

--- a/base/doc/fntguide.tex
+++ b/base/doc/fntguide.tex
@@ -2070,9 +2070,9 @@ tables and forcibly select a series or shape with:
   |\fontseriesforce| \arg{series} \qquad |\fontshapeforce| \arg{shape}
 \end{decl}
 
-With the example above for the |c| series, issueing
-|\fontseriesforce{b}| means that series switches to |b| and not to |bc|.
-Same applies to |\fontshapeforce|.
+With the example above for the |c| series, issuing |\fontseriesforce{b}|
+means that the series switches to |b| and not to |bc|.  Same applies to
+|\fontshapeforce|.
 
 \subsection{Handling of nested emphasis}
 

--- a/base/doc/ltnews39.tex
+++ b/base/doc/ltnews39.tex
@@ -518,7 +518,7 @@ missing and sub-encoding 5 as declared in the kernel is correct.
 \subsection{Further updates to the guides}
 
 We reported about the updated versions of \texttt{usrguide} and
-\texttt{clsguide} in a \LaTeX{} News~37~\cite{39:ltnews37}.  We have
+\texttt{clsguide} in \LaTeX{} News~37~\cite{39:ltnews37}.  We have
 revised \texttt{fntguide} as well to reflect the changes and macros
 added to the kernel over the last years of development.  Note that the
 file name hasn't changed and there is no \texttt{fntguide-historic}.

--- a/base/doc/ltnews39.tex
+++ b/base/doc/ltnews39.tex
@@ -513,7 +513,15 @@ missing and sub-encoding 5 as declared in the kernel is correct.
 %
 \githubissue{1257}
 
+\section{Documentation improvements}
 
+\subsection{Further updates to the guides}
+
+We reported about the updated versions of \texttt{usrguide} and
+\texttt{clsguide} in a \LaTeX{} News~37~\cite{39:ltnews37}.  We have
+revised \texttt{fntguide} as well to reflect the changes and macros
+added to the kernel over the last years of development.  Note that the
+file name hasn't changed and there is no \texttt{fntguide-historic}.
 
 %\section{Bug fixes}
 

--- a/base/doc/ltnews39.tex
+++ b/base/doc/ltnews39.tex
@@ -518,7 +518,7 @@ missing and sub-encoding 5 as declared in the kernel is correct.
 \subsection{Further updates to the guides}
 
 We reported about the updated versions of \texttt{usrguide} and
-\texttt{clsguide} in \LaTeX{} News~37~\cite{39:ltnews37}.  We have
+\texttt{clsguide} in \LaTeX{} News~37~\cite{39:ltnews37}.  We have now
 revised \texttt{fntguide} as well to reflect the changes and macros
 added to the kernel over the last years of development.  Note that the
 file name hasn't changed and there is no \texttt{fntguide-historic}.


### PR DESCRIPTION
* base/doc/fntguide.tex (subsection{Handling of current and requested font series and shape}): New section describing the macros \DeclareFontSeriesChangeRule and
\DeclareFontShapeChangeRule. (#1051)

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
- Under development

## Checklist of required changes before merge will be approved
- [n/a] Test file(s) added
- [X] Version and date string updated in changed source files
- [n/a] Relevant `\changes` entries in source included
- [n/a] Relevant `changes.txt` updated
- [n/a] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
