### PR TITLE
avoid writing tex for #1412

### DIFF
--- a/base/doc/ltnews40.tex
+++ b/base/doc/ltnews40.tex
@@ -415,6 +415,15 @@ has now been corrected.
 
 \section{Changes to packages in the \pkg{tools} category}
 
+\subsection{Modification to generation of the \file{.tex} from \pkg{fileerr}}
+
+The \pkg{fileerr} extraction has been modified to write \texttt{rename-to-empty-base.tex}
+rather than \texttt{.tex} to comply with an expected security change in texlive 2025.
+\texttt{build.lua} has been  modified to rename \texttt{rename-to-empty-base.tex} to \texttt{.tex}
+after unpacking however if using \textsf{docstrip} directly rather than using \textsf{l3build}
+or the unpacked zip file from \CTAN{}, the user must now rename the file and  install as \texttt{.tex}.
+%
+\githubissue{1412}
 
 \subsection{\pkg{array}: Tagging support for \cs{cline}}
 

--- a/base/doc/ltnews40.tex
+++ b/base/doc/ltnews40.tex
@@ -420,7 +420,7 @@ has now been corrected.
 The \pkg{fileerr} extraction has been modified to write \texttt{rename-to-empty-base.tex}
 rather than \texttt{.tex} to comply with an expected security change in texlive 2025.
 \texttt{build.lua} has been  modified to rename \texttt{rename-to-empty-base.tex} to \texttt{.tex}
-after unpacking however if using \textsf{docstrip} directly rather than using \textsf{l3build}
+after unpacking. However if using \textsf{docstrip} directly rather than using \textsf{l3build}
 or the unpacked zip file from \CTAN{}, the user must now rename the file and  install as \texttt{.tex}.
 %
 \githubissue{1412}

--- a/required/tools/build.lua
+++ b/required/tools/build.lua
@@ -63,3 +63,6 @@ function unpack(sources, sourcedirs)
   end
   return 0
 end
+
+-- update function binding
+target_list.unpack.func = unpack

--- a/required/tools/build.lua
+++ b/required/tools/build.lua
@@ -40,29 +40,21 @@ checkconfigs = {"build","config-TU","config-legacy","config-search"}
 dofile (maindir .. "/build-config.lua")
 
 -- special code to handle .tex
-
-function unpack(sources, sourcedirs)
-  local errorlevel = dep_install(unpackdeps)
+oldbundleunpack=bundleunpack
+function bundleunpack(sourcedirs, sources)
+  errorlevel = oldbundleunpack(sourcedirs, sources)
   if errorlevel ~= 0 then
     return errorlevel
   end
-  errorlevel = bundleunpack(sourcedirs, sources)
-  if errorlevel ~= 0 then
-    return errorlevel
-  end
-  texio.write(" * Renaming rename-to-empty-base.tex to .tex")
-  errorlevel = ren(unpackdir,"rename-to-empty-base.tex",".tex")
-  if errorlevel ~= 0 then
-    return errorlevel
-  end
-  for _,i in ipairs(installfiles) do
-    errorlevel = cp(i, unpackdir, localdir)
+  if module == "tools" then
+    texio.write(" * Renaming rename-to-empty-base.tex to .tex\n")
+    errorlevel = ren(unpackdir,"rename-to-empty-base.tex",".tex")
     if errorlevel ~= 0 then
-      return errorlevel
+     return errorlevel
     end
   end
   return 0
 end
 
 -- update function binding
-target_list.unpack.func = unpack
+target_list.bundleunpack.func = bundleunpack

--- a/required/tools/build.lua
+++ b/required/tools/build.lua
@@ -47,7 +47,7 @@ function bundleunpack(sourcedirs, sources)
     return errorlevel
   end
   if module == "tools" then
-    texio.write(" * Renaming rename-to-empty-base.tex to .tex\n")
+    print(" * Renaming rename-to-empty-base.tex to .tex")
     errorlevel = ren(unpackdir,"rename-to-empty-base.tex",".tex")
     if errorlevel ~= 0 then
      return errorlevel

--- a/required/tools/build.lua
+++ b/required/tools/build.lua
@@ -38,3 +38,28 @@ checkconfigs = {"build","config-TU","config-legacy","config-search"}
 
 -- Load the common settings for the LaTeX2e repo
 dofile (maindir .. "/build-config.lua")
+
+-- special code to handle .tex
+
+function unpack(sources, sourcedirs)
+  local errorlevel = dep_install(unpackdeps)
+  if errorlevel ~= 0 then
+    return errorlevel
+  end
+  errorlevel = bundleunpack(sourcedirs, sources)
+  if errorlevel ~= 0 then
+    return errorlevel
+  end
+  texio.write(" * Renaming rename-to-empty-base.tex to .tex")
+  errorlevel = ren(unpackdir,"rename-to-empty-base.tex",".tex")
+  if errorlevel ~= 0 then
+    return errorlevel
+  end
+  for _,i in ipairs(installfiles) do
+    errorlevel = cp(i, unpackdir, localdir)
+    if errorlevel ~= 0 then
+      return errorlevel
+    end
+  end
+  return 0
+end

