### PR TITLE
Add lttemplates module to the source2e doc

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -15,6 +15,9 @@ All changes above are only part of the development branch for the next release.
 	* source2e.tex:
 	Add new module lttemplates to the documentation.
 
+	* lttemplates.dtx:
+	Fix markup typos.
+
 #########################
 # 2024-06-01 Release
 #########################

--- a/base/changes.txt
+++ b/base/changes.txt
@@ -10,6 +10,11 @@ not part of the distribution.
 All changes above are only part of the development branch for the next release.
 ================================================================================
 
+2024-06-04  Yukai Chou  <muzimuzhi@gmail.com>
+
+	* source2e.tex:
+	Add new module lttemplates to the documentation.
+
 #########################
 # 2024-06-01 Release
 #########################

--- a/base/doc/source2e.tex
+++ b/base/doc/source2e.tex
@@ -268,7 +268,7 @@ page_precedence "rnaA"
 
  \DocInclude{ltpara}   % Paragraph hooks (L3 module)
 
- \DocInclude{ltmeta}   % Document Metadara interface (L3 module)
+ \DocInclude{ltmeta}   % Document Metadata interface (L3 module)
 
  \DocInclude{ltspace}  % Spacing, line and page breaking.
 

--- a/base/doc/source2e.tex
+++ b/base/doc/source2e.tex
@@ -256,6 +256,8 @@ page_precedence "rnaA"
 
  \DocInclude{ltsockets}% Socket and plug management (L3 module)
 
+ \DocInclude{lttemplates} % Prototype document functions (was xtemplate)
+
  \DocInclude{ltalloc}  % Allocation of counters and others.
 
  \DocInclude{ltcntrl}  % Program control macros.

--- a/base/lttemplates.dtx
+++ b/base/lttemplates.dtx
@@ -36,7 +36,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{lttemplates.dtx}
-  [2024-04-17 v1.0c LaTeX Kernel (Prototype document functions)]
+  [2024-06-04 v1.0c LaTeX Kernel (Prototype document functions)]
 % \iffalse
 \documentclass{l3doc}
 \GetFileInfo{lttemplates.dtx}
@@ -730,13 +730,13 @@
 %    \end{macrocode}
 % \end{variable}
 %
-% \begin{macro}{\l_@@_default_tl}
+% \begin{variable}{\l_@@_default_tl}
 %   The default value for a key is recovered here from the property list
 %   in which it is stored.
 %    \begin{macrocode}
 \tl_new:N \l_@@_default_tl
 %    \end{macrocode}
-%\ end{macro}
+% \end{variable}
 %
 % \begin{variable}{\l_@@_error_bool}
 %   A flag for errors to be carried forward.
@@ -1319,7 +1319,6 @@
 \cs_new:Npn \@@_split_keytype_arg_aux:n #1 { }
 \cs_new:Npn \@@_split_keytype_arg_aux:w #1 \s_@@_stop { }
 %    \end{macrocode}
-% \end{macro}
 % \end{macro}
 % \end{macro}
 % \end{macro}
@@ -1923,7 +1922,6 @@
   }
 \cs_generate_variant:Nn \@@_convert_to_assignments_aux:nn { nV }
 %    \end{macrocode}
-% \end{macro}
 % \end{macro}
 % \end{macro}
 % \end{macro}


### PR DESCRIPTION
New module `lttemplates` was added in #1132. This PR adds it to the source2e documentation.

The insertion position is the same as that in `format.ins`, after `ltsockets` and before `ltalloc`:
https://github.com/latex3/latex2e/blob/8206f78ebaf594a5b4fca6d2451efec43426ab65/base/format.ins#L172-L174

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
