### PR TITLE
fix small typos in latex-lab

### DIFF
--- a/required/firstaid/latex2e-first-aid-for-external-files.dtx
+++ b/required/firstaid/latex2e-first-aid-for-external-files.dtx
@@ -111,7 +111,7 @@
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\def\LaTeXFirstAidDate{2024/06/25}
+\def\LaTeXFirstAidDate{2024/07/05}
 \def\LaTeXFirstAidVersion{v1.1f}
 %    \end{macrocode}
 %
@@ -343,7 +343,7 @@
 %    It will be replaced when the ``configuration points'' interface
 %    for \LaTeX{} becomes available. At that point the package will be
 %    able to set up a different strategy for doing shipouts and
-%    without the need to overrite a primitive (which it did in the
+%    without the need to overwrite a primitive (which it did in the
 %    past and which we do below) and then this code here can be taken
 %    out again.
 %    \begin{macrocode}
@@ -446,7 +446,7 @@
 %    the classic \TeX{} implementation but with the extended
 %    allocation possibilities of all modern engines is no longer the
 %    case and there is a point where the allocations take a ``jump''
-%    breaking the odering assumption. These days we are fairly close
+%    breaking the ordering assumption. These days we are fairly close
 %    to that point and depending on how many packages are loaded
 %    before \pkg{bigfoot} the package breaks.
 %

--- a/required/latex-lab/latex-lab-amsmath.dtx
+++ b/required/latex-lab/latex-lab-amsmath.dtx
@@ -66,7 +66,7 @@
 % \subsection{File declaration}
 %    \begin{macrocode}
 \ProvidesFile{latex-lab-amsmath.ltx}
-        [2024-02-12 v0.1b amsmath adaptions]
+        [2024-07-05 v0.1b amsmath adaptions]
 %    \end{macrocode}
 % \subsection{Tagpdf support}
 % To make the code independent from tagging being loaded and active
@@ -200,8 +200,8 @@
 %    \end{macrocode}
 %
 % \subsection{\cs{pmb}}
-% \cs{pmb} prints is argument three times. For tagging we must mark
-% two of occurences as artifact.
+% \cs{pmb} prints its argument three times. For tagging we must mark
+% two of occurrences as artifact.
 % For luatex the attributes in the box must be reset, for this
 % we switch to expl3-boxes.
 %    \begin{macrocode}

--- a/required/latex-lab/latex-lab-bib.dtx
+++ b/required/latex-lab/latex-lab-bib.dtx
@@ -16,7 +16,7 @@
 %
 % for those people who are interested or want to report an issue.
 %
-\def\ltlabbibdate{2024-02-12}
+\def\ltlabbibdate{2024-07-05}
 \def\ltlabbibversion{0.81b}
 %<*driver>
 \documentclass{l3doc}
@@ -128,7 +128,7 @@
 %
 % \begin{function}{\@extra@binfo,\@extra@b@citeb}
 % 
-% These are taken from hyperref, they are for chapterbib compability (and also
+% These are taken from hyperref, they are for chapterbib compatibility (and also
 % signal to chapterbib not to change the citation commands)
 % \end{function}
 % 
@@ -157,7 +157,7 @@
 %    \end{macrocode}
 
 % \begin{macro}{\@extra@binfo,\@extra@b@citeb}
-% These are taken from hyperref, they are for chapterbib compability (and also
+% These are taken from hyperref, they are for chapterbib compatibility (and also
 % signal to chapterbib not to change the citation commands)
 %    \begin{macrocode}
 \providecommand*\@extra@binfo{}%
@@ -270,7 +270,7 @@
 %    \end{macrocode}
 % Now we add the tagging structure.
 % TODO: with the next tagpdf version it should no longer be 
-% needed to exand the ref key.
+% needed to expand the ref key.
 %    \begin{macrocode}
 \AddToHookWithArguments{bibcite/before}
   {
@@ -305,7 +305,7 @@
 %  We need in part different code for both systems: 
 %  with biblatex we have to take care that only the first
 %  structure sets a label, and if 
-%  hyperref is not loaded (or deactived) we will need additional code
+%  hyperref is not loaded (or deactivated) we will need additional code
 %  but this currently doesn't exist.
 %  We assume that no document loads both package -- that will probably break.
 %    \begin{macrocode}

--- a/required/latex-lab/latex-lab-block.dtx
+++ b/required/latex-lab/latex-lab-block.dtx
@@ -9,7 +9,7 @@
 %
 %    https://www.latex-project.org/lppl.txt
 %
-\def\ltlabblockdate{2024-03-23}
+\def\ltlabblockdate{2024-07-05}
 \def\ltlabblockversion{0.8n}
 %<*driver>
 \documentclass[kernel]{l3doc}
@@ -341,7 +341,7 @@
 %
 %    The idea of a \key{heading} key needs some further
 %    thoughts. Maybe instead the object type should accept a second
-%    argument and receive input for such a headding from the document
+%    argument and receive input for such a heading from the document
 %    level instead.
 %
 %    The names of the keys need further thoughts and some
@@ -474,7 +474,7 @@
 %    \>\>\> The paragraph text before the display element \ldots\\
 %    \>\>   \struct{/text}\\
 %    \>\>   \struct{display element structure}\\
-%    \>\>\>  Content of the display structure possiblly involving inner \struct{text-unit} tags\\
+%    \>\>\>  Content of the display structure possibly involving inner \struct{text-unit} tags\\
 %    \>\>   \struct{/display element structure}\\
 %    \>\>   \struct{text}\\
 %    \>\>\> \ldots{} continuing the outer paragraph text\\
@@ -722,7 +722,7 @@
                             blockenv implementation]
 %    \end{macrocode}
 %
-%   Generell kernel changes, also loaded by the sec and toc code.
+%   General kernel changes, also loaded by the sec and toc code.
 %    \begin{macrocode}
 \RequirePackage{latex-lab-kernel-changes}
 %    \end{macrocode}
@@ -1981,7 +1981,7 @@
 %    \cs{parskip} and some other housekeeping, unless this block is inside a list and the list
 %    \cs{item} has not yet placed. In that case the vertical
 %    space and penalty us suppressed. This
-%    is controled through the legacy switches \texttt{@noparitem},
+%    is controlled through the legacy switches \texttt{@noparitem},
 %    \texttt{minipage}, and \texttt{@nobreak}.
 %    \begin{macrocode}
     \legacy_if:nTF { @noparitem }
@@ -2520,7 +2520,7 @@
 %
 % \begin{macro}{\item}
 %   Here we already have all the building blocks.  Complain in math
-%   mode.  Distingusih between first item (do necessary tagging) and
+%   mode.  Distinguish between first item (do necessary tagging) and
 %    later items \cs{@@_inter_item:} to
 %   cleanly close what's before, then call \cs{@@_item_instance:n} (which
 %   calls \cs{UseInstance}\{item\}\marg{instance}) to prepare the
@@ -2751,7 +2751,7 @@
   \socket_assign_plug:nn{tagsupport/block-endpe}{on}
 %    \end{macrocode}
 %
-%    Handle the tag name and attribute classess using the key values
+%    Handle the tag name and attribute classes using the key values
 %    from the current list instance.
 %    \begin{macrocode}
   \tl_if_empty:NTF \l_@@_tag_name_tl
@@ -3173,7 +3173,7 @@
 %                   block quoteblock-4,
 %                   block quoteblock-5,
 %                   block quoteblock-6 }
-%    Default layout is to indent equaly from both side.
+%    Default layout is to indent equally from both sides.
 %    \begin{macrocode}
 \DeclareInstance{block}{quoteblock-1}{display}
   { rightmargin = \KeyValue{leftmargin} }

--- a/required/latex-lab/latex-lab-float.dtx
+++ b/required/latex-lab/latex-lab-float.dtx
@@ -16,7 +16,7 @@
 %
 % for those people who are interested or want to report an issue.
 %
-\def\ltlabfloatdate{2024-03-23}
+\def\ltlabfloatdate{2024-07-05}
 \def\ltlabfloatversion{0.81e}
 %<*driver>
 \documentclass{l3doc}
@@ -64,7 +64,7 @@
 % 
 % A special type, called a H-float, (provided by the float package)
 % is always placed in the main text stream and does not
-% necessarly preserve the order with normal floats of the same type: It is basically
+% necessarily preserve the order with normal floats of the same type: It is basically
 % a minipage with a caption.
 % 
 % Floats typically contain a figure (or a table, etc.) and a caption, 

--- a/required/latex-lab/latex-lab-footnotes.dtx
+++ b/required/latex-lab/latex-lab-footnotes.dtx
@@ -17,7 +17,7 @@
 %
 % for those people who are interested or want to report an issue.
 %
-\def\ltlabfootnotedate{2024-03-12}
+\def\ltlabfootnotedate{2024-07-05}
 \def\ltlabfootnoteversion{0.8d}
 
 %<*driver>
@@ -636,7 +636,7 @@
 % number to setup the reference and the link.
 %
 % The structure related to the \cs{footref} is added to the end of the \texttt{/Ref} array of the note and so the
-% \texttt{/Ref} array doesn't necessarly reflect the order of the marks in the document. It would probably
+% \texttt{/Ref} array doesn't necessarily reflect the order of the marks in the document. It would probably
 % be possible to change this, but it is not clear if it actually matters and so it worth the additional coding
 % and processing.
 %
@@ -1673,7 +1673,7 @@
 %
 % \subsubsection{\pkg{memoir}}
 % The \pkg{memoir} class redefines various internal commands to inject its
-% hooks and addtional code. The following reinstates the kernel command and
+% hooks and additional code. The following reinstates the kernel command and
 % so probably breaks various options of \pkg{memoir}, but without the
 % changes it errors anyway. The \pkg{footmisc} package should be used to change
 % for example to para footnotes.
@@ -2446,7 +2446,7 @@
 
 % This can use the default interface, except that a negative value for
 % \footnotemargin makes little sense, so we test for this and warn if
-% necessary. But -\maxdimen is ok again, so would need to be a litte bit more elaborate.
+% necessary. But -\maxdimen is ok again, so would need to be a little bit more elaborate.
 %
 
 %\AddToHook{fntext/para}{
@@ -2483,7 +2483,7 @@
         \leavevmode
 %    \end{macrocode}
 %    Typesetting the mark twice means that one can't have any material
-%    inside that gets unhappy in that case. Tha shouldn't be a
+%    inside that gets unhappy in that case. That shouldn't be a
 %    problem, but perhaps we have to come up with a more elaborate
 %    solution in the end.
 %    \begin{macrocode}

--- a/required/latex-lab/latex-lab-graphic.dtx
+++ b/required/latex-lab/latex-lab-graphic.dtx
@@ -15,7 +15,7 @@
 %    https://github.com/latex3/latex2e/required/latex-lab
 %
 % for those people who are interested or want to report an issue.
-\def\ltlabgraphicdate{2024-03-13}
+\def\ltlabgraphicdate{2024-07-05}
 \def\ltlabgraphicversion{0.80d}
 %
 %<*driver>
@@ -78,7 +78,7 @@
 % The value of a \texttt{BBox} is an array of four numbers that gives the 
 % coordinates of the left, bottom, right, and top edges 
 % of the structure element’s bounding box. That is the rectangle that completely encloses
-% its \emph{visible} content so not necessarly the TeX bounding box: 
+% its \emph{visible} content so not necessarily the TeX bounding box: 
 % if \texttt{viewport} or \texttt{trim} is used and the
 % graphic is not clipped, the visible content can be larger. 
 %  
@@ -146,8 +146,8 @@
 %    \item[\texttt{artifact}] When used the graphic will be tagged as artifact. This doesn't
 %     require a \texttt{BBox} and so works also in some of the not yet supported cases described
 %     above.
-%   \item[\texttt{false}] When used tagging will be stopped completly. It is then the 
-%   responsability of the surrounding code to add appropriate tagging commands.
+%   \item[\texttt{false}] When used tagging will be stopped completely. It is then the 
+%   responsibility of the surrounding code to add appropriate tagging commands.
 %   \item[\meta{name}] Other values will be used as tag names in the structure. If the tag is not
 %   known as a structure tag you will get an warning from tagpdf. The default name is currently
 %   \texttt{Figure}
@@ -291,7 +291,7 @@
 %   ,\l_@@_graphic_trim_uy_fp
 %  }
 % A bunch of fp-variables (we don't use tl-vars, 
-% to avoid to have to take care about minus signs everwhere) 
+% to avoid to have to take care about minus signs everywhere) 
 %    \begin{macrocode}
 \fp_new:N\l_@@_graphic_sin_fp 
 \fp_new:N\l_@@_graphic_cos_fp

