### PR TITLE
Fix a confusing example of `\NeedsTeXFormat`

### DIFF
--- a/base/doc/clsguide.tex
+++ b/base/doc/clsguide.tex
@@ -331,9 +331,9 @@ example the University of Nowhere classes might begin with |unw|. This helps to
 avoid every University having its own thesis class, all called |thesis.cls|.
 
 If you rely on some features of the \LaTeX{} kernel, or on a package,
-please specify the release-date you need.  For example, the package
-error commands were introduced in the June 2022 release so, if you use
-them then you should put:
+please specify the release-date you need.  For example, the keyval
+options (see Section~\ref{Sec:opt:keyval}) were introduced in the June
+2022 release so, if you use them then you should put:
 \begin{verbatim}
    \NeedsTeXFormat{LaTeX2e}[2022-06-01]
 \end{verbatim}


### PR DESCRIPTION
Fix a confusing example of `\NeedsTeXFormat` introduced in 3a04b8a1 (Changes as suggested by David, 2023-04-11).

The current words read as if package error commands were introduced in the June 2022 release.

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
