### PR TITLE
small typo fixes for amsmath and tools

### DIFF
--- a/required/amsmath/amsmath.dtx
+++ b/required/amsmath/amsmath.dtx
@@ -85,7 +85,7 @@ Bug reports can be opened (category \texttt{#1}) at\\%
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\ProvidesPackage{amsmath}[2024/05/23 v2.17q AMS math features]
+\ProvidesPackage{amsmath}[2024/07/01 v2.17q AMS math features]
 %    \end{macrocode}
 %
 % \section{Catcode defenses}
@@ -166,7 +166,7 @@ Bug reports can be opened (category \texttt{#1}) at\\%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % \section{Flush-left equations [DMJ]}
 %
-%    The left margin of math enviroments is controlled by
+%    The left margin of math environments is controlled by
 %    \cs{@mathmargin}.  This can be set to \cs{@centering} to
 %    implement the default behaviour, i.e., centered equations, and to
 %    something else to implement the flushleft style.
@@ -208,7 +208,7 @@ Bug reports can be opened (category \texttt{#1}) at\\%
 %
 %    The next question is what happens when amsmath is used with
 %    one of the standard classes.  Unfortunately, \latex/ implements
-%    \opt{fleqn} somewhat clumsily; instead of paramaterizing the
+%    \opt{fleqn} somewhat clumsily; instead of parameterizing the
 %    definitions of the math structures (as I've attempted to do
 %    here), \fn{fleqn.clo} declares a dimen \cn{mathindent} that is
 %    much like my \cs{@mathmargin} and then redefines \cn\[, \cn\],
@@ -653,7 +653,7 @@ Foreign command \@backslashchar#1;\MessageBreak
 %
 %    the |withdelims| primitives do not work in xetex with OpenType
 %    fonts, and the relevant font dimen parameters are often not set
-%    in luatex as theer are no matching values in the OpenType Math
+%    in luatex as there are no matching values in the OpenType Math
 %    table, so here we use variants that use the font parameters if
 %    they are set, but scale using |\left\right| rather than the
 %    |withdelims| primitives.
@@ -3786,7 +3786,7 @@ and fix things up.}
 %    (In earlier versions of the code anything other than \texttt{b}
 %    or \texttt{t} was interpreted as \texttt{c} and the data was
 %    otherwise dropped.)
-% \changes{v2.17g}{2020/03/10}{Explicity test for b/t/c and return
+% \changes{v2.17g}{2020/03/10}{Explicitly test for b/t/c and return
 %    optional argument is different (gh/5)}
 %    \begin{macrocode}
 \def\ams@start@box#1{%
@@ -3919,7 +3919,7 @@ and fix things up.}
 %    \end{macrocode}
 %    If we picked up a bracket group by mistake here is the place to
 %    return it for processing.
-% \changes{v2.17g}{2020/03/10}{Explicity test for b/t/c and return
+% \changes{v2.17g}{2020/03/10}{Explicitly test for b/t/c and return
 %    optional argument is different (gh/5)}
 %    \begin{macrocode}
           \ams@return@opt@arg
@@ -4018,7 +4018,7 @@ and fix things up.}
             \crcr
 %    \end{macrocode}
 %    And put a mistaking picked up bracket group back:
-% \changes{v2.17g}{2020/03/10}{Explicity test for b/t/c and return
+% \changes{v2.17g}{2020/03/10}{Explicitly test for b/t/c and return
 %    optional argument is different (gh/5)}
 %    \begin{macrocode}
     \ams@return@opt@arg
@@ -4592,7 +4592,7 @@ trying to recover with `aligned'%
 %    \env{alignat} (i.e., the $n$th field of \cs{maxcolumn@widths}.)
 %    It expands to a \<dimen>, so it can be used as the right-hand
 %    side of a \<variable assignment> or \<arithmetic> statement.
-%    It's argument can be any \<number>, \<integer variable> or macro
+%    Its argument can be any \<number>, \<integer variable> or macro
 %    that expands to one of these.  [Check to make sure this is true.]
 %
 %    This is subtler than it looks.
@@ -5041,7 +5041,7 @@ trying to recover with `aligned'%
 %    Next we consider the case when equations are flush-left, but tags
 %    are on the right.  This case is somewhat more complicated than
 %    the previous one, since we can adjust the right margin by varying
-%    the inter-align separatin. Thus, when a tag is found to be too
+%    the inter-align separation. Thus, when a tag is found to be too
 %    close to its equation, we first attempt to decrease
 %    \cs{alignsep@} enough to move the equation off to an acceptable
 %    distance.  Only if that would require a value of \cs{alignsep@}
@@ -5078,7 +5078,7 @@ trying to recover with `aligned'%
 %    \cs{alignsep@} are both~0.  To get the number of align
 %    structures, we first count the number of columns by counting the
 %    number of entries in the \cs{fieldlengths@} for the current row.
-%    The effective length is calcuated by \cs{x@rcalc@width} and put
+%    The effective length is calculated by \cs{x@rcalc@width} and put
 %    in the temporary register \cs{@tempdimc}, using \cs{@tempdimb} as
 %    an auxiliary variable.
 %    \begin{macrocode}
@@ -5523,7 +5523,7 @@ trying to recover with `aligned'%
 %    \end{macro}
 %
 %  \begin{macro}{\place@tag}
-%    \cs{place@tag} takes care of the placment of tags in the
+%    \cs{place@tag} takes care of the placement of tags in the
 %    \env{align} environments.
 %    \begin{macrocode}
 \def\place@tag{%
@@ -6187,7 +6187,7 @@ Cannot use `split' here;\MessageBreak trying to recover with `aligned'}%
 %    in his \fn{amstex.doc} Spivak indicates those commands should never
 %    be used on a first or last line. Perhaps better to leave the
 %    question open unless/until real-life examples turn up.
-% \changes{v2.17m}{2022/02/03}{Make \cs{shoveright} robust (if def is not trival)}
+% \changes{v2.17m}{2022/02/03}{Make \cs{shoveright} robust (if def is not trivial)}
 %    \begin{macrocode}
 \iftagsleft@
     \protected\def\shoveright#1{%
@@ -6212,7 +6212,7 @@ Cannot use `split' here;\MessageBreak trying to recover with `aligned'}%
     }
 \fi
 %    \end{macrocode}
-% \changes{v2.17m}{2022/02/03}{Make \cs{shoveleft} robust (if def is not trival)}
+% \changes{v2.17m}{2022/02/03}{Make \cs{shoveleft} robust (if def is not trivial)}
 %    \begin{macrocode}
 \if@fleqn
     \def\shoveleft#1{#1}%
@@ -6576,14 +6576,14 @@ Cannot use `split' here;\MessageBreak trying to recover with `aligned'}%
 \def\mathdisplay@@pop{\the\mathdisplay@stack}
 %    \end{macrocode}
 %\changes{v2.17k}{2021/08/24}{Move the counter inside the equation and guard
-% with a mathopen for better compability with hyperref, issue gh/652}
+% with a mathopen for better compatibility with hyperref, issue gh/652}
 % As with hyperref incrementing the counter creates a box to raise the anchor
 % it should be in a place where is doesn't affect spacing.
 % Currently the code from hyperref is used to avoid this problem:
 % If fleqn isn't active the counter is set inside the equation and the potential
 % box guarded by a mathopen to avoid side effects on following unary symbols.
 % If fleqn is activated it has to be outside to avoid problems with labels.
-% This solution is temporary and not necessarly the best.
+% This solution is temporary and not necessarily the best.
 %    \begin{macrocode}
 \if@fleqn
 \renewenvironment{equation}{%
@@ -6637,7 +6637,7 @@ Cannot use `split' here;\MessageBreak trying to recover with `aligned'}%
 %
 % \section{Credits}
 %
-%    Much of the code for the \pkg{amsmath} package had its orgin in
+%    Much of the code for the \pkg{amsmath} package had its origin in
 %    \fn{amstex.tex}, written by Michael Spivak. The initial work of
 %    porting \fn{amstex.tex} to \fn{amstex.sty} was done in 1988--1989
 %    by Frank Mittelbach and Rainer Sch\"opf. In 1994 David M. Jones

--- a/required/tools/array.dtx
+++ b/required/tools/array.dtx
@@ -39,7 +39,7 @@
 %    \begin{macrocode}
 %<+package>\NeedsTeXFormat{LaTeX2e}[2024/06/01]
 %<+package>\ProvidesPackage{array}
-%<+package>         [2024/06/14 v2.6d Tabular extension package (FMi)]
+%<+package>         [2024/07/01 v2.6d Tabular extension package (FMi)]
 %
 % \fi
 %
@@ -715,7 +715,7 @@
 %
 % A similar problem happened when "\extrarowheight" was used. For that
 % reason m-cells now manually position the cell content which
-% allows to ignore this extra space request during the vertical aligment.
+% allows to ignore this extra space request during the vertical alignment.
 %
 %
 % \subsection{Bugs and Features}
@@ -1900,7 +1900,7 @@ Bug reports can be opened (category \texttt{#1}) at\\%
 %    is how much do we need to move down? If there is any
 %    =\arraystretch= in place then the first line will have some
 %    unusual height and we don't want to consider that when finding
-%    the middle point. So we substract from the cell height the height
+%    the middle point. So we subtract from the cell height the height
 %    of that strut. But of course we want to include the normal height
 %    of the first line (which would be something like =\ht\strutbox=)
 %    so we need to add that. On the other hand, when centering around
@@ -2656,7 +2656,7 @@ Bug reports can be opened (category \texttt{#1}) at\\%
 % \begin{macro}{\d@llarbegin}
 % \begin{macro}{\d@llarend}
 %    =\d@llar= has to be
-%    locally asigned since otherwise nested \textsf{tabular} and \textsf{array}
+%    locally assigned since otherwise nested \textsf{tabular} and \textsf{array}
 %    environments (via =\multicolumn=) are impossible.
 %    For 25 years or so =\@halignto= was set globally (to save space on the
 %    save stack, but that was a mistake: if there is a tabular in the
@@ -3440,7 +3440,7 @@ Bug reports can be opened (category \texttt{#1}) at\\%
 % \subsection{Implementing column types \texttt{w} and \texttt{W}}
 %
 % In TugBoat 38/2 an extension was presented that implemented two
-% aditional column types \texttt{w} and \texttt{W}. These have now
+% additional column types \texttt{w} and \texttt{W}. These have now
 % been added to the package itself.
 %
 %

--- a/required/tools/manifest.txt
+++ b/required/tools/manifest.txt
@@ -1,6 +1,6 @@
 % \iffalse meta-comment
 %
-% Copyright (C) 1993-2021
+% Copyright (C) 1993-2024
 % The LaTeX Project and any individual authors listed elsewhere
 % in this file.
 %
@@ -49,7 +49,7 @@ bm.dtx
         Access bold math symbols.
 
 calc.dtx
-        Infix arithmetic expresions. Contributed to the distribution by
+        Infix arithmetic expressions. Contributed to the distribution by
         Kresten Krab Thorup and Frank Jensen.
 
 enumerate.dtx
@@ -60,7 +60,7 @@ fileerr.dtx
         missing file error loop.
 
 fontsmpl.dtx
-        Package and test file for producing `font samples'
+        Package and test file for producing `font samples'.
 
 ftnright.dtx
         Place footnotes in the right hand column in two-column mode.
@@ -77,7 +77,7 @@ multicol.dtx
 
 rawfonts.dtx
         Preload fonts under the old internal font names of LaTeX2.09.
-        Not recomended for new packages, but may help when updating old
+        Not recommended for new packages, but may help when updating old
         files.
 
 shellesc.dtx
@@ -103,7 +103,7 @@ verbatim.dtx
         Flexible version of verbatim environment.
 
 xr.dtx
-       eXternall References. Extend \ref to access \label commands in
+       eXternal References. Extend \ref to access \label commands in
        other documents.
 
 xspace.dtx

--- a/required/tools/multicol.dtx
+++ b/required/tools/multicol.dtx
@@ -77,7 +77,7 @@
 %% not for the payment of a license fee per se (which might or might
 %% not follow from this evaluation).
 %%
-%% The license fee, if any, can be payed either to the LaTeX fund
+%% The license fee, if any, can be paid either to the LaTeX fund
 %% (see ltx3info.txt in the base LaTeX distribution) or to the author of
 %% the program who can be contacted at
 %%
@@ -98,7 +98,7 @@
 %<driver> \ProvidesFile{multicol.drv}
 % \fi
 %         \ProvidesFile{multicol.dtx}
-          [2024/06/28 v1.9h  multicolumn formatting (FMi)]
+          [2024/07/01 v1.9h  multicolumn formatting (FMi)]
 %
 %
 %
@@ -684,7 +684,7 @@
 %    this value will additionally trace the mark handling
 %    algorithm. It will show what marks are found, what marks are
 %    considered, etc. To fully understand this information you will
-%    probably have to read carefully trough the implementation.
+%    probably have to read carefully through the implementation.
 % \item[$\meta{number}\geq 4$.]  Setting \meta{number}\pagebreak[2] to
 %    such a high value will additionally place an |\hrule| into your
 %    output, separating the part of text which had already been
@@ -1950,7 +1950,7 @@
 %   the balancing happened in the output routine then \TeX{} reverts
 %   to the |\prevdepth| that was current before the OR once the OR has
 %   finished. In short |\prevdepth| is something you can't set
-%   globally it is alway local to the current list being built. Thus
+%   globally it is always local to the current list being built. Thus
 %   we need to set it back to zero here to avoid incorrect spacing.
 % \changes{v1.8h}{2014/09/12}{Set \cs{prevdepdth} for current vlist
 %   when returning from multicols environment}
@@ -2221,7 +2221,7 @@
 %  \begin{macro}{\multicolmindepthstring}
 %    The default minimum depth of each column corresponds to the depth
 %    of a `p' in the current font. This makes sense for Latin-based
-%    languages and was hard-wired intitially, but for Asian languages
+%    languages and was hard-wired initially, but for Asian languages
 %    it is better to use a zero depth (and alternatively one might
 %    want to use the depth of a strut or a parentheses). So we now
 %    offer a way to adjust this while maintaining backward
@@ -2467,7 +2467,7 @@
 %    If |\kept@firstmark| is non-empty then |\kept@botmark| must be
 %    non-empty too so we can use their values. Otherwise we use the
 %    value of |\kept@topmark| which was first initialized when we
-%    gathered the |\partical@page| and later on was updated to the
+%    gathered the |\partial@page| and later on was updated to the
 %    |\botmark| for the preceding page.
 %
 % \changes{v1.4a}{1992/02/14}{\cs{botmark} set to \cs{splitbotmark}}
@@ -2943,7 +2943,7 @@
 %    marks from this box. This has to be done \emph{before} we add a
 %    penalty of $-10000$ to the top of the box, otherwise only an
 %    empty box will be considered. But even that is not enough: the box
-%    may contain \cs{columnbreak}s in which case doing some artifical
+%    may contain \cs{columnbreak}s in which case doing some artificial
 %    splitting to get the marks out still fails to see all marks
 %    unless we take some special precaution in \cs{get@keptmarks}
 %    (which is now done).

--- a/required/tools/tools-overview.tex
+++ b/required/tools/tools-overview.tex
@@ -132,7 +132,7 @@
   Access bold math symbols.
 }%
 \entry{calc}{%
-  Infix arithmetic expresions. Contributed to the distribution by
+  Infix arithmetic expressions. Contributed to the distribution by
   Kresten Krab Thorup and Frank Jensen.
 }%
 \entry{dcolumn}{%
@@ -149,7 +149,7 @@
   missing file error loop.
 }%
 \entry{fontsmpl}{%
-  Package and test file for producing \emph{font samples}
+  Package and test file for producing \emph{font samples}.
 }%
 \entry{ftnright}{%
   Place footnotes in the right hand column in two-column mode.
@@ -173,7 +173,7 @@
 }%
 \entry{rawfonts}{%
   Preload fonts under the old internal font names of \LaTeX{}2.09.
-  Not recomended for new packages, but may help when updating old
+  Not recommended for new packages, but may help when updating old
   files.
 }%
 \entry{shellesc}{%
@@ -206,7 +206,7 @@
   Flexible version of verbatim environment.
 }%
 \entry{xr}{%
-  eXternall References. Extend \cs{ref} to access \cs{label} commands in
+  eXternal References. Extend \cs{ref} to access \cs{label} commands in
   other documents.
 }%
 \entry{xspace}{%


### PR DESCRIPTION
Fixes some trivial typos in amsmath.dtx and various tools files

# Internal housekeeping

## Status of pull request
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
