### PR TITLE
Fix broken `macrocode` environments

### DIFF
--- a/required/graphics/graphics.dtx
+++ b/required/graphics/graphics.dtx
@@ -27,7 +27,7 @@
 %<driver> \ProvidesFile{graphics.drv}
 % \fi
 %         \ProvidesFile{graphics.dtx}
-          [2024/05/23 v1.4g  Standard LaTeX Graphics (DPC,SPQR)]
+          [2024/08/06 v1.4g  Standard LaTeX Graphics (DPC,SPQR)]
 %
 % \iffalse
 %<*driver>
@@ -1050,7 +1050,8 @@
 %
 %    \begin{macrocode}
 \edef\Gin@gzext{\detokenize{gz}}
-%    \edef{macrocode}
+%    \end{macrocode}
+% \end{macro}
 % \end{macro}
 %
 % \begin{macro}{\Gin@set@curr@file}

--- a/required/tools/theorem.dtx
+++ b/required/tools/theorem.dtx
@@ -24,7 +24,7 @@
 %%
 %
 %
-\def\FMithmInfo{2023/07/05 v2.2c Theorem extension package (FMi)}
+\def\FMithmInfo{2024/08/06 v2.2c Theorem extension package (FMi)}
 %
 % \ProvidesFile{theorem.dtx}[\FMithmInfo]
 %\iffalse   % this is a METACOMMENT !
@@ -952,7 +952,6 @@
 %
 % \subsubsection{The \texttt{changebreak} style}
 %
-%    \begin{macrocode}
 % This style option is stored in the file |thcb.sty|.
 %    \begin{macrocode}
 %<*thcb>


### PR DESCRIPTION
This PR fixes two broken `macrocode` environments.

# Internal housekeeping

## Status of pull request
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] ~Version and~ date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