--- a/required/latex-lab/latex-lab-marginpar.dtx
+++ b/required/latex-lab/latex-lab-marginpar.dtx
@@ -18,7 +18,7 @@
 %
 % for those people who are interested or want to report an issue.
 %
-\def\ltlabmarginpardate{2024-02-12}
+\def\ltlabmarginpardate{2024-07-05}
 \def\ltlabmarginparversion{0.85b}
 
 %<*driver>
@@ -72,7 +72,7 @@
 % They can be tagged either as artifacts (if they are merely distracting decoration),
 % as small headings before the paragraph, or as |Aside|. Unlike the PDF 1.7 fallback |Note|
 % the structure |Aside| is not allowed inside |P|,
-% so if |Aside| is used, it must be placed before or after the current |P| in the surounding |text-unit|, 
+% so if |Aside| is used, it must be placed before or after the current |P| in the surrounding |text-unit|, 
 % or it must split the |P|. Splitting is probably not so good as 
 % |\marginpar| is often used somewhere in the middle of sentence. 
 % The best default is probably to use |Aside|, find the parent |text-unit| and add it there. 

--- a/required/latex-lab/latex-lab-math.dtx
+++ b/required/latex-lab/latex-lab-math.dtx
@@ -19,7 +19,7 @@
 % for those people who are interested or want to report an issue.
 %
 %
-\def\ltlabmathdate{2024-04-16}
+\def\ltlabmathdate{2024-07-05}
 \def\ltlabmathversion{0.5j}
 %
 %<*driver>
@@ -306,7 +306,7 @@
 %  
 %  As mentioned above the MathML-AF can be suppressed for the equations in a group with 
 %  |math/mathml/AF=false|, or
