### PR TITLE
Fix a typo, over commented \end{function}

### DIFF
--- a/base/ltmarks.dtx
+++ b/base/ltmarks.dtx
@@ -17,7 +17,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltmarks.dtx}
-             [2024/06/29 v1.0g LaTeX Kernel (Marks)]
+             [2024/07/08 v1.0g LaTeX Kernel (Marks)]
 % \iffalse
 %
 \documentclass{l3doc}
@@ -211,7 +211,7 @@
 %   The commands are only meaningful inside the output routine, in
 %   other places their result is (while not random) unpredictable due
 %   to the way \LaTeX{} cuts text material into pages.
-%% \end{function}
+% \end{function}
 %
 %
 %


### PR DESCRIPTION
The `%% \end{function}` with two leading `%`s made it to `latex.ltx`. This tiny PR fixes this only case.

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] <s>Version and</s> date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
