### PR TITLE
Exclude dups and non-docs from Documentation artifacts

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -195,7 +195,11 @@ jobs:
         with:
           # example names: "Documentation-base-1", "Documentation-requires"
           name: Documentation-${{ matrix.module }}${{ matrix.environment && format('-{0}', env.LTX_DOC_COMPONENT) || ''}}
-          path: "**/*.pdf"
+          path: |
+            **/*.pdf
+            !build
+            !texmf
+            !**/testfiles*
           # Decide how long to keep the test output artifact:
           retention-days: 21
   # GitHub automatically informs the initiator of any action about the result, but

--- a/.github/workflows/pretest.yaml
+++ b/.github/workflows/pretest.yaml
@@ -173,6 +173,10 @@ jobs:
         with:
           # example names: "Documentation-base-1", "Documentation-requires"
           name: Documentation-${{ matrix.module }}${{ matrix.environment && format('-{0}', env.LTX_DOC_COMPONENT) || ''}}
-          path: "**/*.pdf"
+          path: |
+            **/*.pdf
+            !build
+            !texmf
+            !**/testfiles*
           # Decide how long to keep the test output artifact:
           retention-days: 21


### PR DESCRIPTION
Before
  ```
  Documentation-base-1
  ├── base
  │   └── doc
  │       └── source2e.pdf
  ├── build
  │   └── doc
  │       └── source2e.pdf
  └── texmf
      └── tex
          └── latex
              └── mwe
                  ├── example-image-a.pdf
                  ├── example-image-b.pdf
                  ├── example-image-duck.pdf
                  └── example-image.pdf
  ```
After
  ```
  Documentation-base-1
  └── base
       └── doc
           └── source2e.pdf
  ```

Similar to https://github.com/latex3/latex3/pull/1410.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
