### PR TITLE
fix file input by latex-lab-mathtools.dtx

### DIFF
--- a/required/latex-lab/latex-lab-mathtools.dtx
+++ b/required/latex-lab/latex-lab-mathtools.dtx
@@ -23,7 +23,7 @@
 \EnableCrossrefs
 \CodelineIndex
 \begin{document}
-  \DocInput{latex-lab-amsmath.dtx}
+  \DocInput{latex-lab-mathtools.dtx}
 \end{document}
 %</driver>
 %

--- a/required/latex-lab/latex-lab-mathtools.dtx
+++ b/required/latex-lab/latex-lab-mathtools.dtx
@@ -66,7 +66,7 @@
 % \subsection{File declaration}
 %    \begin{macrocode}
 \ProvidesFile{latex-lab-mathtools.ltx}
-        [2023-01-05 v0.1a mathtools adaptions]
+        [2024-07-13 v0.1a mathtools adaptions]
 %    \end{macrocode}
 % \subsection{Tagpdf support}
 % To make the code independent from tagging being loaded and active


### PR DESCRIPTION
latex-lab-mathtools.dtx currently does `\DocInput{latex-lab-amsmath.dtx}`. This PR changes this to `\DocInput{latex-lab-mathtools.dtx}`.

Since I'm not changing the file `latex-lab-mathtools.ltx` I did not change the date in `\ProvidesFile`, but please let me know if I should.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
