### PR TITLE
Append \everypar toks to \g__para_standard_everypar_tl

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,12 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
+2024-06-23  Yukai Chou  <muzimuzhi@gmail.com>
+
+	* ltpara.dtx
+	Append \everypar toks to \g__parar_standard_everypar_tl, rollback
+	2023/06/01 (gh/1386)
+
 ================================================================================
 All changes above are only part of the development branch for the next release.
 ================================================================================

--- a/base/doc/ltnews39.tex
+++ b/base/doc/ltnews39.tex
@@ -727,8 +727,8 @@ logic for the strut changes when vertical mode is detected.
 
 \subsection{Fix a ``missing \cs{item}'' rollback error}
 
-If \LaTeX{} is rolled back to a date not newer than 2023/06/01 and
-older than 2024/06/01, any list-based environment would raise an error
+If \LaTeX{} is rolled back to a date between 2023/06/01 (inclusive) and
+2024/06/01 (exclusive), any list-based environment would raise an error
 \begin{verbatim}
 ! LaTeX Error: Something's wrong--perhaps a missing \item.
 \end{verbatim}

--- a/base/doc/ltnews39.tex
+++ b/base/doc/ltnews39.tex
@@ -725,6 +725,19 @@ logic for the strut changes when vertical mode is detected.
 \pkg{bigfoot})}
 
 
+\subsection{Fix a ``missing \cs{item}'' rollback error}
+
+If \LaTeX{} is rolled back to a date not newer than 2023/06/01 and
+older than 2024/06/01, any list-based environment would raise an error
+\begin{verbatim}
+! LaTeX Error: Something's wrong--perhaps a missing \item.
+\end{verbatim}
+This has now been corrected as a hotfix in patch level 2, by enhancing
+a 2023/06/01 version rollback code of new paragraph mechanism.
+%
+\githubissue{1386}
+
+
 
 \section{Changes to packages in the \pkg{amsmath} category}
 

--- a/base/ltpara.dtx
+++ b/base/ltpara.dtx
@@ -17,7 +17,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltpara.dtx}
-             [2024/05/16 v1.0m LaTeX Kernel (paragraph hooks)]
+             [2024/06/23 v1.0n LaTeX Kernel (paragraph hooks)]
 % \iffalse
 %
 \documentclass{l3doc}
@@ -819,6 +819,18 @@
   \@@_handle_indent:
 % \the \everypar           % <--- done differently below
 }
+%    \end{macrocode}
+% \changes{v1.0n}{2024/06/23}
+%         {Append \cs{everypar} toks to \cs{g_@@_standard_everypar_tl},
+%          rollback 2023/06/01 (gh/1386)}
+%    \begin{macrocode}
+%<latexrelease>\cs_set:Npn \@@_tmp:w #1#2#3#4#5 { }
+%<latexrelease>\tl_gput_right:Nx \g_@@_standard_everypar_tl {
+%<latexrelease>  \exp_not:N \the
+%<latexrelease>  \exp_not:N \toks
+%<latexrelease>  \exp_after:wN \@@_tmp:w \token_to_meaning:N \everypar
+%<latexrelease>  \c_space_tl
+%<latexrelease>}
 %<latexrelease>\EndIncludeInRelease
 %<latexrelease>\IncludeInRelease{2021/06/01}
 %<latexrelease>       {\g_@@_standard_everypar_tl}{minipage~ fix}
@@ -917,10 +929,10 @@
 %    the paragraph text starts.
 %    \begin{macrocode}
 \tl_gput_right:Nx \g_@@_standard_everypar_tl {
-    \exp_not:N \the
-    \exp_not:N \toks
-    \the \allocationnumber
-    \c_space_tl
+  \exp_not:N \the
+  \exp_not:N \toks
+  \the \allocationnumber
+  \c_space_tl
 }
 %    \end{macrocode}
 %  \end{macro}

--- a/base/testfiles/github-1386.lvt
+++ b/base/testfiles/github-1386.lvt
@@ -1,0 +1,17 @@
+
+\RequirePackage[2024-05-01]{latexrelease}
+
+\documentclass{article}
+
+\input{test2e}
+
+\begin{document}
+
+\START
+
+% should not raise errors
+\begin{itemize}
+  \item This is an item.
+\end{itemize}
+
+\END

--- a/base/testfiles/github-1386.tlg
+++ b/base/testfiles/github-1386.tlg
@@ -1,0 +1,2 @@
+This is a generated file for the LaTeX2e validation system.
+Don't change this file in any respect.


### PR DESCRIPTION
Fix rollback 2023/06/01 of \g__para_standard_everypar_tl, labeled "minipage fix". See #1386.

# Internal housekeeping

## Status of pull request

- Feedback wanted 
- Ready to merge

## Checklist of required changes before merge will be approved
- [x] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [x] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