-%  completly by setting |math/mathml/sources=| in the preamble. 
+%  completely by setting |math/mathml/sources=| in the preamble. 
 %  
 %  Files embedded in a PDF can be listed in the attachments panel of a PDF viewer.
 %  This is probably not so useful for lots of small files (but one could create
@@ -900,7 +900,7 @@
 %    \end{macrocode}
 % \end{plugdecl}
 % 
-% We probably will want to test different tagging receipes.
+% We probably will want to test different tagging recipes.
 % \begin{plugdecl}{default}
 %    \begin{macrocode}
 \socket_new_plug:nnn

--- a/required/latex-lab/latex-lab-namespace.dtx
+++ b/required/latex-lab/latex-lab-namespace.dtx
@@ -26,7 +26,7 @@
 % \fi
 % \title{Prototype reimplementation of \LaTeXe{}'s role mapping}
 % \author{\LaTeX{} Project, initial implementation Ulrike Fischer}
-% \date{v0.8b 2024-03-24}
+% \date{v0.8b 2024-07-05}
 %
 % \maketitle
 %
@@ -37,7 +37,7 @@
 % \section{Introduction}
 %
 % This short file collects tag names from the \LaTeX{} namespace and their role mapping used
-% in the latex-lab files. The names and the roles are not necessarly the final ones!
+% in the latex-lab files. The names and the roles are not necessarily the final ones!
 % 
 % Later settings of the same tag overwrite previous settings.
 % The syntax of a line is a list of three strings ending with commas:

--- a/required/latex-lab/latex-lab-sec.dtx
+++ b/required/latex-lab/latex-lab-sec.dtx
@@ -16,7 +16,7 @@
 %
 % for those people who are interested or want to report an issue.
 %
-\def\ltlabsecdate{2024-02-12}
+\def\ltlabsecdate{2024-07-05}
 \def\ltlabsecversion{0.84c}
 %<*driver>
 \documentclass[kernel]{l3doc}
@@ -121,7 +121,7 @@
 %  commands must be at the right grouping level.
 %  \end{itemize}
 %  
-%  \subsection{Funktions and keys}
+%  \subsection{Functions and keys}
 %
 % \begin{function}{\tag_tool:n,\tagtool}
 % 
@@ -138,7 +138,7 @@
 %     to allow e.g. to put an epigraph or similar in front.
 %     
 %  \item The number in \cs{part} and  \cs{chapter} is currently not correctly 
-%  tagged as a \texttt{Lbl} as this requires to redefine the internal (class dependant)
+%  tagged as a \texttt{Lbl} as this requires to redefine the internal (class dependent)
 %  commands too.
 %     
 %  \end{itemize}
@@ -376,7 +376,7 @@
          \tag_struct_begin:n{tag=part,title=#1}
 %    \end{macrocode}
 % We remap here the text-unit from the paragraph to NonStruct.
-% It would be better to suppress it completly as with the other
+% It would be better to suppress it completely as with the other
 % sectioning commands, but this would require to redefine \cs{@spart}
 % and \cs{@part}, as there is the grouping, and these commands are
 % all slightly different in the standard classes. So this is delayed 

--- a/required/latex-lab/latex-lab-table.dtx
+++ b/required/latex-lab/latex-lab-table.dtx
@@ -16,7 +16,7 @@
 %
 % for those people who are interested or want to report an issue.
 %
-\def\ltlabtbldate{2024-05-25}
+\def\ltlabtbldate{2024-07-05}
 \def\ltlabtblversion{0.85i}
 %<*driver>
 \documentclass{l3doc}
@@ -432,7 +432,7 @@
       {
         \@@_trace:n
           {==>~
-            stucture~stored~for~row~\int_use:N\g_@@_row_int :~
+            structure~stored~for~row~\int_use:N\g_@@_row_int :~
             \seq_use:Nn \g_@@_struct_cur_seq {,}
           }
       }
@@ -711,7 +711,7 @@
     \tag_mc_end_push:
 %    \end{macrocode}
 %    Close the P-chunk. This assumes that para-tagging is active.
-%    For nested tables that is not necessarly true, so we test for it.
+%    For nested tables that is not necessarily true, so we test for it.
 %    \begin{macrocode}
      \bool_lazy_and:nnT
       { \bool_if_exist_p:N \l__tag_para_bool } { \l__tag_para_bool }
@@ -729,7 +729,7 @@
     \tag_struct_end:
 %    \end{macrocode}
 % reopen the P-chunk. This assumes that para-tagging is active.
-% For nested tables that is not necessarly true, so we test for it.
+% For nested tables that is not necessarily true, so we test for it.
 %    \begin{macrocode}
     \bool_lazy_and:nnT
       { \bool_if_exist_p:N \l__tag_para_bool } { \l__tag_para_bool }
@@ -893,7 +893,7 @@
   }
 %    \end{macrocode}
 % This are the old key names kept for now for 
-% compability. They will got at some time.
+% compatibility. They will got at some time.
 %    \begin{macrocode}
 \keys_define:nn { __tag / setup }
   {

--- a/required/latex-lab/latex-lab-testphase.dtx
+++ b/required/latex-lab/latex-lab-testphase.dtx
@@ -47,7 +47,7 @@
 %
 %    Currently the values |phase-I|, |phase-II|, |phase-III| and |new-or| (bundles |new-or-1|
 %    and |new-or-2|) are provided.
-%    |tagpdf| is an undocumented alias for |phase-II| which is kept for compability.
+%    |tagpdf| is an undocumented alias for |phase-II| which is kept for compatibility.
 %    The value |math| combines various math related files.
 %
 % \StopEventually{\setlength\IndexMin{200pt}  \PrintIndex  }

--- a/required/latex-lab/testfiles-table-luatex/table-001.tlg
+++ b/required/latex-lab/testfiles-table-luatex/table-001.tlg
@@ -20,7 +20,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> (endarray) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 9
+==> structure stored for row 1: 9
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.
@@ -42,7 +42,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> (endarray) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 15
+==> structure stored for row 1: 15
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.
@@ -64,7 +64,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> (endarray) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 21
+==> structure stored for row 1: 21
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.
@@ -86,7 +86,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> (endarray) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 27
+==> structure stored for row 1: 27
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.

--- a/required/latex-lab/testfiles-table-luatex/table-002.tlg
+++ b/required/latex-lab/testfiles-table-luatex/table-002.tlg
@@ -32,7 +32,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 9,10,13
+==> structure stored for row 1: 9,10,13
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/colspan' containing plug 'code' used.
@@ -46,7 +46,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 2: 15,-15,16
+==> structure stored for row 2: 15,-15,16
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -68,7 +68,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 3,2,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 3: 18,19,22
+==> structure stored for row 3: 18,19,22
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -86,7 +86,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 4,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 4: 24,25,26
+==> structure stored for row 4: 24,25,26
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -104,7 +104,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 5,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 5: 28,29,30
+==> structure stored for row 5: 28,29,30
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -118,7 +118,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 6: 32,33,-33
+==> structure stored for row 6: 32,33,-33
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/colspan' containing plug 'code' used.
@@ -128,7 +128,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 7: 35,-35,-35
+==> structure stored for row 7: 35,-35,-35
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/colspan' containing plug 'code' used.
@@ -147,7 +147,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 8,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 8: 37,38,39
+==> structure stored for row 8: 37,38,39
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -165,7 +165,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 9,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 9: 41,42,43
+==> structure stored for row 9: 41,42,43
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.

--- a/required/latex-lab/testfiles-table-luatex/table-003.tlg
+++ b/required/latex-lab/testfiles-table-luatex/table-003.tlg
@@ -32,7 +32,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 9,10,13
+==> structure stored for row 1: 9,10,13
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -55,7 +55,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> (endarray) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 18,19
+==> structure stored for row 1: 18,19
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 2,1,1 (max: 3)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.
@@ -71,7 +71,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 2,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 2: 15,20,21
+==> structure stored for row 2: 15,20,21
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -89,7 +89,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 3,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 3: 23,24,25
+==> structure stored for row 3: 23,24,25
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.

--- a/required/latex-lab/testfiles-table-luatex/table-004-tabularx.tlg
+++ b/required/latex-lab/testfiles-table-luatex/table-004-tabularx.tlg
@@ -252,7 +252,7 @@ braces):
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 9,10,13
+==> structure stored for row 1: 9,10,13
 Package tagpdf Info: closing structure 8 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -414,7 +414,7 @@ braces):
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 18,19
+==> structure stored for row 1: 18,19
 Package tagpdf Info: closing structure 17 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -518,7 +518,7 @@ braces):
 >  {{text-unit}{Part}}
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
-==> stucture stored for row 2: 15,20,21
+==> structure stored for row 2: 15,20,21
 Package tagpdf Info: closing structure 14 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -639,7 +639,7 @@ braces):
 >  {{text-unit}{Part}}
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
-==> stucture stored for row 3: 23,24,25
+==> structure stored for row 3: 23,24,25
 Package tagpdf Info: closing structure 22 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -930,7 +930,7 @@ braces):
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 31,32,35
+==> structure stored for row 1: 31,32,35
 Package tagpdf Info: closing structure 30 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1170,7 +1170,7 @@ braces):
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 40,41
+==> structure stored for row 1: 40,41
 Package tagpdf Info: closing structure 39 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1274,7 +1274,7 @@ braces):
 >  {{text-unit}{Part}}
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
-==> stucture stored for row 2: 37,44,45
+==> structure stored for row 2: 37,44,45
 Package tagpdf Info: closing structure 36 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1395,7 +1395,7 @@ braces):
 >  {{text-unit}{Part}}
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
-==> stucture stored for row 3: 47,48,49
+==> structure stored for row 3: 47,48,49
 Package tagpdf Info: closing structure 46 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer

