### PR TITLE
Fix a typo, testpatch -> testpach

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -9,7 +9,7 @@ not part of the distribution.
 2024-06-19  David Carlisle  <David.Carlisle@latex-project.org>
 
 	* fontdef.dtx:
-	preload ts1lmr.fd in Unicode engines
+	preload ts1cmr.fd in Unicode engines
 
 2024-06-19 Joseph Wright  <Joseph.Wright@latex-project.org>
 	* ltkeys.dtx, clsguide.tex

--- a/base/lttab.dtx
+++ b/base/lttab.dtx
@@ -31,7 +31,7 @@
 %%% From File: lttab.dtx
 %<*driver>
 % \fi
-\ProvidesFile{lttab.dtx}[2021/04/20 v1.1s LaTeX Kernel (Columns)]
+\ProvidesFile{lttab.dtx}[2024/06/23 v1.1s LaTeX Kernel (Columns)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{lttab.dtx}
@@ -1499,7 +1499,7 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\@testpatch}
+% \begin{macro}{\@testpach}
 %    \begin{macrocode}
 \def\@testpach#1{\@chclass \ifnum \@lastchclass=\tw@ 4 \else
     \ifnum \@lastchclass=3 5 \else


### PR DESCRIPTION
I don't get the meaning of `\@testpach`, but `\@testpatch` is the only inconsistent naming.

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] <s>Version and</s> date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
