### PR TITLE
Fix unpaired macrocode envs

### DIFF
--- a/base/fontdef.dtx
+++ b/base/fontdef.dtx
@@ -40,7 +40,7 @@
 %<driver, >\ProvidesFile{fontdef.drv}
 % \fi
 % \ProvidesFile{fontdef.dtx}
-           [2024/06/19 v3.0j LaTeX Kernel
+           [2024/07/08 v3.0j LaTeX Kernel
 % \iffalse
 %<text,   >   (Text font setup)
 %<math,   >   (Math font setup)
@@ -539,7 +539,6 @@
 %<*text|latexrelease>
 %<latexrelease>\IncludeInRelease{2020/02/02}%
 %<latexrelease>                 {\updefault}{font defaults change}%
-%    \begin{macrocode}
 \renewcommand\updefault{up}
 %    \end{macrocode}
 %    We append \cs{@empty} to the series value so that we can detect

--- a/base/ltcmdhooks.dtx
+++ b/base/ltcmdhooks.dtx
@@ -20,7 +20,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltcmdhooks.dtx}
-             [2024/04/17 v1.0j LaTeX Kernel (Command hooks)]
+             [2024/07/08 v1.0j LaTeX Kernel (Command hooks)]
 % \iffalse
 %
 \documentclass{l3doc}
@@ -1530,6 +1530,7 @@
 %<latexrelease>                 {cmd~hooks~with~args}
 \cs_new_protected:Npn \@@_patch_retokenize:Nnnn #1 #2 #3 #4
   {
+%    \end{macrocode}
 %   Here, when patching by retokenization, we can only guess the number
 %   of arguments of the macro.
 % \changes{v1.0h}{2023/05/21}

--- a/base/ltfinal.dtx
+++ b/base/ltfinal.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltfinal.dtx}
-             [2024/02/08 v2.3c LaTeX Kernel (Final Settings)]
+             [2024/07/08 v2.3c LaTeX Kernel (Final Settings)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltfinal.dtx}
@@ -930,7 +930,7 @@
 %
 %    \begin{macrocode}
 %<*2ekernel>
-%    \begin{macrocode}
+%    \end{macrocode}
 %
 % We temporarily define |\reserved@a| to apply |\reserved@c| to all the
 % numbers in the range of its arguments.

--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -32,7 +32,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{lthooks.dtx}
-             [2024/06/13 v1.1h LaTeX Kernel (hooks)]
+             [2024/07/08 v1.1h LaTeX Kernel (hooks)]
 % \iffalse
 %
 \documentclass{l3doc}
@@ -7633,6 +7633,7 @@
 %    \begin{macrocode}
 \NewDocumentCommand \SetDefaultHookLabel { m }
   { \@@_set_default_hook_label:n {#1} }
+%    \end{macrocode}
 %
 %   The label is only automatically updated with \cs{@onefilewithoptions}
 %   (\cs{usepackage} and \cs{documentclass}), but some packages, like

--- a/base/ltpictur.dtx
+++ b/base/ltpictur.dtx
@@ -32,7 +32,7 @@
 %<*driver>
 % \fi
       \ProvidesFile{ltpictur.dtx}
-                      [2021/04/20 v1.2b LaTeX Kernel (Picture Mode)]
+                      [2024/07/08 v1.2b LaTeX Kernel (Picture Mode)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltpictur.dtx}
@@ -1413,7 +1413,6 @@
 %    \begin{macrocode}
 \newif\if@ovvline \@ovvlinetrue
 \newif\if@ovhline \@ovhlinetrue
-%    \begin{macrocode}
 %</2ekernel|latexrelease>
 %<latexrelease>\EndIncludeInRelease
 %<latexrelease>\IncludeInRelease{0000/00/00}%


### PR DESCRIPTION
This PR fixes all unpaired `macrocode` envs found in the latest `source2e.pdf`.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] <s>Version and</s> date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