--- a/required/latex-lab/testfiles-table-luatex/table-005.tlg
+++ b/required/latex-lab/testfiles-table-luatex/table-005.tlg
@@ -181,7 +181,7 @@ braces):
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 11
+==> structure stored for row 1: 11
 Package tagpdf Info: closing structure 10 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer

--- a/required/latex-lab/testfiles-table-luatex/table-006-longtable.tlg
+++ b/required/latex-lab/testfiles-table-luatex/table-006-longtable.tlg
@@ -121,7 +121,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 1 row: 1 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 7,8,9
+==> structure stored for row 1: 7,8,9
 Package tagpdf Info: closing structure 6 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -234,7 +234,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 2 row: 2 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 2: 11,12,13
+==> structure stored for row 2: 11,12,13
 Package tagpdf Info: closing structure 10 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -347,7 +347,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 3 row: 3 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 3: 15,16,17
+==> structure stored for row 3: 15,16,17
 Package tagpdf Info: closing structure 14 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -460,7 +460,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 4 row: 4 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 4: 19,20,21
+==> structure stored for row 4: 19,20,21
 Package tagpdf Info: closing structure 18 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -573,7 +573,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 5 row: 5 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 5: 23,24,25
+==> structure stored for row 5: 23,24,25
 Package tagpdf Info: closing structure 22 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -686,7 +686,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 6 row: 6 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 6: 27,28,29
+==> structure stored for row 6: 27,28,29
 Package tagpdf Info: closing structure 26 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -799,7 +799,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 7 row: 7 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 7: 31,32,33
+==> structure stored for row 7: 31,32,33
 Package tagpdf Info: closing structure 30 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -912,7 +912,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 8 row: 8 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 8: 35,36,37
+==> structure stored for row 8: 35,36,37
 Package tagpdf Info: closing structure 34 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1025,7 +1025,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 9 row: 9 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 9: 39,40,41
+==> structure stored for row 9: 39,40,41
 Package tagpdf Info: closing structure 38 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1138,7 +1138,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 10 row: 10 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 10: 43,44,45
+==> structure stored for row 10: 43,44,45
 Package tagpdf Info: closing structure 42 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1251,7 +1251,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 11 row: 11 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 11: 47,48,49
+==> structure stored for row 11: 47,48,49
 Package tagpdf Info: closing structure 46 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1364,7 +1364,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 12 row: 12 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 12: 51,52,53
+==> structure stored for row 12: 51,52,53
 Package tagpdf Info: closing structure 50 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1477,7 +1477,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 13 row: 13 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 13: 55,56,57
+==> structure stored for row 13: 55,56,57
 Package tagpdf Info: closing structure 54 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1590,7 +1590,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 14 row: 14 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 14: 59,60,61
+==> structure stored for row 14: 59,60,61
 Package tagpdf Info: closing structure 58 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1703,7 +1703,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 15 row: 15 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 15: 63,64,65
+==> structure stored for row 15: 63,64,65
 Package tagpdf Info: closing structure 62 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1816,7 +1816,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 16 row: 16 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 16: 67,68,69
+==> structure stored for row 16: 67,68,69
 Package tagpdf Info: closing structure 66 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1929,7 +1929,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 17 row: 17 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 17: 71,72,73
+==> structure stored for row 17: 71,72,73
 Package tagpdf Info: closing structure 70 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -2042,7 +2042,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 18 row: 18 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 18: 75,76,77
+==> structure stored for row 18: 75,76,77
 Package tagpdf Info: closing structure 74 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -2155,7 +2155,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 19 row: 19 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 19: 79,80,81
+==> structure stored for row 19: 79,80,81
 Package tagpdf Info: closing structure 78 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -2268,7 +2268,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 20 row: 20 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 20: 83,84,85
+==> structure stored for row 20: 83,84,85
 Package tagpdf Info: closing structure 82 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -2381,7 +2381,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 21 row: 21 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 21: 87,88,89
+==> structure stored for row 21: 87,88,89
 Package tagpdf Info: closing structure 86 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer

--- a/required/latex-lab/testfiles-table-luatex/table-007-longtable.tlg
+++ b/required/latex-lab/testfiles-table-luatex/table-007-longtable.tlg
@@ -121,7 +121,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 1 row: 1 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 7,8,9
+==> structure stored for row 1: 7,8,9
 Package tagpdf Info: closing structure 6 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -278,7 +278,7 @@ braces):
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 14,15
+==> structure stored for row 1: 14,15
 Package tagpdf Info: closing structure 13 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -375,7 +375,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 2 row: 2 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 2: 11,16,17
+==> structure stored for row 2: 11,16,17
 Package tagpdf Info: closing structure 10 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -488,7 +488,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 3 row: 3 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 3: 19,20,21
+==> structure stored for row 3: 19,20,21
 Package tagpdf Info: closing structure 18 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -601,7 +601,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 4 row: 4 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 4: 23,24,25
+==> structure stored for row 4: 23,24,25
 Package tagpdf Info: closing structure 22 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -714,7 +714,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 5 row: 5 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 5: 27,28,29
+==> structure stored for row 5: 27,28,29
 Package tagpdf Info: closing structure 26 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -827,7 +827,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 6 row: 6 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 6: 31,32,33
+==> structure stored for row 6: 31,32,33
 Package tagpdf Info: closing structure 30 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -940,7 +940,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 7 row: 7 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 7: 35,36,37
+==> structure stored for row 7: 35,36,37
 Package tagpdf Info: closing structure 34 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1025,7 +1025,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 8 row: 8 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 8: 39,-39,40
+==> structure stored for row 8: 39,-39,40
 Package tagpdf Info: closing structure 38 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1138,7 +1138,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 9 row: 9 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 9: 42,43,44
+==> structure stored for row 9: 42,43,44
 Package tagpdf Info: closing structure 41 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1223,7 +1223,7 @@ braces):
 ==> (@arraycr) This row needs 0 additional cell(s)
 --longtable--> chunk row: 10 row: 10 column: 2
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 10: 46,47,-47
+==> structure stored for row 10: 46,47,-47
 Package tagpdf Info: closing structure 45 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1336,7 +1336,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 11 row: 11 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 11: 49,50,51
+==> structure stored for row 11: 49,50,51
 Package tagpdf Info: closing structure 48 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer

--- a/required/latex-lab/testfiles-table-luatex/table-008-multi.tlg
+++ b/required/latex-lab/testfiles-table-luatex/table-008-multi.tlg
@@ -21,7 +21,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 9,-9,-9
+==> structure stored for row 1: 9,-9,-9
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -39,7 +39,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 2,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 2: 11,12,13
+==> structure stored for row 2: 11,12,13
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.
@@ -70,7 +70,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 1,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 1: 19,20,21
+==> structure stored for row 1: 19,20,21
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/colspan' containing plug 'code' used.
@@ -80,7 +80,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 2: 23,-23,-23
+==> structure stored for row 2: 23,-23,-23
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -98,7 +98,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 3,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 3: 25,26,27
+==> structure stored for row 3: 25,26,27
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.

