### PR TITLE
Drop awkward manual line breaks in ltnews31

### DIFF
--- a/base/doc/ltnews31.tex
+++ b/base/doc/ltnews31.tex
@@ -552,8 +552,8 @@ This was corrected.
 \subsection{Ensure that \cs{textbackslash} remains robust}
 
 In the last release we made most document-level commands robust, but
-\cs{textbackslash} became fragile again\\
-whenever  \cs{raggedright} or similar typesetting\\
+\cs{textbackslash} became fragile again
+whenever  \cs{raggedright} or similar typesetting
 was used. This has been fixed.
 %
 \githubissue{203}


### PR DESCRIPTION
These two manual line breaks were added by @car222222 in c3557bb2 (Chris' latest version, 2020-01-27) to improve line breaking. But after typo correction `\cs{\textbackslash}` -> `\cs{textbackslash}` made in 2ef798be (Fixcontentsline (#<span></span>370), 2020-08-15), they are now unneeded and only cause awkward line breaks.

Page breaks are not affected.

|        | Before | after |
|--------|--------|--------|
| Subsction | ![image](https://github.com/latex3/latex2e/assets/6376638/3173a88e-67d7-4d92-b66e-504d0a12a253) | ![image](https://github.com/latex3/latex2e/assets/6376638/76223200-2437-47c1-99b6-a923745a0ed0) |
| Whole page | ![image](https://github.com/latex3/latex2e/assets/6376638/6419b3a5-3aeb-453e-a7de-68acd0d58eb7) | ![image](https://github.com/latex3/latex2e/assets/6376638/2ae65f5e-3528-4e27-b11b-3bc78f1dd161) | 

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
