### PR TITLE
replace `\em` with `\emph` in alltt doc

### DIFF
--- a/base/alltt.dtx
+++ b/base/alltt.dtx
@@ -40,7 +40,7 @@
 %<package>\ProvidesPackage{alltt}
 %<driver>\ProvidesFile{alltt.drv}
 %\ProvidesFile{alltt.dtx}
-              [2024/02/08 v2.0g defines alltt environment]
+              [2024/07/07 v2.0g defines alltt environment]
 %
 %<*driver>
 \documentclass{ltxdoc}
@@ -83,7 +83,7 @@
 %   Here are some things you may want to do in an \Lenv{alltt}
 %   environment:
 %   \begin{itemize}
-%   \item Change fonts--e.g., by typing |{\em emphasized text\/}|
+%   \item Change fonts--e.g., by typing |\emph{emphasized text}|
 %
 %   \item Insert text from a file \file{foo.tex} by typing
 %    |\input{foo}|. Beware that each |<return>| starts a new line, so


### PR DESCRIPTION
~This PR replaces the use of old-style font command `\em` in alltt.dtx with `\emph` since the latter is recommended nowadays.~

As I was informed by @u-fischer, `\em` is not one of the old-style font commands. However, for the reasons expressed in my comment below, I still think this is a useful change.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
