### PR TITLE
fix small typos in base dtx files

### DIFF
--- a/base/classes.dtx
+++ b/base/classes.dtx
@@ -53,7 +53,7 @@
 %<*driver>
 \ProvidesFile{classes.drv}
 %</driver>
-              [2024/02/08 v1.4n
+              [2024/06/29 v1.4n
 %<article|report|book> Standard LaTeX document class]
 %<10pt|11pt|12pt>      Standard LaTeX file (size option)]
 %    \end{macrocode}
@@ -257,7 +257,7 @@
 %
 % \begin{macro}{\@ptsize}
 %    This control sequence is used to store the second digit of the
-%    pointsize we are typesetting in. So, normally, it's value is one
+%    pointsize we are typesetting in. So, normally, its value is one
 %    of 0, 1 or 2.
 %    \begin{macrocode}
 %<*article|report|book>
@@ -362,7 +362,7 @@
 %    with other packages that use the |\@ptsize| variable to select
 %    special actions. It makes the declarations of size options less
 %    than 10pt difficult, although one can probably use \texttt{9}
-%    and \texttt{8} assuming that a class wont define both
+%    and \texttt{8} assuming that a class won't define both
 %    \Lopt{8pt} and \Lopt{18pt} options.
 %
 %    \begin{macrocode}
@@ -3122,7 +3122,7 @@
 %
 % \subsubsection{Theorem}
 %
-%    This document class does not define it's own theorem environments,
+%    This document class does not define its own theorem environments,
 %    the defaults, supplied by the \LaTeX{} format are available.
 %
 % \subsubsection{Titlepage}
@@ -3130,12 +3130,12 @@
 % \begin{environment}{titlepage}
 %  In the normal environments, the titlepage environment does nothing
 %  but start and end a page, and inhibit page numbers. When \LaTeX\ is
-%  in two-column mode, the environmont temporarily switches to
+%  in two-column mode, the environment temporarily switches to
 %  one-column mode.
 %  In the report class, it also resets the page number to one, and
 %  then, in two-column mode, sets it back to one at the end.
 %  For the book class the environment makes sure that the title page
-%  is on a recto page by issueing a \cs{cleardouplepage}-command.
+%  is on a recto page by issuing a \cs{cleardoublepage}-command.
 %  In compatibility mode, it sets the page number to zero. This is
 %  incorrect since it results in using the page parameters for a
 %  right-hand page but it is the way it was. 

--- a/base/doc.dtx
+++ b/base/doc.dtx
@@ -34,7 +34,7 @@
 %\catcode`\<=14
 %<+package|shortvrb>\NeedsTeXFormat{LaTeX2e}[1994/12/01]
 %<+package>
-% Any rollback request before 2016-02-15 we try to fullfil with the 2016 version:
+% Any rollback request before 2016-02-15 we try to fulfill with the 2016 version:
 %<+package>\DeclareRelease{}{1994-06-01}
 %<+package>                      {doc-2016-02-15.sty}
 %<+package>\DeclareRelease{v2.1g}{2016-02-15}
@@ -45,7 +45,7 @@
 %<+package>
 %<+package>\ProvidesPackage{doc}
 %<+shortvrb>\ProvidesPackage{shortvrb}
-%<+package|shortvrb>  [2024/06/04 v3.0q
+%<+package|shortvrb>  [2024/06/29 v3.0q
 %<+package|shortvrb>   Standard LaTeX documentation package V3 (FMi)]
 %\catcode`\<=12
 %
@@ -836,7 +836,7 @@
 %
 % All three above declarations are local to the current group.
 %
-% Production (or not) of the index (via the |\makeindex| commend) is
+% Production (or not) of the index (via the |\makeindex| command) is
 % controlled by using or omitting the following declarations in the
 % driver file preamble; if neither is used, no index is produced.
 % \DescribeInterfaceMacro\PageIndex Using |\PageIndex| makes all index
@@ -5565,7 +5565,7 @@
 % Since version 2.1g, \texttt{doc} creates a \cs{saved@indexname} command
 % which in used by \cs{changes}. We now support that as well. The expansion of
 % this command depends on whether the documented item is macrolike or not,
-% which we don't know here (it's only know by \cs{NewDocElement}). That's why we
+% which we don't know here (it's only known by \cs{NewDocElement}). That's why we
 % need one specific command generating \cs{saved@indexname} the right way for
 % every single item. These commands are
 %    named\cs{@Save\meta{item}IndexName};

--- a/base/ltluatex.dtx
+++ b/base/ltluatex.dtx
@@ -30,7 +30,7 @@
 %<*plain>
 % \fi
 % \ProvidesFile{ltluatex.dtx}