--- a/required/tools/build.lua
+++ b/required/tools/build.lua
@@ -50,7 +50,7 @@ function bundleunpack(sourcedirs, sources)
     print(" * Renaming rename-to-empty-base.tex to .tex")
     errorlevel = ren(unpackdir,"rename-to-empty-base.tex",".tex")
     if errorlevel ~= 0 then
-     return errorlevel
+      return errorlevel
     end
   end
   return 0

--- a/required/tools/changes.txt
+++ b/required/tools/changes.txt
@@ -1,3 +1,10 @@
+2024-09-12  David Carlisle  <David.Carlisle@latex-project.org>
+
+	* build.lua, tools.ins:
+	Modify fileerr extraction to write rename-to-empty-base.tex rather than .tex
+	to comply with expected security change in texlive 2025
+	build.lua modified to rename rename-to-empty-base.tex to .tex after unpacking.
+
 2024-08-13  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
 
 	* longtable.dtx:

--- a/required/tools/tools.ins
+++ b/required/tools/tools.ins
@@ -195,6 +195,8 @@ given in the file `manifest.txt'.
   \file{r.tex}{\from{fileerr.dtx}{run}}
   \file{x.tex}{\from{fileerr.dtx}{exit}}}
 
+\generate{\file{rename-to-empty-base.tex}{\from{fileerr.dtx}{return}}}
+
 
 \Msg{***********************************************************}
 \Msg{*}
@@ -202,21 +204,13 @@ given in the file `manifest.txt'.
 \Msg{* files into a directory searched by TeX:}
 \Msg{*}
 \Msg{* All the files with extension `.sty' and `.tex'}
-\Msg{* Note there also may be a file .tex which is `invisible'}
-\Msg{* on some operating systems.}
+\Msg{* TeX may be blocked from writing .tex so writing rename-to-empty-base.tex}
+\Msg{* Rename that file to .tex after the docstrip generation.}
 \Msg{*}
 \Msg{* To produce the documentation run the .dtx files through LaTeX.}
 \Msg{*}
 \Msg{* Happy TeXing}
 \Msg{***********************************************************}
 
-
-\Msg{}
-\Msg{* Finally trying to make a file `.tex'.}
-\Msg{* TeX may be blocked from writing .tex so writing rename-to-empty-base.tex}
-\Msg{* Rename that file to .tex after the docstrip generation}
-
-
-\generate{\file{rename-to-empty-base.tex}{\from{fileerr.dtx}{return}}}
 
 \endbatchfile

--- a/required/tools/tools.ins
+++ b/required/tools/tools.ins
@@ -213,12 +213,10 @@ given in the file `manifest.txt'.
 
 \Msg{}
 \Msg{* Finally trying to make a file `.tex'.}
-\Msg{* (Placed at the end of this run, as this}
-\Msg{*  may fail on some operating systems.)}
+\Msg{* TeX may be blocked from writing .tex so writing rename-to-empty-base.tex}
+\Msg{* Rename that file to .tex after the docstrip generation}
 
-\let\oldopenout\openout
-\def\openout{\batchmode\immediate\oldopenout}
 
-\generate{\file{.tex}{\from{fileerr.dtx}{return}}}
+\generate{\file{rename-to-empty-base.tex}{\from{fileerr.dtx}{return}}}
 
 \endbatchfile

--- a/required/tools/tools.ins
+++ b/required/tools/tools.ins
@@ -204,8 +204,9 @@ given in the file `manifest.txt'.
 \Msg{* files into a directory searched by TeX:}
 \Msg{*}
 \Msg{* All the files with extension `.sty' and `.tex'}
-\Msg{* TeX may be blocked from writing .tex so writing rename-to-empty-base.tex}
-\Msg{* Rename that file to .tex after the docstrip generation.}
+\Msg{* TeX may be blocked from writing a file called `.tex',}
+\Msg{* so generated a file with name `rename-to-empty-base.tex'.}
+\Msg{* Rename that file to `.tex' after the docstrip generation.}
 \Msg{*}
 \Msg{* To produce the documentation run the .dtx files through LaTeX.}
 \Msg{*}


### PR DESCRIPTION
## Status of pull request



- ready to merge

<strike>Currently no changelog or ltnews item, just looking for review on the mechanism</strike>
(write a file with non-empty base then use an overloaded l3build <strike>unpack</strike> bundleunpack function
to rename at the end.

As far as I can see the l3build texlua script renaming a file via os.execute{mv ...
is not subject to the restriction on writing .tex. (confirmed by Karl in the associated issue)

