### PR TITLE
fix for tagging-project issue 262

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,10 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
+2024-07-27 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
+	* lttagging.dtx: (subsection{Paragraph sockets}): A socket and plug to restore paragraph
+	setting added. 
+
 2024-07-13 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
 	* lttagging.dtx: (subsection{Tagging sockets}): toc-related tagging sockets added. 
 

--- a/base/lttagging.dtx
+++ b/base/lttagging.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{lttagging.dtx}
-             [2024/07/14 v1.0d LaTeX Kernel (tagging support)]
+             [2024/07/27 v1.0e LaTeX Kernel (tagging support)]
 % \iffalse
 \documentclass{l3doc}
 \GetFileInfo{lttagging.dtx}
@@ -214,7 +214,6 @@
          }
          \ERRORusetaggingsocket  % that should get a proper error message
 }
-\ExplSyntaxOff
 %    \end{macrocode}
 %
 %  \end{macro}
@@ -223,6 +222,34 @@
 % This collects tagging sockets that should be generally available
 % so that they can also be used even if the tagging code is not loaded. 
 % 
+% \subsubsection{Tagging support for paragraph setup}
+% 
+% Paragraphs are tagged through the code in the para/hooks. This code is sometimes
+% adjusted, e.g. to produce a \enquote{flattened} paragraph or to use a different tag.
+% Sockets related to such code part are collected here.
+%
+% \begin{socketdecl}{tagsupport/para/restore}
+% This socket restore the para related settings to their default. It
+% should be used in places where ``normal'' paragraph tagging must be ensured, for example
+% at the begin of a footnote. 
+%    \begin{macrocode}
+\NewSocket{tagsupport/para/restore}{0}
+%    \end{macrocode}
+% \end{socketdecl}
+% 
+% \begin{plugdecl}{default}
+%    \begin{macrocode}
+\NewSocketPlug{tagsupport/para/restore}{default}
+ {
+   \tl_set:Nn    \l__tag_para_main_tag_tl {text-unit}
+   \tl_set_eq:NN \l__tag_para_tag_tl\l__tag_para_tag_default_tl
+   \bool_set_false:N\l__tag_para_flattened_bool
+ }
+\AssignSocketPlug{tagsupport/para/restore}{default}
+\ExplSyntaxOff 
+%    \end{macrocode}
+% \end{socketdecl}
+
 % \subsubsection{Tagging sockets for toc}
 
 % \begin{socketdecl}{tagsupport/toc/contentsline/before,

--- a/base/lttagging.dtx
+++ b/base/lttagging.dtx
@@ -226,10 +226,10 @@
 % 
 % Paragraphs are tagged through the code in the para/hooks. This code is sometimes
 % adjusted, e.g. to produce a \enquote{flattened} paragraph or to use a different tag.
-% Sockets related to such code part are collected here.
+% Sockets related to such code parts are collected here.
 %
 % \begin{socketdecl}{tagsupport/para/restore}
-% This socket restore the para related settings to their default. It
+% This socket restores the para related settings to their default. It
 % should be used in places where ``normal'' paragraph tagging must be ensured, for example
 % at the begin of a footnote. 
 %    \begin{macrocode}

--- a/base/lttagging.dtx
+++ b/base/lttagging.dtx
@@ -248,7 +248,7 @@
 \AssignSocketPlug{tagsupport/para/restore}{default}
 \ExplSyntaxOff 
 %    \end{macrocode}
-% \end{socketdecl}
+% \end{plugdecl}
 
 % \subsubsection{Tagging sockets for toc}
 

--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -1,3 +1,7 @@
+2024-07-11 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
+	* latex-lab-footnote.dtx: restore paragraph defaults at the begin of the footnote
+	tagging-project#262
+
 2024-07-13  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 
 	* latex-lab-table.dtx (subsection{Tagging support sockets}):

--- a/required/latex-lab/latex-lab-footnotes.dtx
+++ b/required/latex-lab/latex-lab-footnotes.dtx
@@ -17,8 +17,8 @@
 %
 % for those people who are interested or want to report an issue.
 %
-\def\ltlabfootnotedate{2024-07-05}
-\def\ltlabfootnoteversion{0.8d}
+\def\ltlabfootnotedate{2024-07-27}
+\def\ltlabfootnoteversion{0.8e}
 
 %<*driver>
 \documentclass{l3doc}
@@ -1150,6 +1150,21 @@
 %
 %
 % \begin{macro}{\fnote_footnotetext:n}
+% We temporarily test for the tagging socket until it is in the next release:
+%    \begin{macrocode}
+\str_if_exist:cF { l__socket_tagsupport/para/restore_plug_str }
+    {
+      \NewSocket{tagsupport/para/restore}{0}
+      \NewSocketPlug{tagsupport/para/restore}{default}
+        {
+          \tl_set:Nn    \l__tag_para_main_tag_tl {text-unit}
+          \tl_set_eq:NN \l__tag_para_tag_tl\l__tag_para_tag_default_tl
+          \bool_set_false:N\l__tag_para_flattened_bool
+        }
+      \AssignSocketPlug{tagsupport/para/restore}{default}
+    }
+%    \end{macrocode}
+%
 %    \begin{macrocode}
 \cs_new_protected:Npn \fnote_footnotetext:n #1 {
   \@@_debug_footnotetext:
@@ -1191,6 +1206,7 @@
     \floatingpenalty \@MM
     \hsize\columnwidth
     \@parboxrestore
+    \UseTaggingSocket{para/restore}
     \parindent 1em     % typical default used in \@makefntext moved up here
     \def\@currentcounter{footnote}
     \protected@edef \@currentlabel { \p@footnote \@thefnmark }

--- a/required/latex-lab/testfiles-OR/footmisc-007-rollback.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-007-rollback.tlg
@@ -18,7 +18,7 @@ l. ...\makeatletter\show\@footnotemark
                                      \makeatother
 Patched @footnotetext
 > \@footnotetext=\protected\long macro:
-#1->\__fnote_debug_footnotetext: \hook_use:n {fntext/before}\socket_use:n {tagsupport/fntext/begin}\socket_use:nn {fntext/process}{\hook_use:n {fntext}\reset@font \footnotesize \interlinepenalty \interfootnotelinepenalty \splittopskip \footnotesep \splitmaxdepth \dp \strutbox \floatingpenalty \@MM \hsize \columnwidth \@parboxrestore \parindent 1em\def \@currentcounter {footnote}\protected@edef \@currentlabel {\p@footnote \@thefnmark }\hook_use:n {fntext/para}\color@begingroup \socket_use:nn {fntext/make}{\socket_use:n {fntext/begin}\hook_use:n {fntext/begin}\ignorespaces #1\hook_use:n {fntext/end}\socket_use:n {fntext/end}}\par \color@endgroup }\socket_use:n {tagsupport/fntext/end}\hook_use:n {fntext/after}.
+#1->\__fnote_debug_footnotetext: \hook_use:n {fntext/before}\socket_use:n {tagsupport/fntext/begin}\socket_use:nn {fntext/process}{\hook_use:n {fntext}\reset@font \footnotesize \interlinepenalty \interfootnotelinepenalty \splittopskip \footnotesep \splitmaxdepth \dp \strutbox \floatingpenalty \@MM \hsize \columnwidth \@parboxrestore \UseTaggingSocket {para/restore}\parindent 1em\def \@currentcounter {footnote}\protected@edef \@currentlabel {\p@footnote \@thefnmark }\hook_use:n {fntext/para}\color@begingroup \socket_use:nn {fntext/make}{\socket_use:n {fntext/begin}\hook_use:n {fntext/begin}\ignorespaces #1\hook_use:n {fntext/end}\socket_use:n {fntext/end}}\par \color@endgroup }\socket_use:n {tagsupport/fntext/end}\hook_use:n {fntext/after}.
 l. ...\makeatletter\show\@footnotetext
                                      \makeatother
 -> The hook 'fnmark/before':

--- a/required/latex-lab/testfiles-OR/footnote-heading.lvt
+++ b/required/latex-lab/testfiles-OR/footnote-heading.lvt
@@ -1,0 +1,18 @@
+% from gh https://github.com/latex3/tagging-project/issues/262
+\ExplSyntaxOn
+\debug_on:n { check-declarations , deprecation }
+\ExplSyntaxOff
+\input{regression-test}
+\DocumentMetadata{
+	pdfstandard=A-4f,
+	pdfversion=2.0,
+	lang=en-US,
+	testphase={phase-III},
+}
+\documentclass{article}
+
+\begin{document}
+\START
+\section{First topic\footnote{This section closely follows Newton (1687).}}
+
+\end{document}

--- a/required/latex-lab/testfiles-OR/footnote-heading.tlg
+++ b/required/latex-lab/testfiles-OR/footnote-heading.tlg
@@ -1,0 +1,25 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <14.4> on input line ....
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <7> on input line ....
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <8> on input line ....
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <6> on input line ....
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <5> on input line ....
+[1
+] (footnote-heading.aux)
+Package tagpdf Info: Finalizing the tagging structure:
+(tagpdf)             Writing out ~13 structure objects
+(tagpdf)             with ~12 'MC' leaf nodes.
+(tagpdf)             Be patient if there are lots of objects!
+Package tagpdf Info: writing ParentTree
+Package tagpdf Info: writing IDTree
+Package tagpdf Info: writing RoleMap
+Package tagpdf Info: writing ClassMap
+Package tagpdf Info: writing NameSpaces
+Package tagpdf Info: writing StructElems
+Package tagpdf Info: writing Root


### PR DESCRIPTION
This fixes https://github.com/latex3/tagging-project/issues/262 by resetting some tagging commands to their default value at the begin of footins.

# Internal housekeeping

## Status of pull request

X Ready to merge

## Checklist of required changes before merge will be approved
- [ x] Test file(s) added
- [ x] Version and date string updated in changed source files
- [ x] Relevant `\changes` entries in source included
- [ x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)? 
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
