### PR TITLE
fix small typos

### DIFF
--- a/base/doc/clsguide.tex
+++ b/base/doc/clsguide.tex
@@ -1220,7 +1220,7 @@ The arguments \meta{label} and \meta{list of properties} can contain
 commands that are expanded. \meta{label} can expand to an arbitrary
 string (as long as it can safely be written to the \texttt{aux}-file)
 but note that the label names of \cs{label} and \cs{RecordProperties}
-share a singe namespace. This means that you get a \texttt{Label `A'
+share a single namespace. This means that you get a \texttt{Label `A'
   multiply defined} warning with the following code:
 \begin{verbatim}
 \label{A}\RecordProperties{A}{abspage}
@@ -1272,7 +1272,7 @@ immediately when \cs{RecordProperties} is used but during the next
    the standard \cs{label}/\cs{pageref}.
 
  \item[\texttt{pagenum} (default: \texttt{0}, at shipout)] The current page as arabic number. This is
-   suitable for integer operations and comparisions.
+   suitable for integer operations and comparisons.
 
  \item[\texttt{label} (default: \texttt{??})] The content of \cs{@currentlabel}. This is the value 
      that you get also with the standard \cs{label}/\cs{ref}. 

--- a/base/doc/clsguide.tex
+++ b/base/doc/clsguide.tex
@@ -42,7 +42,7 @@
     \texttt{clsguide.tex} for full details.}%
 }
 
-\date{2024-04-06}
+\date{2024-05-24}
 
 \NewDocumentCommand\cs{m}{\texttt{\textbackslash\detokenize{#1}}}
 \NewDocumentCommand\marg{m}{\arg{#1}}

--- a/base/doc/ltnews28.tex
+++ b/base/doc/ltnews28.tex
@@ -126,7 +126,7 @@ happened. For example, the German word ``Gr\"o\ss e'' (height) entered on a
 German keyboard could show up as ``Gr\v T\`ae'' on a different
 computer using a different encoding by default.
 
-So in summmary the situation wasn't at all good and it was clear in
+So in summary the situation wasn't at all good and it was clear in
 the early nineties that \LaTeXe{} (that was being developed to provide
 a \LaTeX{} version usable across the world) had to provide a solution
 to this issue.
@@ -318,7 +318,7 @@ As a result some parts of the columns did overprint each other.
 
 The fix required a redesign of the output routines used by
 \pkg{multicol} and while it ``should'' be transparent in other cases
-(and all tests in the regession test suite came out fine) there is the
+(and all tests in the regression test suite came out fine) there is the
 off-chance that code that hooked into internals of \pkg{multicol}
 needs adjustment.
 

--- a/base/doc/usrguide.tex
+++ b/base/doc/usrguide.tex
@@ -43,7 +43,7 @@
     \texttt{usrguide.tex} for full details.}%
 }
 
-\date{2024-03-17}
+\date{2024-05-24}
 
 \NewDocumentCommand\cs{m}{\texttt{\textbackslash\detokenize{#1}}}
 \NewDocumentCommand\marg{m}{\arg{#1}}
@@ -646,7 +646,7 @@ take account of the possibility that the \meta{token} has been made active
 (category code~$13$) and will split at such tokens. 
 Spaces are trimmed at each end of each item parsed. Exactly one set
 of braces will be stripped if an entire item is surrounded by them,
-i.e.~the following inputs and outputs result (each separte item as
+i.e.~the following inputs and outputs result (each separate item as
 a brace group).
 \begin{verbatim}
 a      ==> {a}


### PR DESCRIPTION
Fixes a few small typos in clsguide, ltnews28, and usrguide.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
- Under development
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
