### PR TITLE
Fix typo, \Umathcar -> \Umathchar

### DIFF
--- a/required/amsmath/ams-external.txt
+++ b/required/amsmath/ams-external.txt
@@ -60,7 +60,6 @@
 \Rightarrow
 \Tilde
 \Umathaccent
-\Umathcar
 \Umathchar
 \Umathcharnumdef
 \Umathcode

--- a/required/amsmath/amsmath-2018-12-01.sty
+++ b/required/amsmath/amsmath-2018-12-01.sty
@@ -517,7 +517,7 @@ Foreign command \@backslashchar#1;\MessageBreak
          \else  % \not \mathxxx
              \@xp\Umathch@\meaning@"0"\Umathch@
              \ifgtest@ % if \Umathchar
-             \else % else not \Umathcar
+             \else % else not \Umathchar
            \@xp\macro@\meaning@@\macro@
            \ifgtest@ % if macro test
              \@xp\not@\meaning@\not@

--- a/required/amsmath/amsmath.dtx
+++ b/required/amsmath/amsmath.dtx
@@ -86,7 +86,7 @@ Bug reports can be opened (category \texttt{#1}) at\\%
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\ProvidesPackage{amsmath}[2024/03/13 v2.17p AMS math features]
+\ProvidesPackage{amsmath}[2024/05/09 v2.17p AMS math features]
 %    \end{macrocode}
 %
 % \section{Catcode defenses}
@@ -1162,7 +1162,7 @@ Foreign command \@backslashchar#1;\MessageBreak
 %    \begin{macrocode}
              \@xp\Umathch@\meaning@"0"\Umathch@
              \ifgtest@ % if \Umathchar
-             \else % else not \Umathcar
+             \else % else not \Umathchar
 %    \end{macrocode}
 %    \begin{macrocode}
            \@xp\macro@\meaning@@\macro@

--- a/required/amsmath/testfiles/github-amsrobust-0123.lvt
+++ b/required/amsmath/testfiles/github-amsrobust-0123.lvt
@@ -44,7 +44,7 @@
 %\test{\PackageWarningNoLine}
 %\test{\PackageWarning}
 %\test{\Umathaccent}
-%\test{\Umathcar}
+%\test{\Umathchar}
 %\test{\Umathcharnumdef}
 %\test{\Umathchar}
 %\test{\Umathcodenum}

--- a/required/tools/changes.txt
+++ b/required/tools/changes.txt
@@ -5,6 +5,11 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 =======================================================================
 
+2024-05-09  Yukai Chou  <muzimuzhi@gmail.com>
+
+	* amsmath.dtx:
+	Fix typo in comment, \Umathcar -> \Umathchar (gh/1343)
+
 2024-04-10  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
 
 	* xr.dtx:


### PR DESCRIPTION
There is a remaining `\Umathcar` in `amsmath-2018-12-01.sty` which I'm not sure whether can be modified or not.

See #1343.

**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] <s>Version and</s> date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
