### PR TITLE
latex-lab: avoid space after double-column floats

### DIFF
--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -1,3 +1,8 @@
+2024-03-23  Yukai Chou  <muzimuzhi@gmail.com>
+
+	* latex-lab-float.dtx (subsection{Patching}):
+	Fix missing underscore (_) in csname
+
 2024-03-23 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
 	* latex-lab-block.dtx: store main text-unit number for marginpars.
 

--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -2,6 +2,7 @@
 
 	* latex-lab-float.dtx (subsection{Patching}):
 	Fix missing underscore (_) in csname
+	Adjust white space before comment in \end@dblfloat
 
 2024-03-23 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
 	* latex-lab-block.dtx: store main text-unit number for marginpars.

--- a/required/latex-lab/latex-lab-float.dtx
+++ b/required/latex-lab/latex-lab-float.dtx
@@ -16,8 +16,8 @@
 %
 % for those people who are interested or want to report an issue.
 %
-\def\ltlabfloatdate{2024-03-22}
-\def\ltlabfloatversion{0.81d}
+\def\ltlabfloatdate{2024-03-23}
+\def\ltlabfloatversion{0.81e}
 %<*driver>
 \documentclass{l3doc}
 \EnableCrossrefs
@@ -337,7 +337,7 @@
 %    \end{macrocode}
 % If the float is in hmode we have to interrupt the P 
 %    \begin{macrocode}
-     \@nameuse{@@_float_stoppar:}% <---end P
+     \@nameuse{@@_float_stop_par:}% <---end P
      \@floatpenalty -\@Mii
    \else
      \@floatpenalty-\@Miii

--- a/required/latex-lab/latex-lab-float.dtx
+++ b/required/latex-lab/latex-lab-float.dtx
@@ -436,7 +436,7 @@
         \penalty\@floatpenalty
       \else
         \vadjust{\penalty -\@Miv \vbox{}\penalty\@floatpenalty}\@Esphack
-        \@nameuse{@@_float_start_par:} %restart P safe here??
+        \@nameuse{@@_float_start_par:}% restart P safe here??
       \fi
     \fi
   \else

--- a/required/latex-lab/testfiles-float/float-005-double.luatex.tlg
+++ b/required/latex-lab/testfiles-float/float-005-double.luatex.tlg
@@ -1341,7 +1341,6 @@ Completed box being shipped out [1]
 .......\TU/lmr/m/n/10  
 .......\glue(\spaceskip) 1.11444 plus 4.99997 minus 0.37036
 .......\penalty 10000
-.......\glue 0.0
 .......\penalty 10000
 .......\glue(\parfillskip) 0.0 plus 1.0fil
 .......\glue(\rightskip) 0.0

--- a/required/latex-lab/testfiles-float/float-005-double.luatex.tlg
+++ b/required/latex-lab/testfiles-float/float-005-double.luatex.tlg
@@ -1413,8 +1413,6 @@ Completed box being shipped out [2]
 ...\glue 8.0 plus 2.0fil
 ...\vbox(30.88889+0.00002)x469.0, direction TLT
 ....\vbox(30.88889+0.0)x469.0, direction TLT
-.....\pdfliteral page <lua data reference ...>
-.....\pdfliteral page <lua data reference ...>
 .....\special{}
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0

--- a/required/latex-lab/testfiles-float/float-005-double.tlg
+++ b/required/latex-lab/testfiles-float/float-005-double.tlg
@@ -40,7 +40,6 @@ Package tagpdf Info: Parent-Child 'Aside' --> 'Part'.
 Package tagpdf Info: Parent-Child 'Aside' --> 'P'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from 'Aside/pdf2' --> 'text/latex' on line ...
-Package tagpdf Warning: nested marked content found - mcid 3
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from 'P/pdf2' --> 'MC' on line ...
@@ -1214,6 +1213,7 @@ Completed box being shipped out [1]
 .......\OT1/cmr/m/n/10 m
 .......\OT1/cmr/m/n/10 .
 .......\glue 4.44444 plus 4.99997 minus 0.37036
+.......\pdfliteral page{EMC}
 .......\penalty 10000
 .......\glue 0.0
 .......\write1{\new@label@record{mcid-7}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{7}{tagmcid}{\__property_code_tagmcid: }}}
@@ -1222,6 +1222,8 @@ Completed box being shipped out [1]
 .......\penalty 10000
 .......\glue(\parfillskip) 0.0 plus 1.0fil
 .......\glue(\rightskip) 0.0
+......\marks4{e-,3,8,}
+......\marks4{e+,3,8,}
 ......\penalty 0
 ......\penalty 10000
 ......\marks4{b-,7,8,P,,,}


### PR DESCRIPTION
Similar to 9107c274 (avoid space around floats, 2024-03-22) and the following 05e3cb96 (white space affecting test results, 2024-03-22) which adjusted white spaces before comments in `\@xfloat` and `\end@float`, this PR adjusts white space before comment in `\end@dblfloat`.

A wrong csname is also corrected. There're only `\__tag_float_(stop|start)_par:`, no `\__tag_float_stoppar:`
https://github.com/latex3/latex2e/blob/05e3cb969ad621d30b9b3354317d9894eaeb7c72/required/latex-lab/latex-lab-float.dtx#L272-L293

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
