### PR TITLE
Drop extra backslashes in \cs

### DIFF
--- a/base/latexrelease.dtx
+++ b/base/latexrelease.dtx
@@ -40,7 +40,7 @@
 %<*latexrelease>
 % \fi
 %         \ProvidesFile{latexrelease.dtx}
-          [2022/11/14 v1.0p LaTeX release emulation and tests
+          [2024/08/11 v1.0p LaTeX release emulation and tests
               (including releases up to \latexreleaseversion)]
 % \iffalse
 %</latexrelease>
@@ -507,7 +507,7 @@
 % \end{macro}
 %
 % \changes{v1.0c}{2015/02/19}{Swap argument order}
-% \changes{v1.0k}{2018/05/08}{reset \cs{\requestedLaTeXdate} for current
+% \changes{v1.0k}{2018/05/08}{reset \cs{requestedLaTeXdate} for current
 %                             and latest options, github issue 43}
 %    \begin{macrocode}
 \DeclareOption*{%

--- a/required/amsmath/amsmath.dtx
+++ b/required/amsmath/amsmath.dtx
@@ -85,7 +85,7 @@ Bug reports can be opened (category \texttt{#1}) at\\%
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\ProvidesPackage{amsmath}[2024/07/01 v2.17r AMS math features]
+\ProvidesPackage{amsmath}[2024/08/11 v2.17r AMS math features]
 %    \end{macrocode}
 %
 % \section{Catcode defenses}
@@ -1147,7 +1147,7 @@ Foreign command \@backslashchar#1;\MessageBreak
          \gdef\thedots@{\dotsb@}%
        \else
 %    \end{macrocode}
-%    In case \cs{\@let@token} is a robust \LaTeXe{} command, i.e.,
+%    In case \cs{@let@token} is a robust \LaTeXe{} command, i.e.,
 %    expands to \cs{protect}
 %    \verb*=\somename =, we save the \cs{meaning} of
 %    \verb*=\somename = in \cs{meaning@} (possibly followed by some dots that have
@@ -3402,7 +3402,7 @@ ill-advised in LaTeX.%
 % \end{macro}
 %
 %  \begin{macro}{\column@plus}
-%    \cs{\column@plus} is a useful abbreviation.
+%    \cs{column@plus} is a useful abbreviation.
 %    \begin{macrocode}
 \def\column@plus{%
     \global\advance\column@\@ne
@@ -5539,7 +5539,7 @@ trying to recover with `aligned'%
 %    might occur at the beginning of the current line.  More
 %    specifically, we first set \cs{count@} equal to the number of
 %    interalign spaces preceding the current field (namely, $\lfloor
-%    (\cs{\column@}-1)/2 \rfloor$), and then subtract \cs{count@} from
+%    (\cs{column@}-1)/2 \rfloor$), and then subtract \cs{count@} from
 %    both \cs{@tempcnta} and \cs{@tempcntb}.  The rationale is that
 %    for the purposes of adjusting the spacing between the tag and the
 %    equation, the only flexible interalign spaces are those after

--- a/required/latex-lab/latex-lab-block.dtx
+++ b/required/latex-lab/latex-lab-block.dtx
@@ -9,7 +9,7 @@
 %
 %    https://www.latex-project.org/lppl.txt
 %
-\def\ltlabblockdate{2024-08-10}
+\def\ltlabblockdate{2024-08-11}
 \def\ltlabblockversion{0.8p}
 %<*driver>
 \documentclass[kernel]{l3doc}
@@ -1614,7 +1614,7 @@
 %    \end{macrocode}
 %    We need to know later if we have nested blockenvs inside
 %    a flattened environment. Whenever we  start a new blockenv we
-%    increment \cs{\l__tag_block_flattened_level_int} if it is already
+%    increment \cs{l__tag_block_flattened_level_int} if it is already
 %    different from zero. If it is zero we increment it if flattening
 %    is requested.
 %    Thus a value of \texttt{0} means no flattening requested so far


### PR DESCRIPTION
Fix a kind of typos in which the `\cs{\cmd}` instead of `\cs{cmd}` were used.

The first case was caught in https://github.com/latex3/latex2e/pull/1433/files#diff-2894a2a41a9c4086e553f9e9679c6b68529007f9f47408c47a3bafdb219aa294R1617
```diff
-% increment \cs{\l_@@_flattened_level_int} if it is already
+% increment \cs{\l__tag_block_flattened_level_int} if it is already
```

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] <s>Version and</s> date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