--- a/required/latex-lab/testfiles-table-luatex/table-009.tlg
+++ b/required/latex-lab/testfiles-table-luatex/table-009.tlg
@@ -170,7 +170,7 @@ braces):
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 9,10,11
+==> structure stored for row 1: 9,10,11
 Package tagpdf Info: closing structure 8 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -229,7 +229,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 2: 13,-13,-13
+==> structure stored for row 2: 13,-13,-13
 Package tagpdf Info: closing structure 12 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -350,7 +350,7 @@ braces):
 >  {{text-unit}{Part}}
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
-==> stucture stored for row 3: 15,16,17
+==> structure stored for row 3: 15,16,17
 Package tagpdf Info: closing structure 14 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -471,7 +471,7 @@ braces):
 >  {{text-unit}{Part}}
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
-==> stucture stored for row 4: 19,20,21
+==> structure stored for row 4: 19,20,21
 Package tagpdf Info: closing structure 18 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -591,7 +591,7 @@ braces):
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 5: 23,24,25
+==> structure stored for row 5: 23,24,25
 Package tagpdf Info: closing structure 22 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer

--- a/required/latex-lab/testfiles-table-luatex/table-021-longtable.tlg
+++ b/required/latex-lab/testfiles-table-luatex/table-021-longtable.tlg
@@ -30,7 +30,7 @@ Don't change this file in any respect.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 --longtable--> chunk row: 1 row: 1 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 9,10,11
+==> structure stored for row 1: 9,10,11
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -48,7 +48,7 @@ Don't change this file in any respect.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 --longtable--> chunk row: 2 row: 2 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 2: 13,14,15
+==> structure stored for row 2: 13,14,15
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -66,7 +66,7 @@ Don't change this file in any respect.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 --longtable--> chunk row: 3 row: 3 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 3: 17,18,19
+==> structure stored for row 3: 17,18,19
 [Sockets] ==> Socket 'tagsupport/tbl/longtable/finalize' containing plug 'Table' used.
 --longtable--> chunk row: 3 row: 4 column: 0
 [Sockets] ==> Socket 'tagsupport/tbl/longtable/head' containing plug 'Table' used.

--- a/required/latex-lab/testfiles-table-pdftex/table-001.tlg
+++ b/required/latex-lab/testfiles-table-pdftex/table-001.tlg
@@ -20,7 +20,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> (endarray) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 9
+==> structure stored for row 1: 9
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.
@@ -42,7 +42,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> (endarray) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 15
+==> structure stored for row 1: 15
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.
@@ -64,7 +64,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> (endarray) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 21
+==> structure stored for row 1: 21
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.
@@ -86,7 +86,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 27
+==> structure stored for row 1: 27
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.

--- a/required/latex-lab/testfiles-table-pdftex/table-002.tlg
+++ b/required/latex-lab/testfiles-table-pdftex/table-002.tlg
@@ -32,7 +32,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 9,10,13
+==> structure stored for row 1: 9,10,13
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/colspan' containing plug 'code' used.
@@ -46,7 +46,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 2: 15,-15,16
+==> structure stored for row 2: 15,-15,16
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -68,7 +68,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 3,2,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 3: 18,19,22
+==> structure stored for row 3: 18,19,22
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -86,7 +86,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 4,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 4: 24,25,26
+==> structure stored for row 4: 24,25,26
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -104,7 +104,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 5,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 5: 28,29,30
+==> structure stored for row 5: 28,29,30
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -118,7 +118,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 6: 32,33,-33
+==> structure stored for row 6: 32,33,-33
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/colspan' containing plug 'code' used.
@@ -128,7 +128,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 7: 35,-35,-35
+==> structure stored for row 7: 35,-35,-35
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/colspan' containing plug 'code' used.
@@ -147,7 +147,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 8,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 8: 37,38,39
+==> structure stored for row 8: 37,38,39
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -165,7 +165,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 9,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 9: 41,42,43
+==> structure stored for row 9: 41,42,43
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.

--- a/required/latex-lab/testfiles-table-pdftex/table-003.tlg
+++ b/required/latex-lab/testfiles-table-pdftex/table-003.tlg
@@ -32,7 +32,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 9,10,13
+==> structure stored for row 1: 9,10,13
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -55,7 +55,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> (endarray) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 18,19
+==> structure stored for row 1: 18,19
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 2,1,1 (max: 3)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.
@@ -71,7 +71,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 2,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 2: 15,20,21
+==> structure stored for row 2: 15,20,21
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -89,7 +89,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 3,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 3: 23,24,25
+==> structure stored for row 3: 23,24,25
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.

--- a/required/latex-lab/testfiles-table-pdftex/table-004-tabularx.tlg
+++ b/required/latex-lab/testfiles-table-pdftex/table-004-tabularx.tlg
@@ -264,7 +264,7 @@ braces):
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 9,10,13
+==> structure stored for row 1: 9,10,13
 Package tagpdf Info: closing structure 8 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -432,7 +432,7 @@ braces):
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 18,19
+==> structure stored for row 1: 18,19
 Package tagpdf Info: closing structure 17 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -543,7 +543,7 @@ braces):
 >  {{text-unit}{Part}}
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
-==> stucture stored for row 2: 15,20,21
+==> structure stored for row 2: 15,20,21
 Package tagpdf Info: closing structure 14 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -670,7 +670,7 @@ braces):
 >  {{text-unit}{Part}}
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
-==> stucture stored for row 3: 23,24,25
+==> structure stored for row 3: 23,24,25
 Package tagpdf Info: closing structure 22 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -975,7 +975,7 @@ braces):
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 31,32,35
+==> structure stored for row 1: 31,32,35
 Package tagpdf Info: closing structure 30 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1221,7 +1221,7 @@ braces):
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 40,41
+==> structure stored for row 1: 40,41
 Package tagpdf Info: closing structure 39 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1332,7 +1332,7 @@ braces):
 >  {{text-unit}{Part}}
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
-==> stucture stored for row 2: 37,44,45
+==> structure stored for row 2: 37,44,45
 Package tagpdf Info: closing structure 36 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1459,7 +1459,7 @@ braces):
 >  {{text-unit}{Part}}
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
-==> stucture stored for row 3: 47,48,49
+==> structure stored for row 3: 47,48,49
 Package tagpdf Info: closing structure 46 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer

--- a/required/latex-lab/testfiles-table-pdftex/table-005.tlg
+++ b/required/latex-lab/testfiles-table-pdftex/table-005.tlg
@@ -187,7 +187,7 @@ braces):
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 11
+==> structure stored for row 1: 11
 Package tagpdf Info: closing structure 10 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer

--- a/required/latex-lab/testfiles-table-pdftex/table-006-longtable.tlg
+++ b/required/latex-lab/testfiles-table-pdftex/table-006-longtable.tlg
@@ -127,7 +127,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 1 row: 1 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 7,8,9
+==> structure stored for row 1: 7,8,9
 Package tagpdf Info: closing structure 6 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -246,7 +246,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 2 row: 2 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 2: 11,12,13
+==> structure stored for row 2: 11,12,13
 Package tagpdf Info: closing structure 10 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -365,7 +365,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 3 row: 3 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 3: 15,16,17
+==> structure stored for row 3: 15,16,17
 Package tagpdf Info: closing structure 14 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -484,7 +484,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 4 row: 4 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 4: 19,20,21
+==> structure stored for row 4: 19,20,21
 Package tagpdf Info: closing structure 18 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -603,7 +603,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 5 row: 5 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 5: 23,24,25
