### PR TITLE
Use \m instead of \arg

### DIFF
--- a/base/doc/fntguide.tex
+++ b/base/doc/fntguide.tex
@@ -2019,11 +2019,11 @@ with |\DeclareFontSeriesChangeRule|:
   \leavevmode\hfill    \arg{result} \arg{alternative result}
 \end{decl}
 
-The \arg{current series} is the value currently stored in |\f@series|,
-\arg{requested series} is the new series requested, \arg{result} is the
+The \m{current series} is the value currently stored in |\f@series|,
+\m{requested series} is the new series requested, \m{result} is the
 combined value if it exists for the given font family, and
-\arg{alternative result} is a fallback in case \arg{result} doesn't
-exist.  The example above now looks like this:
+\m{alternative result} is a fallback in case \m{result} doesn't exist.
+The example above now looks like this:
 \begin{verbatim}
    \DeclareFontSeriesChangeRule{c}{b}{bc}{}
 \end{verbatim}


### PR DESCRIPTION
* base/doc/fntguide.tex (subsection{Handling of current and requested font series and shape}): Use \m and not \arg in text body.

- Ready to merge

This is a small followup to commit 04632b1 fixing a minor glitch.