-[2024/06/04 v1.2d
+[2024/06/29 v1.2d
 % LaTeX Kernel (LuaTeX support)^^A
 %\iffalse
 %<plain>   LuaTeX support for plain TeX (core)%
@@ -422,7 +422,7 @@
 % same callback and descriptions.
 %
 % The callback functions do not have to be registered yet when the functions is called.
-% Ony the constraints for which both callback descriptions refer to callbacks
+% Only the constraints for which both callback descriptions refer to callbacks
 % registered at the time the callback is called will have an effect.
 %
 % \endgroup
@@ -1339,7 +1339,7 @@ luatexbase.new_luafunction = new_luafunction
 % Additionally |callbackrules| describes the ordering constraints: It contains two
 % element tables with the descriptions of the constrained callback implementations.
 % It can additionally contain a |type| entry indicating the kind of rule. A missing
-% value indicates a normal ordering contraint.
+% value indicates a normal ordering constraint.
 %
 % \changes{v1.2a}{2022/10/03}{Add rules for callback ordering}
 %    \begin{macrocode}
@@ -1401,7 +1401,7 @@ local callbacklist = setmetatable({}, {
           end
           list[i] = current.value
         else
-          -- Cycle occured. TODO: Show cycle for debugging
+          -- Cycle occurred. TODO: Show cycle for debugging
           -- list[i] = ...
           local remaining = {}
           for name, entry in next, meta do
@@ -1435,7 +1435,7 @@ local callbacklist = setmetatable({}, {
           for i=2, length//2 do
             cycle[i], cycle[length + 1 - i] = cycle[length + 1 - i], cycle[i]
           end
-          error('Cycle occured at ' .. table.concat(cycle, ' -> ', 1, length))
+          error('Cycle occurred at ' .. table.concat(cycle, ' -> ', 1, length))
         end
       end
     end

--- a/base/ltmarks.dtx
+++ b/base/ltmarks.dtx
@@ -17,7 +17,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltmarks.dtx}
-             [2024/05/31 v1.0g LaTeX Kernel (Marks)]
+             [2024/06/29 v1.0g LaTeX Kernel (Marks)]
 % \iffalse
 %
 \documentclass{l3doc}
@@ -806,7 +806,7 @@
   \tl_new:c   { g_@@_last-column_first_  #1 _tl }
   \tl_new:c   { g_@@_last-column_last_   #1 _tl }
 %    \end{macrocode}
-%    All marks will have an identication at the beginning of the form
+%    All marks will have an identification at the beginning of the form
 %    \cs{@@_id:n}\texttt\{\meta{number}\texttt\} and therefore the
 %    initial empty values should have that too, so that data extraction
 %    is going to be uniform.
@@ -1027,7 +1027,7 @@
 %
 %    We disguise \cs{c_max_dim} in an odd looking csname, which then
 %    shows up as part of the display of an error message if that error
-%    happens. This csname forms part of the error diplay so what
+%    happens. This csname forms part of the error display so what
 %    you get is something like
 %\begin{verbatim}
 %   ! Infinite glue shrinkage found in box being split.

--- a/base/ltpara.dtx
+++ b/base/ltpara.dtx
@@ -17,7 +17,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltpara.dtx}
-             [2024/06/23 v1.0n LaTeX Kernel (paragraph hooks)]
+             [2024/06/29 v1.0n LaTeX Kernel (paragraph hooks)]
 % \iffalse
 %
 \documentclass{l3doc}
@@ -480,7 +480,7 @@
 %    ended by \cs{RawParEnd}\footnote{Technical note for those who
 %    know their \textit{\TeX book\/}: the \cs{RawParEnd} command
 %    invokes the original \TeX{} engine definition of \cs{par} that
-%    (soley) triggers the paragraph builder in \TeX{} when found
+%    (solely) triggers the paragraph builder in \TeX{} when found
 %    inside unrestricted horizontal mode and does nothing in other
 %    processing modes.}
 %    and not by \cs{par} (or a blank line), because the latter will execute
@@ -634,7 +634,7 @@
 % \glue(\parskip) 0.0 plus 1.0
 % \glue(\baselineskip) 5.16669
 %\end{verbatim}
-%   but now there is anothe \cs{parskip} glue (that is always 0pt):
+%   but now there is another \cs{parskip} glue (that is always 0pt):
 %\begin{verbatim}
 % \glue(\parskip) 0.0 plus 1.0
 % \glue(\parskip) 0.0
@@ -1087,7 +1087,7 @@
 %    it should get removed before the hook code gets added so we have
 %    to arrange for this removal.  
 %
-%    As in other simular cases, it maybe best to add here 
+%    As in other similar cases, it may be best to add here 
 %    a \cs{nobreak} in case the hook itself adds glue and thus 
 %    creates a non-explicit and unwanted potential breakpoont.  
 %    On the other hand (as has been argued) the code in the hook 

--- a/base/ltproperties.dtx
+++ b/base/ltproperties.dtx
@@ -30,7 +30,7 @@
 %<*driver> 
 % \fi
 \ProvidesFile{ltproperties.dtx}
-             [2024/04/17 v1.0e LaTeX Kernel (Properties)]
+             [2024/06/29 v1.0e LaTeX Kernel (Properties)]
 % \iffalse
 %
 \documentclass[full]{l3doc}
@@ -94,7 +94,7 @@
 % and labels which consist of lists of these properties. The reason for the
 % split is that individual labels will want to record some but not all
 % properties. For examples, a label concerned with position would track
-% the $x$ and $y$ co-ordinates of the current point, but not for example
+% the $x$ and $y$ coordinates of the current point, but not for example
 % the page number.
 %
 % In the current implementation, properties share a single namespace. This
@@ -404,7 +404,7 @@
 %
 % \begin{variable}{pagenum}
 %   (shipout) The current page as arabic number. This is suitable for integer operations and
-%   comparisions.
+%   comparisons.
 % \end{variable}
 % 
 % \begin{variable}{label}

--- a/base/ltsockets.dtx
+++ b/base/ltsockets.dtx
@@ -33,7 +33,7 @@
 %<*driver> 
 % \fi
 \ProvidesFile{ltsockets.dtx}
-             [2024/02/11 v0.9a LaTeX Kernel (Sockets)]
+             [2024/06/29 v0.9a LaTeX Kernel (Sockets)]
 % \iffalse
 %
 \documentclass{l3doc}
@@ -87,7 +87,7 @@
 % executing code for each command or environment in the document
 % source. Through various steps this code transforms the input and
 % eventually generates typeset output appearing in a \enquote{galley}
-% from which individual pages are cut off in an asyncronous way. This
+% from which individual pages are cut off in an asynchronous way. This
 % page generating process is normally not directly associated with
 % commands in the input\footnote{Excepts for directives such as
 %   \cs{newpage}.} but is triggered whenever the galley has received
@@ -208,7 +208,7 @@
 % simply calls some instance that implements the logic and that instance
 % is altered by selecting a different templates and/or adjusting their
 % parameters. However, in many cases customization through parameters is
-% overkill in such a case (or otherwise awkward, because paramerization
+% overkill in such a case (or otherwise awkward, because parameterization
 % is better done on a higher level instead of individually for small
 % blocks of code) and using the template mechanism just to replace one
 % block of code with a different one results in a fairly high
@@ -400,7 +400,7 @@
 %
 %   However, there is no requirement that sockets and
 %   hook names have to be different. In fact, if a certain action that
-%   could overwise be specified as hook code has to be executed always
+%   could otherwise be specified as hook code has to be executed always
 %   last (or first) one could ensure this by placing a socket (single
 %   action) after a hook (or vice versa) and using the same name to
 %   indicate the relationship, e.g., 

--- a/base/lttagging.dtx
+++ b/base/lttagging.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{lttagging.dtx}
-             [2024/06/10 v1.0b LaTeX Kernel (tagging support)]
+             [2024/06/29 v1.0b LaTeX Kernel (tagging support)]
 % \iffalse
 \documentclass{l3doc}
 \GetFileInfo{lttagging.dtx}
@@ -149,7 +149,7 @@
 \cs_new_eq:NN \ResumeTagging  \use_none:n
 %    \end{macrocode}
 %
-%    A simplified version of this defnition should move to
+%    A simplified version of this definition should move to
 %    \pkg{tagpdf} and dropped here, eventually.
 %    \begin{macrocode}
 \AddToHook{begindocument/before}{

--- a/base/testfiles/tlb-callbacks-002.luatex.tlg
+++ b/base/testfiles/tlb-callbacks-002.luatex.tlg
@@ -10,5 +10,5 @@ First try: fifth second third forth first
 Second try: fifth third forth second first
 Third try: fifth forth third second first
 Cycle:
-./ltluatex.lua:...: Cycle occured at second -> forth -> third -> second
+./ltluatex.lua:...: Cycle occurred at second -> forth -> third -> second
 Recovered: fifth second forth third first


### PR DESCRIPTION
Fixes a few small typos in the base dtx files.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