+==> structure stored for row 5: 23,24,25
 Package tagpdf Info: closing structure 22 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -722,7 +722,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 6 row: 6 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 6: 27,28,29
+==> structure stored for row 6: 27,28,29
 Package tagpdf Info: closing structure 26 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -841,7 +841,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 7 row: 7 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 7: 31,32,33
+==> structure stored for row 7: 31,32,33
 Package tagpdf Info: closing structure 30 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -960,7 +960,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 8 row: 8 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 8: 35,36,37
+==> structure stored for row 8: 35,36,37
 Package tagpdf Info: closing structure 34 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1079,7 +1079,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 9 row: 9 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 9: 39,40,41
+==> structure stored for row 9: 39,40,41
 Package tagpdf Info: closing structure 38 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1198,7 +1198,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 10 row: 10 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 10: 43,44,45
+==> structure stored for row 10: 43,44,45
 Package tagpdf Info: closing structure 42 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1317,7 +1317,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 11 row: 11 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 11: 47,48,49
+==> structure stored for row 11: 47,48,49
 Package tagpdf Info: closing structure 46 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1436,7 +1436,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 12 row: 12 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 12: 51,52,53
+==> structure stored for row 12: 51,52,53
 Package tagpdf Info: closing structure 50 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1555,7 +1555,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 13 row: 13 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 13: 55,56,57
+==> structure stored for row 13: 55,56,57
 Package tagpdf Info: closing structure 54 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1674,7 +1674,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 14 row: 14 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 14: 59,60,61
+==> structure stored for row 14: 59,60,61
 Package tagpdf Info: closing structure 58 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1793,7 +1793,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 15 row: 15 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 15: 63,64,65
+==> structure stored for row 15: 63,64,65
 Package tagpdf Info: closing structure 62 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1912,7 +1912,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 16 row: 16 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 16: 67,68,69
+==> structure stored for row 16: 67,68,69
 Package tagpdf Info: closing structure 66 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -2031,7 +2031,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 17 row: 17 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 17: 71,72,73
+==> structure stored for row 17: 71,72,73
 Package tagpdf Info: closing structure 70 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -2150,7 +2150,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 18 row: 18 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 18: 75,76,77
+==> structure stored for row 18: 75,76,77
 Package tagpdf Info: closing structure 74 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -2269,7 +2269,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 19 row: 19 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 19: 79,80,81
+==> structure stored for row 19: 79,80,81
 Package tagpdf Info: closing structure 78 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -2388,7 +2388,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 20 row: 20 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 20: 83,84,85
+==> structure stored for row 20: 83,84,85
 Package tagpdf Info: closing structure 82 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -2507,7 +2507,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 21 row: 21 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 21: 87,88,89
+==> structure stored for row 21: 87,88,89
 Package tagpdf Info: closing structure 86 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer

--- a/required/latex-lab/testfiles-table-pdftex/table-007-longtable.tlg
+++ b/required/latex-lab/testfiles-table-pdftex/table-007-longtable.tlg
@@ -127,7 +127,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 1 row: 1 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 7,8,9
+==> structure stored for row 1: 7,8,9
 Package tagpdf Info: closing structure 6 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -290,7 +290,7 @@ braces):
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 14,15
+==> structure stored for row 1: 14,15
 Package tagpdf Info: closing structure 13 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -394,7 +394,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 2 row: 2 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 2: 11,16,17
+==> structure stored for row 2: 11,16,17
 Package tagpdf Info: closing structure 10 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -513,7 +513,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 3 row: 3 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 3: 19,20,21
+==> structure stored for row 3: 19,20,21
 Package tagpdf Info: closing structure 18 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -632,7 +632,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 4 row: 4 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 4: 23,24,25
+==> structure stored for row 4: 23,24,25
 Package tagpdf Info: closing structure 22 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -751,7 +751,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 5 row: 5 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 5: 27,28,29
+==> structure stored for row 5: 27,28,29
 Package tagpdf Info: closing structure 26 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -870,7 +870,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 6 row: 6 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 6: 31,32,33
+==> structure stored for row 6: 31,32,33
 Package tagpdf Info: closing structure 30 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -989,7 +989,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 7 row: 7 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 7: 35,36,37
+==> structure stored for row 7: 35,36,37
 Package tagpdf Info: closing structure 34 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1078,7 +1078,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 8 row: 8 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 8: 39,-39,40
+==> structure stored for row 8: 39,-39,40
 Package tagpdf Info: closing structure 38 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1197,7 +1197,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 9 row: 9 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 9: 42,43,44
+==> structure stored for row 9: 42,43,44
 Package tagpdf Info: closing structure 41 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1286,7 +1286,7 @@ braces):
 ==> (@arraycr) This row needs 0 additional cell(s)
 --longtable--> chunk row: 10 row: 10 column: 2
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 10: 46,47,-47
+==> structure stored for row 10: 46,47,-47
 Package tagpdf Info: closing structure 45 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -1405,7 +1405,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 --longtable--> chunk row: 11 row: 11 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 11: 49,50,51
+==> structure stored for row 11: 49,50,51
 Package tagpdf Info: closing structure 48 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer

--- a/required/latex-lab/testfiles-table-pdftex/table-008-multi.tlg
+++ b/required/latex-lab/testfiles-table-pdftex/table-008-multi.tlg
@@ -21,7 +21,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 9,-9,-9
+==> structure stored for row 1: 9,-9,-9
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -39,7 +39,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 2,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 2: 11,12,13
+==> structure stored for row 2: 11,12,13
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.
@@ -70,7 +70,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 1,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 1: 19,20,21
+==> structure stored for row 1: 19,20,21
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/colspan' containing plug 'code' used.
@@ -80,7 +80,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 2: 23,-23,-23
+==> structure stored for row 2: 23,-23,-23
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -98,7 +98,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 3,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 3: 25,26,27
+==> structure stored for row 3: 25,26,27
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.

--- a/required/latex-lab/testfiles-table-pdftex/table-009.tlg
+++ b/required/latex-lab/testfiles-table-pdftex/table-009.tlg
@@ -178,7 +178,7 @@ braces):
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 9,10,11
+==> structure stored for row 1: 9,10,11
 Package tagpdf Info: closing structure 8 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -239,7 +239,7 @@ braces):
 >  {{Root}{StructTreeRoot}}.
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 2: 13,-13,-13
+==> structure stored for row 2: 13,-13,-13
 Package tagpdf Info: closing structure 12 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -366,7 +366,7 @@ braces):
 >  {{text-unit}{Part}}
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
-==> stucture stored for row 3: 15,16,17
+==> structure stored for row 3: 15,16,17
 Package tagpdf Info: closing structure 14 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -493,7 +493,7 @@ braces):
 >  {{text-unit}{Part}}
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
-==> stucture stored for row 4: 19,20,21
+==> structure stored for row 4: 19,20,21
 Package tagpdf Info: closing structure 18 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer
@@ -619,7 +619,7 @@ braces):
 >  {{Document}{Document}}
 >  {{Root}{StructTreeRoot}}.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 5: 23,24,25
