### PR TITLE
Add forth empty argument to a \contentsline example

### DIFF
--- a/base/ltsect.dtx
+++ b/base/ltsect.dtx
@@ -31,7 +31,7 @@
 %%% From File: ltsect.dtx
 %<*driver>
 % \fi
-\ProvidesFile{ltsect.dtx}[2021/07/28 v1.1f LaTeX Kernel (Sectioning)]
+\ProvidesFile{ltsect.dtx}[2024/03/25 v1.1f LaTeX Kernel (Sectioning)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltsect.dtx}
@@ -835,13 +835,13 @@
 % \begin{macro}{\contentsline}
 % The |\contentsline{|\meta{type}|}{|\meta{entry}|}{|\meta{page}|}{}|
 % macro produces a \meta{type} entry in a table of contents, etc.
-% It will appear in the |.toc| or other file.  For example,
-% The entry for subsection 1.4.3 in the table of contents for
-% example, might be produced by:
+% It will appear in the |.toc| or other file.
+% For example, the entry for subsection 1.4.3 in the table of contents,
+% might be produced by:
 %
 %  \begin{verbatim}
 %       \contentsline{subsection}
-%           {\makebox{30pt}[r]{1.4.3} Gnats and Gnus}{22}
+%           {\numberline{1.4.3}Gnats and Gnus}{22}{}
 %  \end{verbatim}
 %
 %  The |\protect| command causes command sequences to be written


### PR DESCRIPTION
The forth argument was added in 0b7a68ea (Gh633 (#<span></span>634), 2021-07-28).

**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] <s>Version and</s> date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