+==> structure stored for row 5: 23,24,25
 Package tagpdf Info: closing structure 22 tagged /TR
 tagpdf DEBUG Info: Struct end inserted [on line ...]
 The sequence \g__tag_struct_tag_stack_seq contains the items (without outer

--- a/required/latex-lab/testfiles-table-pdftex/table-012-caption.tlg
+++ b/required/latex-lab/testfiles-table-pdftex/table-012-caption.tlg
@@ -5,7 +5,7 @@ Don't change this file in any respect.
 ==> current cell data: 1,1,\LT@cols 
 ==> (head/foot) This row needs 0 additional cell(s)
 --longtable--> chunk row: 200 row: 1 column: 1
-==> stucture stored for row 1: 7,-7
+==> structure stored for row 1: 7,-7
 --longtable--> chunk row: 200 row: 1 column: 0
 -->> Saving \LT@head 
 --longtable--> chunk row: 0 row: 1 column: 0
@@ -14,61 +14,61 @@ Don't change this file in any respect.
 --longtable--> chunk row: 1 row: 2 column: 1
 ==> Inserting 1 additional cell(s) into previous row:
 ==> current cell data: 2,1,1
-==> stucture stored for row 2: 9,10
+==> structure stored for row 2: 9,10
 ==> current cell data: 3,1,1
 ==> (@arraycr) This row needs 1 additional cell(s)
 --longtable--> chunk row: 2 row: 3 column: 1
 ==> Inserting 1 additional cell(s) into previous row:
 ==> current cell data: 3,1,1
-==> stucture stored for row 3: 12,13
+==> structure stored for row 3: 12,13
 ==> current cell data: 4,1,1
 ==> (@arraycr) This row needs 1 additional cell(s)
 --longtable--> chunk row: 3 row: 4 column: 1
 ==> Inserting 1 additional cell(s) into previous row:
 ==> current cell data: 4,1,1
-==> stucture stored for row 4: 15,16
+==> structure stored for row 4: 15,16
 ==> current cell data: 5,1,1
 ==> (@arraycr) This row needs 1 additional cell(s)
 --longtable--> chunk row: 4 row: 5 column: 1
 ==> Inserting 1 additional cell(s) into previous row:
 ==> current cell data: 5,1,1
-==> stucture stored for row 5: 18,19
+==> structure stored for row 5: 18,19
 ==> current cell data: 6,1,1
 ==> (@arraycr) This row needs 1 additional cell(s)
 --longtable--> chunk row: 5 row: 6 column: 1
 ==> Inserting 1 additional cell(s) into previous row:
 ==> current cell data: 6,1,1
-==> stucture stored for row 6: 21,22
+==> structure stored for row 6: 21,22
 ==> current cell data: 7,1,1
 ==> (@arraycr) This row needs 1 additional cell(s)
 --longtable--> chunk row: 6 row: 7 column: 1
 ==> Inserting 1 additional cell(s) into previous row:
 ==> current cell data: 7,1,1
-==> stucture stored for row 7: 24,25
+==> structure stored for row 7: 24,25
 ==> current cell data: 8,1,1
 ==> (@arraycr) This row needs 1 additional cell(s)
 --longtable--> chunk row: 7 row: 8 column: 1
 ==> Inserting 1 additional cell(s) into previous row:
 ==> current cell data: 8,1,1
-==> stucture stored for row 8: 27,28
+==> structure stored for row 8: 27,28
 ==> current cell data: 9,1,1
 ==> (@arraycr) This row needs 1 additional cell(s)
 --longtable--> chunk row: 8 row: 9 column: 1
 ==> Inserting 1 additional cell(s) into previous row:
 ==> current cell data: 9,1,1
-==> stucture stored for row 9: 30,31
+==> structure stored for row 9: 30,31
 ==> current cell data: 10,1,1
 ==> (@arraycr) This row needs 1 additional cell(s)
 --longtable--> chunk row: 9 row: 10 column: 1
 ==> Inserting 1 additional cell(s) into previous row:
 ==> current cell data: 10,1,1
-==> stucture stored for row 10: 33,34
+==> structure stored for row 10: 33,34
 ==> current cell data: 11,1,1
 ==> (endlongtable) This row needs 1 additional cell(s)
 --longtable--> chunk row: 9 row: 11 column: 1
 ==> Inserting 1 additional cell(s) into previous row:
 ==> current cell data: 11,1,1
-==> stucture stored for row 11: 36,37
+==> structure stored for row 11: 36,37
 --longtable--> chunk row: 9 row: 12 column: 0
 ! Infinite glue shrinkage found in box being split.
 \__box_dim_eval:n ...box_dim_eval:w #1\scan_stop: 

--- a/required/latex-lab/testfiles-table-pdftex/table-015.tlg
+++ b/required/latex-lab/testfiles-table-pdftex/table-015.tlg
@@ -21,7 +21,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 9,-9,-9
+==> structure stored for row 1: 9,-9,-9
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -39,7 +39,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 2,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 2: 11,12,13
+==> structure stored for row 2: 11,12,13
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.
@@ -62,7 +62,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 19,-19,-19
+==> structure stored for row 1: 19,-19,-19
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -80,7 +80,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 2,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 2: 21,22,23
+==> structure stored for row 2: 21,22,23
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.

--- a/required/latex-lab/testfiles-table-pdftex/table-016-math.tlg
+++ b/required/latex-lab/testfiles-table-pdftex/table-016-math.tlg
@@ -5,11 +5,11 @@ Don't change this file in any respect.
 ==> current cell data: 1,1,1
 ==> current cell data: 1,2,1
 ==> (@arraycr) This row needs 0 additional cell(s)
-==> stucture stored for row 1: 9,10
+==> structure stored for row 1: 9,10
 ==> current cell data: 2,1,1
 ==> current cell data: 2,2,1
 ==> (@arraycr) This row needs 0 additional cell(s)
-==> stucture stored for row 2: 12,13
+==> structure stored for row 2: 12,13
 ==> restored cell data: 0,0,1 (outer level)
 ====>first-result=macro:->\begin {Vmatrix} D_1t & -a_{12}t_2\\ -a_{21}t_1 & D_2t \end {Vmatrix}
 ====>first-tmpmathcontent=macro:->

--- a/required/latex-lab/testfiles-table-pdftex/table-017.tlg
+++ b/required/latex-lab/testfiles-table-pdftex/table-017.tlg
@@ -20,7 +20,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> (endarray) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 9
+==> structure stored for row 1: 9
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.
@@ -47,7 +47,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 1,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 1: 15,16
+==> structure stored for row 1: 15,16
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -60,7 +60,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> (endarray) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 2: 18,19
+==> structure stored for row 2: 18,19
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.
@@ -90,7 +90,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> (@arraycr) This row needs 0 additional cell(s)
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 25,26,27
+==> structure stored for row 1: 25,26,27
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -108,7 +108,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 2,2,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 2: 29,30,31
+==> structure stored for row 2: 29,30,31
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.
@@ -163,7 +163,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 ==> current cell data: 1,7,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 1: 37,38,39,40,41,42,43,44,45
+==> structure stored for row 1: 37,38,39,40,41,42,43,44,45
 [Sockets] ==> Socket 'tagsupport/tbl/finalize' containing plug 'Table' used.
 ==> restored cell data: 0,0,1 (outer level)
 [Sockets] ==> Socket 'tagsupport/tbl/hmode/end' containing plug 'Table' used.

--- a/required/latex-lab/testfiles-table-pdftex/table-019.tlg
+++ b/required/latex-lab/testfiles-table-pdftex/table-019.tlg
@@ -23,7 +23,7 @@ Don't change this file in any respect.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 --longtable--> chunk row: 1 row: 1 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 7,8,9
+==> structure stored for row 1: 7,8,9
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -41,7 +41,7 @@ Don't change this file in any respect.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 --longtable--> chunk row: 2 row: 2 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 2: 11,12,13
+==> structure stored for row 2: 11,12,13
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -59,7 +59,7 @@ Don't change this file in any respect.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 --longtable--> chunk row: 3 row: 3 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 3: 15,16,17
+==> structure stored for row 3: 15,16,17
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -77,7 +77,7 @@ Don't change this file in any respect.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 --longtable--> chunk row: 4 row: 4 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 4: 19,20,21
+==> structure stored for row 4: 19,20,21
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -96,7 +96,7 @@ Don't change this file in any respect.
 ==> current cell data: 5,2,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 5: 23,24,25
+==> structure stored for row 5: 23,24,25
 --longtable--> chunk row: 5 row: 5 column: 0
 [Sockets] ==> Socket 'tagsupport/tbl/longtable/head' containing plug 'Table' used.
 --longtable--> chunk row: 0 row: 5 column: 0
@@ -118,7 +118,7 @@ Don't change this file in any respect.
 ==> current cell data: 6,2,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 6: 27,28,29
+==> structure stored for row 6: 27,28,29
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -136,7 +136,7 @@ Don't change this file in any respect.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 --longtable--> chunk row: 2 row: 7 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 7: 31,32,33
+==> structure stored for row 7: 31,32,33
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -154,7 +154,7 @@ Don't change this file in any respect.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 --longtable--> chunk row: 3 row: 8 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 8: 35,36,37
+==> structure stored for row 8: 35,36,37
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -172,7 +172,7 @@ Don't change this file in any respect.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 --longtable--> chunk row: 4 row: 9 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 9: 39,40,41
+==> structure stored for row 9: 39,40,41
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -191,7 +191,7 @@ Don't change this file in any respect.
 ==> current cell data: 10,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 10: 43,44,45
+==> structure stored for row 10: 43,44,45
 --longtable--> chunk row: 5 row: 10 column: 0
 --longtable--> chunk row: 0 row: 10 column: 0
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
@@ -212,7 +212,7 @@ Don't change this file in any respect.
 ==> current cell data: 11,1,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 11: 47,48,49
+==> structure stored for row 11: 47,48,49
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -230,7 +230,7 @@ Don't change this file in any respect.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 --longtable--> chunk row: 2 row: 12 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 12: 51,52,53
+==> structure stored for row 12: 51,52,53
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -248,7 +248,7 @@ Don't change this file in any respect.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 --longtable--> chunk row: 3 row: 13 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 13: 55,56,57
+==> structure stored for row 13: 55,56,57
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -266,7 +266,7 @@ Don't change this file in any respect.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 --longtable--> chunk row: 4 row: 14 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 14: 59,60,61
+==> structure stored for row 14: 59,60,61
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/begin' containing plug 'TD' used.
@@ -284,7 +284,7 @@ Don't change this file in any respect.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 --longtable--> chunk row: 5 row: 15 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 15: 63,64,65
+==> structure stored for row 15: 63,64,65
 --longtable--> chunk row: 5 row: 15 column: 0
 --longtable--> chunk row: 0 row: 15 column: 0
 [Sockets] ==> Socket 'tagsupport/tbl/longtable/finalize' containing plug 'Table' used.

--- a/required/latex-lab/testfiles-table-pdftex/table-020.tlg
+++ b/required/latex-lab/testfiles-table-pdftex/table-020.tlg
@@ -23,7 +23,7 @@ Don't change this file in any respect.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 --longtable--> chunk row: 200 row: 1 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 7,8,9
+==> structure stored for row 1: 7,8,9
 --longtable--> chunk row: 200 row: 1 column: 0
 -->> Saving \LT@head 
 --longtable--> chunk row: 0 row: 1 column: 0
@@ -44,7 +44,7 @@ Don't change this file in any respect.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 --longtable--> chunk row: 0 row: 2 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 2: 11,12,13
+==> structure stored for row 2: 11,12,13
 [Sockets] ==> Socket 'tagsupport/tbl/longtable/finalize' containing plug 'Table' used.
 --longtable--> chunk row: 0 row: 3 column: 0
 [Sockets] ==> Socket 'tagsupport/tbl/longtable/head' containing plug 'Table' used.
@@ -75,7 +75,7 @@ Don't change this file in any respect.
 ==> current cell data: 1,2,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 1: 16,17,18
+==> structure stored for row 1: 16,17,18
 --longtable--> chunk row: 200 row: 1 column: 0
 -->> Saving \LT@head 
 --longtable--> chunk row: 0 row: 1 column: 0
@@ -97,7 +97,7 @@ Don't change this file in any respect.
 ==> current cell data: 2,2,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 2: 20,21,22
+==> structure stored for row 2: 20,21,22
 [Sockets] ==> Socket 'tagsupport/tbl/longtable/finalize' containing plug 'Table' used.
 --longtable--> chunk row: 0 row: 3 column: 0
 [Sockets] ==> Socket 'tagsupport/tbl/longtable/head' containing plug 'Table' used.
@@ -128,7 +128,7 @@ Don't change this file in any respect.
 ==> current cell data: 1,2,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 1: 25,26,27
+==> structure stored for row 1: 25,26,27
 --longtable--> chunk row: 200 row: 1 column: 0
 -->> Saving \LT@head 
 --longtable--> chunk row: 0 row: 1 column: 0
@@ -150,7 +150,7 @@ Don't change this file in any respect.
 ==> current cell data: 2,2,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 2: 29,30,31
+==> structure stored for row 2: 29,30,31
 --longtable--> chunk row: 200 row: 2 column: 0
 -->> Saving \LT@firsthead 
 --longtable--> chunk row: 0 row: 2 column: 0
@@ -172,7 +172,7 @@ Don't change this file in any respect.
 ==> current cell data: 3,2,1
 [Sockets] ==> Socket 'tag/struct/tag' containing plug 'latex-tags' used.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
-==> stucture stored for row 3: 33,34,35
+==> structure stored for row 3: 33,34,35
 [Sockets] ==> Socket 'tagsupport/tbl/longtable/finalize' containing plug 'Table' used.
 --longtable--> chunk row: 0 row: 4 column: 0
 [Sockets] ==> Socket 'tagsupport/tbl/longtable/head' containing plug 'Table' used.

--- a/required/latex-lab/testfiles-table-pdftex/table-021-longtable.tlg
+++ b/required/latex-lab/testfiles-table-pdftex/table-021-longtable.tlg
@@ -24,7 +24,7 @@ Don't change this file in any respect.
 ==> (head/foot) This row needs 0 additional cell(s)
 --longtable--> chunk row: 200 row: 1 column: 1
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 1: 9,-9,-9
+==> structure stored for row 1: 9,-9,-9
 --longtable--> chunk row: 200 row: 1 column: 0
 -->> Saving \LT@firsthead 
 --longtable--> chunk row: 0 row: 1 column: 0
@@ -54,7 +54,7 @@ Don't change this file in any respect.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 --longtable--> chunk row: 1 row: 2 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 2: 11,12,13
+==> structure stored for row 2: 11,12,13
 --longtable--> chunk row: 1 row: 3 column: 0
 --longtable--> chunk row: 1 row: 3 column: 0
 [Sockets] ==> Socket 'tagsupport/tbl/row/begin' containing plug 'TR' used.
@@ -74,7 +74,7 @@ Don't change this file in any respect.
 [Sockets] ==> Socket 'tagsupport/tbl/cell/end' containing plug 'TD' used.
 --longtable--> chunk row: 2 row: 3 column: 3
 [Sockets] ==> Socket 'tagsupport/tbl/row/end' containing plug 'TR' used.
-==> stucture stored for row 3: 15,16,17
+==> structure stored for row 3: 15,16,17
 --longtable--> chunk row: 2 row: 4 column: 0
 --longtable--> chunk row: 2 row: 4 column: 0
 [Sockets] ==> Socket 'tagsupport/tbl/longtable/finalize' containing plug 'Table' used.

--- a/required/latex-lab/update-table.sh
+++ b/required/latex-lab/update-table.sh
@@ -20,6 +20,7 @@ l3build save -cconfig-table-pdftex \
 	table-014-pbox-longtable \
 	table-015 \
 	table-016 \
+	table-016-math \
 	table-017 \
 	table-018 \
 	table-019 \


### PR DESCRIPTION
Fixes a few small typos in the latex-lab bundle.

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
