### PR TITLE
Improve footnotes and adapt Ref to changes in tagpdf

### DIFF
--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -1,4 +1,8 @@
 2024-09-19 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
+	* latex-lab-sec.dtx,latex-lab-footnotes.dtx: 
+	correct and improve footnotes in longtable
+
+2024-09-19 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
 	* latex-lab-toc.dtx,latex-lab-footnotes.dtx: adapt Ref handling to tagpdf 0.99f
 
 2024-09-13 Ulrike Fischer <Ulrike.Fischer@latex-project.org>

--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -1,3 +1,6 @@
+2024-09-19 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
+	* latex-lab-toc.dtx,latex-lab-footnotes.dtx: adapt Ref handling to tagpdf 0.99f
+
 2024-09-13 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
 	* documentmetadata-support.dtx: change warning to error if pdfstandard is unknown,
       see https://github.com/latex3/pdfresources/issues/77#issuecomment-2329522654. 

--- a/required/latex-lab/latex-lab-footnotes.dtx
+++ b/required/latex-lab/latex-lab-footnotes.dtx
@@ -17,8 +17,8 @@
 %
 % for those people who are interested or want to report an issue.
 %
-\def\ltlabfootnotedate{2024-07-27}
-\def\ltlabfootnoteversion{0.8e}
+\def\ltlabfootnotedate{2024-09-19}
+\def\ltlabfootnoteversion{0.8f}
 
 %<*driver>
 \documentclass{l3doc}
@@ -1953,10 +1953,7 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_gput_ref:nn #1 #2 %#1 the structure number receiving the ref #2
   {
-    \tag_if_active:T
-      {
-        \tag_struct_gput:nne {#1}{ref}{\tag_struct_object_ref:e { #2 }}
-      }
+    \tag_struct_gput:nnn {#1}{ref_num}{#2}
   }
 \cs_new_protected:Npn \fnote_gput_refs:nn #1 #2 % pair of numbers
   {

--- a/required/latex-lab/latex-lab-footnotes.dtx
+++ b/required/latex-lab/latex-lab-footnotes.dtx
@@ -1985,6 +1985,10 @@
         \tag_struct_begin:n 
           { 
             tag=footnote,
+%    \end{macrocode}
+% We add 0 for now to ensure to get a number even if the sec code is not loaded
+% or if the seq is empty (which it shouldn't unless there is an coding error) 
+%    \begin{macrocode}
             parent=\int_max:nn{2}{\tag_get:n{current_Sect}+0} 
           }
       }  

--- a/required/latex-lab/latex-lab-footnotes.dtx
+++ b/required/latex-lab/latex-lab-footnotes.dtx
@@ -1964,11 +1964,7 @@
 %    \end{macrocode}
 % \end{macro}
 %
-%    \begin{macrocode}
-\tl_new:N \l_@@_dflt_struct_tl
-\tl_set:Nn \l_@@_dflt_struct_tl {1}
-%    \end{macrocode}
-% kernel hooks for taggin
+% kernel hooks for tagging
 % this sets the structure around the whole text
 %
 %
@@ -1978,14 +1974,19 @@
   {
     \tag_mc_end_push:
 %    \end{macrocode}
-% test if a footnote is allowed, if not move up to the document structure.
+% test if a footnote is allowed, if not move up to the next sect or
+% the document structure.
 %    \begin{macrocode}
     \tag_check_child:nnTF {FENote}{pdf2}
       { 
         \tag_struct_begin:n { tag=footnote }
       }
       {  
-        \tag_struct_begin:n { tag=footnote,parent=\l_@@_dflt_struct_tl }
+        \tag_struct_begin:n 
+          { 
+            tag=footnote,
+            parent=\int_max:nn{2}{\tag_get:n{current_Sect}+0} 
+          }
       }  
 %    \end{macrocode}
 % Store the current structure number for labels.

--- a/required/latex-lab/latex-lab-sec.dtx
+++ b/required/latex-lab/latex-lab-sec.dtx
@@ -16,8 +16,8 @@
 %
 % for those people who are interested or want to report an issue.
 %
-\def\ltlabsecdate{2024-07-05}
-\def\ltlabsecversion{0.84c}
+\def\ltlabsecdate{2024-09-19}
+\def\ltlabsecversion{0.84d}
 %<*driver>
 \documentclass[kernel]{l3doc}
 \EnableCrossrefs

--- a/required/latex-lab/latex-lab-sec.dtx
+++ b/required/latex-lab/latex-lab-sec.dtx
@@ -227,55 +227,56 @@
 %
 %    \begin{macrocode}
 %<*package>
+%<@@=tag>
 %    \end{macrocode}
 % \subsubsection{Tagging commands}
 %
 %
-% \begin{variable}{\g__tag_sec_stack_seq}
+% \begin{variable}{\g_@@_sec_stack_seq}
 % The stack holds the tag, the level and the structure number.
 %    \begin{macrocode}
-\seq_new:N   \g__tag_sec_stack_seq
-\seq_gpush:Nn\g__tag_sec_stack_seq {{Document}{-100}{2}}
+\seq_new:N   \g_@@_sec_stack_seq
+\seq_gpush:Nn\g_@@_sec_stack_seq {{Document}{-100}{2}}
 %    \end{macrocode}
 % \end{variable}
 % 
-% \begin{macro}{\__tag_get_data_current_Sect:}
+% \begin{macro}{\@@_get_data_current_Sect:}
 % This allows to retrieve the number of the current Sect structure (or
 % Document if we are outside any Sect) with |\tag_get:n{current_Sect}|
 %    \begin{macrocode}
-\cs_new:Npn \__tag_get_data_current_Sect:
+\cs_new:Npn \@@_get_data_current_Sect:
  {
-   \exp_last_unbraced:Ne\use_iii:nnn{\seq_item:Nn\g__tag_sec_stack_seq{1}}
+   \exp_last_unbraced:Ne\use_iii:nnn{\seq_item:Nn\g_@@_sec_stack_seq{1}}
  }
 %    \end{macrocode}
 % \end{macro}
-% \begin{variable}{\l__tag_sec_Sect_bool}
+% \begin{variable}{\l_@@_sec_Sect_bool}
 % This boolean controls if a Sect structure is opened. 
 %    \begin{macrocode}
-\bool_new:N     \l__tag_sec_Sect_bool
-\bool_set_true:N\l__tag_sec_Sect_bool
+\bool_new:N     \l_@@_sec_Sect_bool
+\bool_set_true:N\l_@@_sec_Sect_bool
 %    \end{macrocode}
 % \end{variable}
 %
-% \begin{macro}{\__tag_sec_begin:nn}
+% \begin{macro}{\@@_sec_begin:nn}
 % This starts a sectioning structure. 
 % Currently the tag is fix, either Sect or Part, depending on the level,
 % but this will perhaps change. The second argument is currently unused.
 %    \begin{macrocode}
-\cs_new_protected:Npn\__tag_sec_begin:nn #1 #2 %#1 level #2 keyval
+\cs_new_protected:Npn\@@_sec_begin:nn #1 #2 %#1 level #2 keyval
   {
     \tag_struct_begin:n 
       {
          tag= {\int_compare:nNnTF {#1}={-1}{Part}{Sect}}
         ,#2
       } 
-    \seq_gpush:Ne \g__tag_sec_stack_seq 
-      {{\g__tag_struct_tag_tl}{\int_eval:n{#1}}{\g__tag_struct_stack_current_tl}}    
+    \seq_gpush:Ne \g_@@_sec_stack_seq 
+      {{\g_@@_struct_tag_tl}{\int_eval:n{#1}}{\g_@@_struct_stack_current_tl}}    
   }
 %    \end{macrocode}
 % \end{macro}
 % 
-% \begin{macro}{\__tag_sec_end:n}
+% \begin{macro}{\@@_sec_end:n}
 %    \begin{macrocode}
 \msg_new:nnn { tag } {wrong-sect-nesting}
   {
@@ -283,65 +284,65 @@
     It~is~not~equal~to~the~current~structure~#2~on~the~main~stack
   }
 
-\cs_new_protected:Npn\__tag_sec_end:n #1 % #1 level
+\cs_new_protected:Npn\@@_sec_end:n #1 % #1 level
   {
-    \seq_get:NN \g__tag_sec_stack_seq \l__tag_tmpa_tl
-    \int_compare:nNnT {#1}<{\exp_last_unbraced:NV\use_ii:nnn\l__tag_tmpa_tl+1}
+    \seq_get:NN \g_@@_sec_stack_seq \l_@@_tmpa_tl
+    \int_compare:nNnT {#1}<{\exp_last_unbraced:NV\use_ii:nnn\l_@@_tmpa_tl+1}
       {
-        \seq_get:NN\g__tag_struct_tag_stack_seq \l__tag_tmpb_tl
+        \seq_get:NN\g_@@_struct_tag_stack_seq \l_@@_tmpb_tl
         \exp_args:Nee
           \tl_if_eq:nnTF 
-            {\exp_last_unbraced:NV\use_i:nnn\l__tag_tmpa_tl}
-            {\exp_last_unbraced:NV\use_i:nn\l__tag_tmpb_tl}
+            {\exp_last_unbraced:NV\use_i:nnn\l_@@_tmpa_tl}
+            {\exp_last_unbraced:NV\use_i:nn\l_@@_tmpb_tl}
             {
-              \seq_gpop:NN \g__tag_sec_stack_seq \l__tag_tmpa_tl
+              \seq_gpop:NN \g_@@_sec_stack_seq \l_@@_tmpa_tl
               \tag_struct_end:
-              \__tag_sec_end:n {#1}        
+              \@@_sec_end:n {#1}        
             }
             { 
               \msg_warning:nnee {tag}{wrong-sect-nesting}
-               { \exp_last_unbraced:NV\use_i:nnn \l__tag_tmpa_tl }
-               { \exp_last_unbraced:NV\use_i:nn \l__tag_tmpb_tl } 
+               { \exp_last_unbraced:NV\use_i:nnn \l_@@_tmpa_tl }
+               { \exp_last_unbraced:NV\use_i:nn \l_@@_tmpb_tl } 
             }
       }  
   } 
 %    \end{macrocode}
 % \end{macro}
 
-% \begin{macro}{\__tag_tool_para_split:}
+% \begin{macro}{\@@_tool_para_split:}
 % Runin-sectioning command must separate the heading from the following text. 
 % 
 %    \begin{macrocode}
-\cs_new_protected:Npn \__tag_tool_para_split:
+\cs_new_protected:Npn \@@_tool_para_split:
   {
     \tag_mc_end:
     \tag_struct_end:        
-    \tag_struct_begin:n{tag=\l__tag_para_tag_default_tl}
+    \tag_struct_begin:n{tag=\l_@@_para_tag_default_tl}
     \tag_mc_begin:n{}
-    \__tag_setup_restore_para_default:
+    \@@_setup_restore_para_default:
   }
 %    \end{macrocode}
 % \end{macro}
 
-% \begin{macro}{\__tag_setup_restore_para_default:}
+% \begin{macro}{\@@_setup_restore_para_default:}
 % We change the para tagging in the sectioning code.
 % This here restores the default. Currently it only resets the 
 % the tag, but perhaps more will be needed later. 
 %    \begin{macrocode}
-\cs_new_protected:Npn \__tag_setup_restore_para_default:
+\cs_new_protected:Npn \@@_setup_restore_para_default:
   {
-    \tl_set:Nn \l__tag_para_main_tag_tl {text-unit}
-    \tl_set_eq:NN\l__tag_para_tag_tl\l__tag_para_tag_default_tl
+    \tl_set:Nn \l_@@_para_main_tag_tl {text-unit}
+    \tl_set_eq:NN\l_@@_para_tag_tl\l_@@_para_tag_default_tl
   }
 %    \end{macrocode}
 % \end{macro}
 % 
-% \begin{macro}{\__tag_sec_end_display:}
+% \begin{macro}{\@@_sec_end_display:}
 %    \begin{macrocode}
-\cs_new_protected:Npn \__tag_sec_end_display:
+\cs_new_protected:Npn \@@_sec_end_display:
   {
     \tag_struct_end: %P = Hn
-    \__tag_setup_restore_para_default:
+    \@@_setup_restore_para_default:
   }
 %    \end{macrocode}
 % \end{macro}
@@ -349,17 +350,17 @@
 % Open sec structures should be closed at the end of the document. This should
 % be done before tagpdf closes the Document structure.
 %    \begin{macrocode}
-\hook_gput_code:nnn{tagpdf/finish/before}{tagpdf/sec}{\__tag_sec_end:n{-10}}
+\hook_gput_code:nnn{tagpdf/finish/before}{tagpdf/sec}{\@@_sec_end:n{-10}}
 \hook_gset_rule:nnnn {tagpdf/finish/before}{tagpdf/sec}{before}{tagpdf}  
 %    \end{macrocode}
 %
 % The commands \cs{mainmatter}, \cs{backmatter}, \cs{frontmatter} and
 % \cs{appendix} close all \texttt{Sect} and \texttt{Part} structures.
 %    \begin{macrocode}
-\AddToHook{cmd/frontmatter/before}{\__tag_sec_end:n{-10}}
-\AddToHook{cmd/mainmatter/before} {\__tag_sec_end:n{-10}}
-\AddToHook{cmd/backmatter/before} {\__tag_sec_end:n{-10}}
-\AddToHook{cmd/appendix/before}   {\__tag_sec_end:n{-10}}
+\AddToHook{cmd/frontmatter/before}{\@@_sec_end:n{-10}}
+\AddToHook{cmd/mainmatter/before} {\@@_sec_end:n{-10}}
+\AddToHook{cmd/backmatter/before} {\@@_sec_end:n{-10}}
+\AddToHook{cmd/appendix/before}   {\@@_sec_end:n{-10}}
 %    \end{macrocode}
 %
 % \subsection{Tagging tools}
@@ -378,10 +379,10 @@
   {
     ,sec-start-part .code:n = 
       {
-        \bool_if:NT\l__tag_sec_Sect_bool
+        \bool_if:NT\l_@@_sec_Sect_bool
           {
-            \__tag_sec_end:n   {-1} 
-            \__tag_sec_begin:nn{-1}{tag=Part}
+            \@@_sec_end:n   {-1} 
+            \@@_sec_begin:nn{-1}{tag=Part}
           }  
          \tag_struct_begin:n{tag=part,title=#1}
 %    \end{macrocode}
@@ -392,43 +393,43 @@
 % all slightly different in the standard classes. So this is delayed 
 % to the time when sectioning commands are redefined with templates.
 %    \begin{macrocode}
-         \tl_set:Nn\l__tag_para_main_tag_tl {NonStruct}
-         \tl_set:Nn\l__tag_para_tag_tl {Span}
+         \tl_set:Nn\l_@@_para_main_tag_tl {NonStruct}
+         \tl_set:Nn\l_@@_para_tag_tl {Span}
       }
-    ,sec-stop-part .code:n = {\__tag_sec_end_display:}
+    ,sec-stop-part .code:n = {\@@_sec_end_display:}
     ,sec-start-chapter .code:n =
      {
-       \bool_if:NT\l__tag_sec_Sect_bool
+       \bool_if:NT\l_@@_sec_Sect_bool
          {
-           \__tag_sec_end:n   {0} 
-           \__tag_sec_begin:nn{0}{tag=Sect}
+           \@@_sec_end:n   {0} 
+           \@@_sec_begin:nn{0}{tag=Sect}
          }  
         \tag_struct_begin:n{tag=chapter,title=#1}
 %    \end{macrocode}
 % similar to part we remap to NonStruct for now ...
 %    \begin{macrocode}
-        \tl_set:Nn\l__tag_para_main_tag_tl {NonStruct}
-        \tl_set:Nn\l__tag_para_tag_tl {Span}
+        \tl_set:Nn\l_@@_para_main_tag_tl {NonStruct}
+        \tl_set:Nn\l_@@_para_tag_tl {Span}
      }
     ,sec-stop-chapter .meta:n = { sec-stop-part}  
     ,sec-start .code:n = % #1 is a name like "section" 
       {        
-        \bool_if:NT\l__tag_sec_Sect_bool
+        \bool_if:NT\l_@@_sec_Sect_bool
           {       
-            \__tag_sec_end:n    {\cs_if_exist_use:c{toclevel@#1}+0} 
-            \__tag_sec_begin:nn {\cs_if_exist_use:c{toclevel@#1}+0}{tag=Sect}
+            \@@_sec_end:n    {\cs_if_exist_use:c{toclevel@#1}+0} 
+            \@@_sec_begin:nn {\cs_if_exist_use:c{toclevel@#1}+0}{tag=Sect}
           }  
-        \tl_set:Nn\l__tag_para_tag_tl{#1}
+        \tl_set:Nn\l_@@_para_tag_tl{#1}
       } 
     ,sec-start .value_required:n = true     
-    ,sec-split-para .code:n = {\__tag_tool_para_split:}
-    ,restore-para .code:n = {\__tag_setup_restore_para_default:}
+    ,sec-split-para .code:n = {\@@_tool_para_split:}
+    ,restore-para .code:n = {\@@_setup_restore_para_default:}
     ,sec-stop .code:n = 
       {
-        \par\__tag_sec_end:n   {\cs_if_exist_use:c{toclevel@#1}+0}
+        \par\@@_sec_end:n   {\cs_if_exist_use:c{toclevel@#1}+0}
       }
     ,sec-stop .value_required:n = true  
-    ,sec-add-grouping .bool_set:N = \l__tag_sec_Sect_bool
+    ,sec-add-grouping .bool_set:N = \l_@@_sec_Sect_bool
   } 
 %    \end{macrocode}
 %
@@ -679,8 +680,8 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@kernel@tag@hangfrom #1
   {
-     \tagstructbegin{tag=\l__tag_para_tag_tl}
-     \cs_if_exist_use:N \__tag_gincr_para_begin_int:
+     \tagstructbegin{tag=\l_@@_para_tag_tl}
+     \cs_if_exist_use:N \@@_gincr_para_begin_int:
      \tagstructbegin{tag=Lbl}
      \setbox\@tempboxa
        \hbox
@@ -690,7 +691,7 @@
 %    \begin{macrocode}
            \bool_lazy_and:nnT
             {\tag_if_active_p:}
-            {\g__tag_mode_lua_bool}
+            {\g_@@_mode_lua_bool}
             {\tagmcbegin{tag=Lbl}}
            {#1}
          }
@@ -725,6 +726,7 @@
 % \cs{@sect} is only changed to replace the hyperref patches
 % and to use the new \cs{@kernel@tag@hangfrom} and \cs{@kernel@tag@svsec}
 %    \begin{macrocode}
+%<@@=>
 \def\@sect#1#2#3#4#5#6[#7]#8{%  
   \ifnum #2>\c@secnumdepth
     \def\@svsec{\@hyp@section@target@nnn{[section]}{}{#3}}
@@ -737,7 +739,7 @@
   \@tempskipa #5\relax
   \ifdim \@tempskipa>\z@
     \begingroup
-    \tagtool{para-flattened=true} % or \bool_set_true\l__tag_para_flattened_bool
+    \tagtool{para-flattened=true} % or \bool_set_true\l_@@_para_flattened_bool
       #6{%
          \ifnum #2>\c@secnumdepth
           \@hangfrom {\hskip #3\relax\@svsec}%

--- a/required/latex-lab/latex-lab-sec.dtx
+++ b/required/latex-lab/latex-lab-sec.dtx
@@ -232,13 +232,23 @@
 %
 %
 % \begin{variable}{\g__tag_sec_stack_seq}
-% The stack holds the tag and the level.
+% The stack holds the tag, the level and the structure number.
 %    \begin{macrocode}
 \seq_new:N   \g__tag_sec_stack_seq
-\seq_gpush:Nn\g__tag_sec_stack_seq {{Document}{-100}}
+\seq_gpush:Nn\g__tag_sec_stack_seq {{Document}{-100}{2}}
 %    \end{macrocode}
 % \end{variable}
 % 
+% \begin{macro}{\__tag_get_data_current_Sect:}
+% This allows to retrieve the number of the current Sect structure (or
+% Document if we are outside any Sect) with |\tag_get:n{current_Sect}|
+%    \begin{macrocode}
+\cs_new:Npn \__tag_get_data_current_Sect:
+ {
+   \exp_last_unbraced:Ne\use_iii:nnn{\seq_item:Nn\g__tag_sec_stack_seq{1}}
+ }
+%    \end{macrocode}
+% \end{macro}
 % \begin{variable}{\l__tag_sec_Sect_bool}
 % This boolean controls if a Sect structure is opened. 
 %    \begin{macrocode}
@@ -246,8 +256,7 @@
 \bool_set_true:N\l__tag_sec_Sect_bool
 %    \end{macrocode}
 % \end{variable}
- 
-% 
+%
 % \begin{macro}{\__tag_sec_begin:nn}
 % This starts a sectioning structure. 
 % Currently the tag is fix, either Sect or Part, depending on the level,
@@ -260,7 +269,8 @@
          tag= {\int_compare:nNnTF {#1}={-1}{Part}{Sect}}
         ,#2
       } 
-    \seq_gpush:Ne \g__tag_sec_stack_seq {{\g__tag_struct_tag_tl}{\int_eval:n{#1}}}    
+    \seq_gpush:Ne \g__tag_sec_stack_seq 
+      {{\g__tag_struct_tag_tl}{\int_eval:n{#1}}{\g__tag_struct_stack_current_tl}}    
   }
 %    \end{macrocode}
 % \end{macro}
@@ -276,12 +286,12 @@
 \cs_new_protected:Npn\__tag_sec_end:n #1 % #1 level
   {
     \seq_get:NN \g__tag_sec_stack_seq \l__tag_tmpa_tl
-    \int_compare:nNnT {#1}<{\exp_last_unbraced:NV\use_ii:nn\l__tag_tmpa_tl+1}
+    \int_compare:nNnT {#1}<{\exp_last_unbraced:NV\use_ii:nnn\l__tag_tmpa_tl+1}
       {
         \seq_get:NN\g__tag_struct_tag_stack_seq \l__tag_tmpb_tl
         \exp_args:Nee
           \tl_if_eq:nnTF 
-            {\exp_last_unbraced:NV\use_i:nn\l__tag_tmpa_tl}
+            {\exp_last_unbraced:NV\use_i:nnn\l__tag_tmpa_tl}
             {\exp_last_unbraced:NV\use_i:nn\l__tag_tmpb_tl}
             {
               \seq_gpop:NN \g__tag_sec_stack_seq \l__tag_tmpa_tl
@@ -290,7 +300,7 @@
             }
             { 
               \msg_warning:nnee {tag}{wrong-sect-nesting}
-               { \exp_last_unbraced:NV\use_i:nn \l__tag_tmpa_tl }
+               { \exp_last_unbraced:NV\use_i:nnn \l__tag_tmpa_tl }
                { \exp_last_unbraced:NV\use_i:nn \l__tag_tmpb_tl } 
             }
       }  

--- a/required/latex-lab/latex-lab-toc.dtx
+++ b/required/latex-lab/latex-lab-toc.dtx
@@ -143,21 +143,21 @@
 % Moved into tagpdf!
 % \end{variable}
 %
-% \begin{macro}{\g_@@_struct_ref_by_dest:}
+% \begin{macro}{\@@_struct_ref_by_dest:}
 %  This command is executed and update the Ref keys
 %  of the structures listed in |\g_@@_struct_ref_by_dest_prop|.
 %  It is currently only relevant for the |TOCI|. But other structures
 %  could need that later too.
 %  The command is executed in the |tagpdf/finish/before| hook.
 %    \begin{macrocode}
-\cs_new_protected:Npn \g_@@_struct_ref_by_dest:
+\cs_new_protected:Npn \@@_struct_ref_by_dest:
   {
     \prop_map_inline:Nn\g_@@_struct_ref_by_dest_prop
       {
         \tag_struct_gput:nnn {##1}{ref_dest}{##2}
       }
   }
-\hook_gput_code:nnn {tagpdf/finish/before}{tagpdf/struct/Ref}{\g_@@_struct_ref_by_dest:}
+\hook_gput_code:nnn {tagpdf/finish/before}{tagpdf/struct/Ref}{\@@_struct_ref_by_dest:}
 %    \end{macrocode}
 % \end{macro}
 %

--- a/required/latex-lab/latex-lab-toc.dtx
+++ b/required/latex-lab/latex-lab-toc.dtx
@@ -160,15 +160,7 @@
   {
     \prop_map_inline:Nn\g_@@_struct_ref_by_dest_prop
       {
-        \prop_get:NnNTF \g_@@_struct_dest_num_prop {##2} \l_@@_tmpa_tl
-          {
-            \@@_struct_gput_data_ref:ee
-              { ##1 }
-              { \tag_struct_object_ref:e{ \l_@@_tmpa_tl }}
-          }
-          {
-            \msg_warning:nnnn {tag}{struct-dest-unknown}{##2}{ ##1}
-          }
+        \tag_struct_gput:nnn {##1}{ref_dest}{##2}
       }
   }
 \hook_gput_code:nnn {tagpdf/finish/before}{tagpdf/struct/Ref}{\g_@@_struct_ref_by_dest:}

--- a/required/latex-lab/latex-lab-toc.dtx
+++ b/required/latex-lab/latex-lab-toc.dtx
@@ -16,8 +16,8 @@
 %
 % for those people who are interested or want to report an issue.
 %
-\def\ltlabtocdate{2024-07-11}
-\def\ltlabtocversion{0.85c}
+\def\ltlabtocdate{2024-09-19}
+\def\ltlabtocversion{0.85d}
 %<*driver>
 \documentclass{l3doc}
 \EnableCrossrefs
@@ -150,12 +150,6 @@
 %  could need that later too.
 %  The command is executed in the |tagpdf/finish/before| hook.
 %    \begin{macrocode}
-\msg_new:nnn { tag } {struct-dest-unknown}
- {
-   Destination~#1~has~no~related~structure.\\
-   /Ref~for~structure~#2~not~updated
- }
-
 \cs_new_protected:Npn \g_@@_struct_ref_by_dest:
   {
     \prop_map_inline:Nn\g_@@_struct_ref_by_dest_prop

--- a/required/latex-lab/latex-lab-toc.dtx
+++ b/required/latex-lab/latex-lab-toc.dtx
@@ -136,30 +136,6 @@
     }
  }
 %    \end{macrocode}
-% \begin{variable}{\g_@@_struct_ref_by_dest_prop}
-% This variable contains structures whose Ref key should be updated
-% at the end to point to structured related with this destination.
-% As this is probably need in other places too, it is not only a toc-variable.
-% Moved into tagpdf!
-% \end{variable}
-%
-% \begin{macro}{\@@_struct_ref_by_dest:}
-%  This command is executed and update the Ref keys
-%  of the structures listed in |\g_@@_struct_ref_by_dest_prop|.
-%  It is currently only relevant for the |TOCI|. But other structures
-%  could need that later too.
-%  The command is executed in the |tagpdf/finish/before| hook.
-%    \begin{macrocode}
-\cs_new_protected:Npn \@@_struct_ref_by_dest:
-  {
-    \prop_map_inline:Nn\g_@@_struct_ref_by_dest_prop
-      {
-        \tag_struct_gput:nnn {##1}{ref_dest}{##2}
-      }
-  }
-\hook_gput_code:nnn {tagpdf/finish/before}{tagpdf/struct/Ref}{\@@_struct_ref_by_dest:}
-%    \end{macrocode}
-% \end{macro}
 %
 % \section{Toc code}
 % \begin{variable}{\g_@@_toc_level_int,\g_@@_toc_stack_seq}
@@ -294,17 +270,17 @@
 %    \begin{macrocode}
           \group_begin:
            \text_declare_expand_equivalent:Nn \numberline \use_none:n
-           \exp_args:Ne \tag_struct_begin:n{tag=TOCI,title={\text_purify:n {#2}}}
+           \exp_args:Ne 
+           \tag_struct_begin:n{tag=TOCI,title={\text_purify:n {#2}}}           
 %    \end{macrocode}
-% The TOCI structure should get a /Ref, so we put a request with its destination
-% name into the prop.
+% The TOCI structure should get a /Ref, we use a destination
+% to retrieve it.
 % \begin{NOTE}{UF}
 % This only works with hyperref currently. Without hyperref we
 % need to store fake names.
 % \end{NOTE}
 %    \begin{macrocode}
-           \prop_gput:Nee \g_@@_struct_ref_by_dest_prop
-             { \tag_get:n {struct_num} }{#4}
+           \tag_struct_gput:nnn { \tag_get:n {struct_num} }{ref_dest}{#4}
            \seq_gpush:Ne \g_@@_toc_stack_seq {{TOCI}\use:c{toclevel@#1}}
           \group_end:
        }

--- a/required/latex-lab/testfiles-OR-luatex/footmisc-014-hang.tlg
+++ b/required/latex-lab/testfiles-OR-luatex/footmisc-014-hang.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/check-declarations.tlg
+++ b/required/latex-lab/testfiles-OR/check-declarations.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footmisc-002.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-002.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footmisc-003.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-003.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footmisc-004.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-004.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footmisc-005.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-005.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footmisc-006.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-006.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footmisc-007-rollback.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-007-rollback.tlg
@@ -74,7 +74,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footmisc-009-multiple-tagging.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-009-multiple-tagging.tlg
@@ -71,7 +71,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footmisc-009-multiple.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-009-multiple.tlg
@@ -71,7 +71,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footmisc-010-setspace-tagging.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-010-setspace-tagging.tlg
@@ -66,7 +66,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footmisc-010-setspace.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-010-setspace.tlg
@@ -66,7 +66,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footmisc-011-para.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-011-para.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footmisc-012-side-hyperref.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-012-side-hyperref.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footmisc-012-side.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-012-side.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footmisc-013-scrartcl.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-013-scrartcl.tlg
@@ -60,7 +60,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footmisc-014-hang.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-014-hang.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footmisc-floats-abovefloats-flushbottom.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-floats-abovefloats-flushbottom.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footmisc-floats-abovefloats.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-floats-abovefloats.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footmisc-floats-belowfloats-flushbottom.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-floats-belowfloats-flushbottom.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footmisc-floats-latex.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-floats-latex.tlg
@@ -55,7 +55,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footnote-float-above.tlg
+++ b/required/latex-lab/testfiles-OR/footnote-float-above.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footnote-hyperref-001.tlg
+++ b/required/latex-lab/testfiles-OR/footnote-hyperref-001.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/footnote-par.tlg
+++ b/required/latex-lab/testfiles-OR/footnote-par.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/tagging-001.tlg
+++ b/required/latex-lab/testfiles-OR/tagging-001.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\l__fnote_dflt_struct_tl }}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote

--- a/required/latex-lab/testfiles-OR/tagging-002-longtable.pvt
+++ b/required/latex-lab/testfiles-OR/tagging-002-longtable.pvt
@@ -1,0 +1,16 @@
+\DocumentMetadata{testphase={phase-III,title,table,firstaid}}
+\input{regression-test}
+\documentclass{article}
+\usepackage{longtable}
+
+\begin{document}
+\START
+\section{abc}
+\begin{longtable}{p{3cm}}
+ Test\footnote{abc}\\
+\end{longtable}
+\subsection{bla}
+\begin{longtable}{p{3cm}}
+ Test\footnote{abc}\\
+\end{longtable}
+\end{document}

--- a/required/latex-lab/testfiles-OR/tagging-002-longtable.tpf
+++ b/required/latex-lab/testfiles-OR/tagging-002-longtable.tpf
@@ -1,0 +1,1709 @@
+%PDF-1.5
+%–‘≈ÿ
+41 0 obj
+<<
+/Type /Metadata /Subtype /XML
+/Length 11701     
+>>
+stream
+<?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/">
+ <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about=""
+    xmlns:pdf="http://ns.adobe.com/pdf/1.3/"
+    xmlns:xmpRights="http://ns.adobe.com/xap/1.0/rights/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:photoshop="http://ns.adobe.com/photoshop/1.0/"
+    xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+    xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"
+    xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"
+    xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/"
+    xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/"
+    xmlns:pdfx="http://ns.adobe.com/pdfx/1.3/"
+    xmlns:pdfxid="http://www.npes.org/pdfx/ns/id/"
+    xmlns:prism="http://prismstandard.org/namespaces/basic/3.0/"
+    xmlns:stFnt="http://ns.adobe.com/xap/1.0/sType/Font#"
+    xmlns:Iptc4xmpCore="http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/"
+    xmlns:pdfaExtension="http://www.aiim.org/pdfa/ns/extension/"
+    xmlns:pdfaSchema="http://www.aiim.org/pdfa/ns/schema#"
+    xmlns:pdfaProperty="http://www.aiim.org/pdfa/ns/property#"
+    xmlns:pdfaType="http://www.aiim.org/pdfa/ns/type#"
+    xmlns:pdfaField="http://www.aiim.org/pdfa/ns/field#">
+   <pdfaExtension:schemas>
+    <rdf:Bag>
+     <rdf:li rdf:parseType="Resource">
+      <pdfaSchema:schema>XMP Media Management Schema</pdfaSchema:schema>
+      <pdfaSchema:prefix>xmpMM</pdfaSchema:prefix>
+      <pdfaSchema:namespaceURI>http://ns.adobe.com/xap/1.0/mm/</pdfaSchema:namespaceURI>
+      <pdfaSchema:property>
+       <rdf:Seq>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>OriginalDocumentID</pdfaProperty:name>
+         <pdfaProperty:valueType>URI</pdfaProperty:valueType>
+         <pdfaProperty:category>internal</pdfaProperty:category>
+         <pdfaProperty:description>The common identifier for all versions and renditions of a document.</pdfaProperty:description>
+        </rdf:li>
+       </rdf:Seq>
+      </pdfaSchema:property>
+     </rdf:li>
+     <rdf:li rdf:parseType="Resource">
+      <pdfaSchema:schema>PDF/A Identification Schema</pdfaSchema:schema>
+      <pdfaSchema:prefix>pdfaid</pdfaSchema:prefix>
+      <pdfaSchema:namespaceURI>http://www.aiim.org/pdfa/ns/id/</pdfaSchema:namespaceURI>
+      <pdfaSchema:property>
+       <rdf:Seq>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>year</pdfaProperty:name>
+         <pdfaProperty:valueType>Integer</pdfaProperty:valueType>
+         <pdfaProperty:category>internal</pdfaProperty:category>
+         <pdfaProperty:description>Year of standard</pdfaProperty:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>rev</pdfaProperty:name>
+         <pdfaProperty:valueType>Integer</pdfaProperty:valueType>
+         <pdfaProperty:category>internal</pdfaProperty:category>
+         <pdfaProperty:description>Revision year of standard</pdfaProperty:description>
+        </rdf:li>
+       </rdf:Seq>
+      </pdfaSchema:property>
+     </rdf:li>
+     <rdf:li rdf:parseType="Resource">
+      <pdfaSchema:schema>PDF/UA Universal Accessibility Schema</pdfaSchema:schema>
+      <pdfaSchema:prefix>pdfuaid</pdfaSchema:prefix>
+      <pdfaSchema:namespaceURI>http://www.aiim.org/pdfua/ns/id/</pdfaSchema:namespaceURI>
+      <pdfaSchema:property>
+       <rdf:Seq>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>part</pdfaProperty:name>
+         <pdfaProperty:valueType>Integer</pdfaProperty:valueType>
+         <pdfaProperty:category>internal</pdfaProperty:category>
+         <pdfaProperty:description>Part of ISO 14289 standard</pdfaProperty:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>rev</pdfaProperty:name>
+         <pdfaProperty:valueType>Integer</pdfaProperty:valueType>
+         <pdfaProperty:category>internal</pdfaProperty:category>
+         <pdfaProperty:description>Revision of ISO 14289 standard</pdfaProperty:description>
+        </rdf:li>
+       </rdf:Seq>
+      </pdfaSchema:property>
+     </rdf:li>
+     <rdf:li rdf:parseType="Resource">
+      <pdfaSchema:schema>PDF/X ID Schema</pdfaSchema:schema>
+      <pdfaSchema:prefix>pdfxid</pdfaSchema:prefix>
+      <pdfaSchema:namespaceURI>http://www.npes.org/pdfx/ns/id/</pdfaSchema:namespaceURI>
+      <pdfaSchema:property>
+       <rdf:Seq>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>GTS_PDFXVersion</pdfaProperty:name>
+         <pdfaProperty:valueType>Text</pdfaProperty:valueType>
+         <pdfaProperty:category>internal</pdfaProperty:category>
+         <pdfaProperty:description>ID of PDF/X standard</pdfaProperty:description>
+        </rdf:li>
+       </rdf:Seq>
+      </pdfaSchema:property>
+     </rdf:li>
+     <rdf:li rdf:parseType="Resource">
+      <pdfaSchema:schema>PRISM Basic Metadata</pdfaSchema:schema>
+      <pdfaSchema:prefix>prism</pdfaSchema:prefix>
+      <pdfaSchema:namespaceURI>http://prismstandard.org/namespaces/basic/3.0/</pdfaSchema:namespaceURI>
+      <pdfaSchema:property>
+       <rdf:Seq>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>complianceProfile</pdfaProperty:name>
+         <pdfaProperty:valueType>Text</pdfaProperty:valueType>
+         <pdfaProperty:category>internal</pdfaProperty:category>
+         <pdfaProperty:description>PRISM specification compliance profile to which this document adheres</pdfaProperty:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>publicationName</pdfaProperty:name>
+         <pdfaProperty:valueType>Text</pdfaProperty:valueType>
+         <pdfaProperty:category>external</pdfaProperty:category>
+         <pdfaProperty:description>Publication name</pdfaProperty:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>aggregationType</pdfaProperty:name>
+         <pdfaProperty:valueType>Text</pdfaProperty:valueType>
+         <pdfaProperty:category>external</pdfaProperty:category>
+         <pdfaProperty:description>Publication type</pdfaProperty:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>bookEdition</pdfaProperty:name>
+         <pdfaProperty:valueType>Text</pdfaProperty:valueType>
+         <pdfaProperty:category>external</pdfaProperty:category>
+         <pdfaProperty:description>Edition of the book in which the document was published</pdfaProperty:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>volume</pdfaProperty:name>
+         <pdfaProperty:valueType>Text</pdfaProperty:valueType>
+         <pdfaProperty:category>external</pdfaProperty:category>
+         <pdfaProperty:description>Publication volume number</pdfaProperty:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>number</pdfaProperty:name>
+         <pdfaProperty:valueType>Text</pdfaProperty:valueType>
+         <pdfaProperty:category>external</pdfaProperty:category>
+         <pdfaProperty:description>Publication issue number within a volume</pdfaProperty:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>pageRange</pdfaProperty:name>
+         <pdfaProperty:valueType>Text</pdfaProperty:valueType>
+         <pdfaProperty:category>external</pdfaProperty:category>
+         <pdfaProperty:description>Page range for the document within the print version of its publication</pdfaProperty:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>issn</pdfaProperty:name>
+         <pdfaProperty:valueType>Text</pdfaProperty:valueType>
+         <pdfaProperty:category>external</pdfaProperty:category>
+         <pdfaProperty:description>ISSN for the printed publication in which the document was published</pdfaProperty:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>eIssn</pdfaProperty:name>
+         <pdfaProperty:valueType>Text</pdfaProperty:valueType>
+         <pdfaProperty:category>external</pdfaProperty:category>
+         <pdfaProperty:description>ISSN for the electronic publication in which the document was published</pdfaProperty:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>isbn</pdfaProperty:name>
+         <pdfaProperty:valueType>Text</pdfaProperty:valueType>
+         <pdfaProperty:category>external</pdfaProperty:category>
+         <pdfaProperty:description>ISBN for the publication in which the document was published</pdfaProperty:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>doi</pdfaProperty:name>
+         <pdfaProperty:valueType>Text</pdfaProperty:valueType>
+         <pdfaProperty:category>external</pdfaProperty:category>
+         <pdfaProperty:description>Digital Object Identifier for the document</pdfaProperty:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>url</pdfaProperty:name>
+         <pdfaProperty:valueType>URL</pdfaProperty:valueType>
+         <pdfaProperty:category>external</pdfaProperty:category>
+         <pdfaProperty:description>URL at which the document can be found</pdfaProperty:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>byteCount</pdfaProperty:name>
+         <pdfaProperty:valueType>Integer</pdfaProperty:valueType>
+         <pdfaProperty:category>internal</pdfaProperty:category>
+         <pdfaProperty:description>Approximate file size in octets</pdfaProperty:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>pageCount</pdfaProperty:name>
+         <pdfaProperty:valueType>Integer</pdfaProperty:valueType>
+         <pdfaProperty:category>internal</pdfaProperty:category>
+         <pdfaProperty:description>Number of pages in the print version of the document</pdfaProperty:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+         <pdfaProperty:name>subtitle</pdfaProperty:name>
+         <pdfaProperty:valueType>Text</pdfaProperty:valueType>
+         <pdfaProperty:category>external</pdfaProperty:category>
+         <pdfaProperty:description>Document's subtitle</pdfaProperty:description>
+        </rdf:li>
+       </rdf:Seq>
+      </pdfaSchema:property>
+     </rdf:li>
+    </rdf:Bag>
+   </pdfaExtension:schemas>
+   <pdf:Producer>pdftex-NN.NN.NN</pdf:Producer>
+   <pdf:PDFVersion>1.5</pdf:PDFVersion>
+   <dc:type>
+    <rdf:Bag>
+     <rdf:li>Text</rdf:li>
+    </rdf:Bag>
+   </dc:type>
+   <dc:language>
+    <rdf:Bag>
+     <rdf:li>en</rdf:li>
+    </rdf:Bag>
+   </dc:language>
+   <dc:date>
+    <rdf:Seq>
+     <rdf:li>2016-05-20T09:00:00Z</rdf:li>
+    </rdf:Seq>
+   </dc:date>
+   <dc:format>application/pdf</dc:format>
+   <dc:source>tagging-002-longtable.tex</dc:source>
+   <xmp:CreatorTool>LaTeX</xmp:CreatorTool>
+   <xmp:CreateDate>2016-05-20T09:00:00Z</xmp:CreateDate>
+   <xmp:ModifyDate>2016-05-20T09:00:00Z</xmp:ModifyDate>
+   <xmp:MetadataDate>2016-05-20T09:00:00Z</xmp:MetadataDate>
+   <xmpMM:DocumentID>uuid:24799a11-f9c7-4af3-84b6-3d112f582198</xmpMM:DocumentID>
+   <xmpMM:InstanceID>uuid:0a57c455-157a-4141-8c19-6237d832fc80</xmpMM:InstanceID>
+   <prism:complianceProfile>three</prism:complianceProfile>
+   <prism:pageCount>1</prism:pageCount>
+  </rdf:Description>
+ </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>
+endstream
+endobj
+43 0 obj
+<<
+/Length 1408      
+>>
+stream
+/opacity1 gs
+/Artifact BMC
+EMC
+/Lbl <</MCID 0 >> BDC
+BT
+/F41 14.3462 Tf 133.768 657.235 Td [(1)]TJ
+ET
+EMC
+/section <</MCID 1 >> BDC
+BT
+/F41 14.3462 Tf 157.434 657.235 Td [(ab)-30(c)]TJ
+ET
+EMC
+/Artifact BMC
+EMC
+/text <</MCID 2 >> BDC
+BT
+/F39 9.9626 Tf 263.104 627.048 Td [(T)83(est)]TJ
+ET
+EMC
+/Lbl <</MCID 3 >> BDC
+BT
+/F42 6.9738 Tf 281.697 630.664 Td [(1)]TJ
+ET
+EMC
+/text <</MCID 4 >> BDC
+EMC
+/Artifact BMC
+EMC
+/Lbl <</MCID 5 >> BDC
+BT
+/F52 11.9552 Tf 133.768 583.621 Td [(1.1)]TJ
+ET
+EMC
+/subsection <</MCID 6 >> BDC
+BT
+/F52 11.9552 Tf 164.396 583.621 Td [(bla)]TJ
+ET
+EMC
+/Artifact BMC
+EMC
+/text <</MCID 7 >> BDC
+BT
+/F39 9.9626 Tf 263.104 556.865 Td [(T)83(est)]TJ
+ET
+EMC
+/Lbl <</MCID 8 >> BDC
+BT
+/F42 6.9738 Tf 281.697 560.48 Td [(2)]TJ
+ET
+EMC
+/text <</MCID 9 >> BDC
+EMC
+/Artifact BMC
+EMC
+q
+1 0 0 1 133.768 535.146 cm
+[]0 d 0 J 0.398 w 0 0 m 137.482 0 l S
+Q
+/text <</MCID 10 >> BDC
+EMC
+/Lbl <</MCID 11 >> BDC
+BT
+/F50 5.9776 Tf 147.547 528.522 Td [(1)]TJ
+ET
+EMC
+/text <</MCID 12 >> BDC
+EMC
+/text <</MCID 13 >> BDC
+BT
+/F43 7.9701 Tf 151.697 525.709 Td [(ab)-30(c)]TJ
+ET
+EMC
+/text <</MCID 14 >> BDC
+EMC
+/text <</MCID 15 >> BDC
+EMC
+/Lbl <</MCID 16 >> BDC
+BT
+/F50 5.9776 Tf 147.547 519.035 Td [(2)]TJ
+ET
+EMC
+/text <</MCID 17 >> BDC
+EMC
+/text <</MCID 18 >> BDC
+BT
+/F43 7.9701 Tf 151.697 516.223 Td [(ab)-30(c)]TJ
+ET
+EMC
+/text <</MCID 19 >> BDC
+EMC
+/Artifact BMC
+BT
+/F39 9.9626 Tf 303.134 89.365 Td [(1)]TJ
+ET
+EMC
+endstream
+endobj
+15 0 obj
+<<
+/Type /Page
+/Contents 43 0 R
+/Resources 42 0 R
+/MediaBox [0 0 612 792]
+/Tabs /S /StructParents 0 
+/Parent 50 0 R
+>>
+endobj
+42 0 obj
+<<
+/ExtGState 1 0 R 
+/Font << /F41 44 0 R /F39 45 0 R /F42 46 0 R /F52 47 0 R /F50 48 0 R /F43 49 0 R >>
+/ProcSet [ /PDF /Text ]
+>>
+endobj
+1 0 obj
+<< /opacity1 <</ca 1/CA 1>>  >>
+endobj
+51 0 obj
+<< /Marked true  >>
+endobj
+6 0 obj
+<< /Nums [0 [ 14 0 R 13 0 R 20 0 R 21 0 R 20 0 R 29 0 R 28 0 R 34 0 R 35 0 R 34 0 R 25 0 R 26 0 R 25 0 R 25 0 R 25 0 R 39 0 R 40 0 R 39 0 R 39 0 R 39 0 R ]
+] >>
+endobj
+52 0 obj
+<< /Limits [(ID.002) (ID.032)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 16 0 R (ID.009) 17 0 R (ID.010) 18 0 R (ID.011) 19 0 R (ID.012) 20 0 R (ID.013) 21 0 R (ID.014) 22 0 R (ID.015) 23 0 R (ID.016) 24 0 R (ID.017) 25 0 R (ID.018) 26 0 R (ID.019) 27 0 R (ID.020) 28 0 R (ID.021) 29 0 R (ID.022) 30 0 R (ID.023) 31 0 R (ID.024) 32 0 R (ID.025) 33 0 R (ID.026) 34 0 R (ID.027) 35 0 R (ID.028) 36 0 R (ID.029) 37 0 R (ID.030) 38 0 R (ID.031) 39 0 R (ID.032) 40 0 R ] >>
+endobj
+53 0 obj
+<< /Kids [52 0 R] >>
+endobj
+7 0 obj
+<< /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
+endobj
+54 0 obj
+<< /justify <</O/Layout/TextAlign/Justify>>
+/TH-both <</O/Table/Scope/Both>>
+/TH-row <</O/Table/Scope/Row>>
+/TH-col <</O/Table/Scope/Column>>
+ >>
+endobj
+9 0 obj
+<<  /Type /StructElem /S /Document /P 5 0 R /K 12 0 R /ID (ID.002) >>
+endobj
+10 0 obj
+<<  /Type /StructElem /S /Artifact /P 5 0 R /ID (ID.003) >>
+endobj
+11 0 obj
+<<  /Type /StructElem /S /Artifact /P 5 0 R /ID (ID.004) >>
+endobj
+12 0 obj
+<<  /Type /StructElem /S /Sect /P 9 0 R /K [13 0 R 16 0 R 22 0 R 27 0 R] /ID (ID.005) >>
+endobj
+13 0 obj
+<<  /Type /StructElem /S /section /P 12 0 R /K [14 0 R <</Type /MCR /Pg 15 0 R/MCID 1>>] /ID (ID.006) >>
+endobj
+14 0 obj
+<<  /Type /StructElem /S /Lbl /P 13 0 R /K <</Type /MCR /Pg 15 0 R/MCID 0>> /ID (ID.007) >>
+endobj
+16 0 obj
+<<  /Type /StructElem /S /Table /P 12 0 R /K 17 0 R /ID (ID.008) >>
+endobj
+17 0 obj
+<<  /Type /StructElem /S /TR /P 16 0 R /K 18 0 R /ID (ID.009) >>
+endobj
+18 0 obj
+<<  /Type /StructElem /S /TD /P 17 0 R /K 19 0 R /ID (ID.010) >>
+endobj
+19 0 obj
+<<  /Type /StructElem /S /Div /P 18 0 R /K 20 0 R /ID (ID.011) >>
+endobj
+20 0 obj
+<<  /Type /StructElem /C /justify /S /text /P 19 0 R /K [<</Type /MCR /Pg 15 0 R/MCID 2>> 21 0 R <</Type /MCR /Pg 15 0 R/MCID 4>>] /ID (ID.012) >>
+endobj
+21 0 obj
+<<  /Type /StructElem /S /footnotemark /P 20 0 R /Ref [ 22 0 R ] /K <</Type /MCR /Pg 15 0 R/MCID 3>> /ID (ID.013) >>
+endobj
+22 0 obj
+<<  /Type /StructElem /S /footnote /P 12 0 R /Ref [ 21 0 R ] /K [23 0 R 24 0 R] /ID (ID.014) >>
+endobj
+23 0 obj
+<<  /Type /StructElem /S /footnotelabel /P 22 0 R /K 26 0 R /ID (ID.015) >>
+endobj
+24 0 obj
+<<  /Type /StructElem /S /Div /P 22 0 R /K 25 0 R /ID (ID.016) >>
+endobj
+25 0 obj
+<<  /Type /StructElem /C /justify /S /text /P 24 0 R /K [<</Type /MCR /Pg 15 0 R/MCID 10>> <</Type /MCR /Pg 15 0 R/MCID 12>> <</Type /MCR /Pg 15 0 R/MCID 13>> <</Type /MCR /Pg 15 0 R/MCID 14>>] /ID (ID.017) >>
+endobj
+26 0 obj
+<<  /Type /StructElem /S /NonStruct /P 23 0 R /K <</Type /MCR /Pg 15 0 R/MCID 11>> /ID (ID.018) >>
+endobj
+27 0 obj
+<<  /Type /StructElem /S /Sect /P 12 0 R /K [28 0 R 30 0 R 36 0 R] /ID (ID.019) >>
+endobj
+28 0 obj
+<<  /Type /StructElem /S /subsection /P 27 0 R /K [29 0 R <</Type /MCR /Pg 15 0 R/MCID 6>>] /ID (ID.020) >>
+endobj
+29 0 obj
+<<  /Type /StructElem /S /Lbl /P 28 0 R /K <</Type /MCR /Pg 15 0 R/MCID 5>> /ID (ID.021) >>
+endobj
+30 0 obj
+<<  /Type /StructElem /S /Table /P 27 0 R /K 31 0 R /ID (ID.022) >>
+endobj
+31 0 obj
+<<  /Type /StructElem /S /TR /P 30 0 R /K 32 0 R /ID (ID.023) >>
+endobj
+32 0 obj
+<<  /Type /StructElem /S /TD /P 31 0 R /K 33 0 R /ID (ID.024) >>
+endobj
+33 0 obj
+<<  /Type /StructElem /S /Div /P 32 0 R /K 34 0 R /ID (ID.025) >>
+endobj
+34 0 obj
+<<  /Type /StructElem /C /justify /S /text /P 33 0 R /K [<</Type /MCR /Pg 15 0 R/MCID 7>> 35 0 R <</Type /MCR /Pg 15 0 R/MCID 9>>] /ID (ID.026) >>
+endobj
+35 0 obj
+<<  /Type /StructElem /S /footnotemark /P 34 0 R /Ref [ 36 0 R ] /K <</Type /MCR /Pg 15 0 R/MCID 8>> /ID (ID.027) >>
+endobj
+36 0 obj
+<<  /Type /StructElem /S /footnote /P 27 0 R /Ref [ 35 0 R ] /K [37 0 R 38 0 R] /ID (ID.028) >>
+endobj
+37 0 obj
+<<  /Type /StructElem /S /footnotelabel /P 36 0 R /K 40 0 R /ID (ID.029) >>
+endobj
+38 0 obj
+<<  /Type /StructElem /S /Div /P 36 0 R /K 39 0 R /ID (ID.030) >>
+endobj
+39 0 obj
+<<  /Type /StructElem /C /justify /S /text /P 38 0 R /K [<</Type /MCR /Pg 15 0 R/MCID 15>> <</Type /MCR /Pg 15 0 R/MCID 17>> <</Type /MCR /Pg 15 0 R/MCID 18>> <</Type /MCR /Pg 15 0 R/MCID 19>>] /ID (ID.031) >>
+endobj
+40 0 obj
+<<  /Type /StructElem /S /NonStruct /P 37 0 R /K <</Type /MCR /Pg 15 0 R/MCID 16>> /ID (ID.032) >>
+endobj
+5 0 obj
+<<  /Type /StructTreeRoot /IDTree 53 0 R /ClassMap 54 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
+endobj
+56 0 obj
+[531.1 590.1 472.1]
+endobj
+57 0 obj
+[611 611]
+endobj
+58 0 obj
+[312.4 562.4 562.4 562.4 562.4 562.4 562.4 562.4 562.4 562.4 562.4 562.4 312.4 312.4 874.8 874.8 874.8 531.1 874.8 849.3 799.6 812.3 862.1 738.2 707 884 879.4 418.9 580.9 880.6 675.8 1066.9 879.4 844.7 768.3 844.7 838.9 624.8 782.2 864.4 849.3 1161.8 849.3 849.3 687.3 312.4 562.4 312.4 687.3 874.8 312.4 546.7 624.8 499.9 624.8 513.2 343.7 562.4 624.8 312.4 343.7 593.6 312.4]
+endobj
+59 0 obj
+[569.3 569.3]
+endobj
+60 0 obj
+[499.9 499.9 499.9 499.9 499.9 499.9 499.9 499.9 499.9 277.7 277.7 777.6 777.6 777.6 472.1 777.6 749.8 708.2 722 763.7 680.4 652.6 784.5 749.8 361 513.8 777.6 624.8 916.4 749.8 777.6 680.4 777.6 735.9 555.4 722 749.8 749.8 1027.5 749.8 749.8 611 277.7 499.9 277.7 611 777.6 277.7 499.9 555.4 444.3 555.4 444.3 305.5 499.9 555.4 277.7 305.5 527.7 277.7 833.1 555.4 499.9 555.4 527.7 391.6 394.3 388.8]
+endobj
+61 0 obj
+[549.9 549.9 549.9 549.9 549.9 549.9 549.9 549.9 549.9 305.5 305.5 855.4 855.4 855.4 519.3 855.4 830.2 781.7 794.3 842.8 721.6 691 864.3 859.8 404.9 567.8 860.8 660.5 1043 859.8 825.8 751.1 825.8 817.3 611 764.7 845 830.2 1135.7 830.2 830.2 672.1 305.5 549.9 305.5 672.1 855.4 305.5 549.9 611 488.8]
+endobj
+62 0 obj
+<<
+/Length1 727
+/Length2 7574
+/Length3 0
+/Length 8301      
+>>
+[BINARY STREAM]
+endobj
+63 0 obj
+<<
+/Type /FontDescriptor
+/FontName /AZUAYJ+SFBX1200
+/Flags 4
+/FontBBox [-223 -316 1694 925]
+/Ascent 690
+/CapHeight 690
+/Descent -194
+/ItalicAngle 0
+/StemV 50
+/XHeight 444
+/CharSet (/a/b/l/one/period)
+/FontFile 62 0 R
+>>
+endobj
+64 0 obj
+<<
+/Length1 727
+/Length2 2916
+/Length3 0
+/Length 3643      
+>>
+[BINARY STREAM]
+endobj
+65 0 obj
+<<
+/Type /FontDescriptor
+/FontName /AAUTQH+SFBX1440
+/Flags 4
+/FontBBox [-218 -316 1652 915]
+/Ascent 690
+/CapHeight 690
+/Descent -194
+/ItalicAngle 0
+/StemV 50
+/XHeight 444
+/CharSet (/a/b/c/one)
+/FontFile 64 0 R
+>>
+endobj
+66 0 obj
+<<
+/Length1 721
+/Length2 14010
+/Length3 0
+/Length 14731     
+>>
+[BINARY STREAM]
+endobj
+67 0 obj
+<<
+/Type /FontDescriptor
+/FontName /QNUIBG+SFRM0600
+/Flags 4
+/FontBBox [-210 -320 1719 944]
+/Ascent 694
+/CapHeight 679
+/Descent -194
+/ItalicAngle 0
+/StemV 50
+/XHeight 430
+/CharSet (/one/two)
+/FontFile 66 0 R
+>>
+endobj
+68 0 obj
+<<
+/Length1 721
+/Length2 1158
+/Length3 0
+/Length 1879      
+>>
+[BINARY STREAM]
+endobj
+69 0 obj
+<<
+/Type /FontDescriptor
+/FontName /JDSMEO+SFRM0700
+/Flags 4
+/FontBBox [-203 -320 1628 942]
+/Ascent 689
+/CapHeight 689
+/Descent -194
+/ItalicAngle 0
+/StemV 50
+/XHeight 430
+/CharSet (/one/two)
+/FontFile 68 0 R
+>>
+endobj
+70 0 obj
+<<
+/Length1 721
+/Length2 9381
+/Length3 0
+/Length 10102     
+>>
+[BINARY STREAM]
+endobj
+71 0 obj
+<<
+/Type /FontDescriptor
+/FontName /WOWNJR+SFRM0800
+/Flags 4
+/FontBBox [-203 -320 1554 938]
+/Ascent 689
+/CapHeight 689
+/Descent -194
+/ItalicAngle 0
+/StemV 50
+/XHeight 430
+/CharSet (/a/b/c)
+/FontFile 70 0 R
+>>
+endobj
+72 0 obj
+<<
+/Length1 721
+/Length2 9015
+/Length3 0
+/Length 9736      
+>>
+[BINARY STREAM]
+endobj
+73 0 obj
+<<
+/Type /FontDescriptor
+/FontName /SSKXDU+SFRM1000
+/Flags 4
+/FontBBox [-189 -321 1456 937]
+/Ascent 689
+/CapHeight 689
+/Descent -194
+/ItalicAngle 0
+/StemV 50
+/XHeight 430
+/CharSet (/T/e/one/s/t)
+/FontFile 72 0 R
+>>
+endobj
+55 0 obj
+<<
+/Type /Encoding
+/Differences [46/period 49/one/two 84/T 97/a/b/c 101/e 108/l 115/s/t]
+>>
+endobj
+74 0 obj
+<<
+/Length 2030      
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: ProcSet (CIDInit)
+%%IncludeResource: ProcSet (CIDInit)
+%%BeginResource: CMap (TeX-ecbx1200-cm-super-t1-0)
+%%Title: (TeX-ecbx1200-cm-super-t1-0 TeX ecbx1200-cm-super-t1 0)
+%%Version: 1.000
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<< /Registry (TeX)
+/Ordering (ecbx1200-cm-super-t1)
+/Supplement 0
+>> def
+/CMapName /TeX-ecbx1200-cm-super-t1-0 def
+/CMapType 2 def
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+13 beginbfrange
+<0E> <0F> <2039>
+<10> <12> <201C>
+<15> <16> <2013>
+<21> <26> <0021>
+<28> <5F> <0028>
+<61> <7E> <0061>
+<98> <99> <0178>
+<C0> <D6> <00C0>
+<D8> <DE> <00D8>
+<E0> <F0> <00E0>
+<F1> <F6> <00F1>
+<F8> <FC> <00F8>
+<FD> <FE> <00FD>
+endbfrange
+94 beginbfchar
+<00> <0060>
+<01> <00B4>
+<02> <02C6>
+<03> <02DC>
+<04> <00A8>
+<05> <02DD>
+<06> <02DA>
+<07> <02C7>
+<08> <02D8>
+<09> <00AF>
+<0A> <02D9>
+<0B> <00B8>
+<0C> <02DB>
+<0D> <201A>
+<13> <00AB>
+<14> <00BB>
+<17> <200C>
+<19> <0131>
+<1A> <0237>
+<1B> <00660066>
+<1C> <00660069>
+<1D> <0066006C>
+<1E> <006600660069>
+<1F> <00660066006C>
+<20> <2423>
+<27> <2019>
+<60> <2018>
+<7F> <002D>
+<80> <0102>
+<81> <0104>
+<82> <0106>
+<83> <010C>
+<84> <010E>
+<85> <011A>
+<86> <0118>
+<87> <011E>
+<88> <0139>
+<89> <013D>
+<8A> <0141>
+<8B> <0143>
+<8C> <0147>
+<8D> <014A>
+<8E> <0150>
+<8F> <0154>
+<90> <0158>
+<91> <015A>
+<92> <0160>
+<93> <015E>
+<94> <0164>
+<95> <0162>
+<96> <0170>
+<97> <016E>
+<9A> <017D>
+<9B> <017B>
+<9C> <0132>
+<9D> <0130>
+<9E> <0111>
+<9F> <00A7>
+<A0> <0103>
+<A1> <0105>
+<A2> <0107>
+<A3> <010D>
+<A4> <010F>
+<A5> <011B>
+<A6> <0119>
+<A7> <011F>
+<A8> <013A>
+<A9> <013E>
+<AA> <0142>
+<AB> <0144>
+<AC> <0148>
+<AD> <014B>
+<AE> <0151>
+<AF> <0155>
+<B0> <0159>
+<B1> <015B>
+<B2> <0161>
+<B3> <015F>
+<B4> <0165>
+<B5> <0163>
+<B6> <0171>
+<B7> <016F>
+<B8> <00FF>
+<B9> <017A>
+<BA> <017E>
+<BB> <017C>
+<BC> <0133>
+<BD> <00A1>
+<BE> <00BF>
+<BF> <00A3>
+<D7> <0152>
+<DF> <00530053>
+<F7> <0153>
+<FF> <00DF>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+47 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /AZUAYJ+SFBX1200
+/FontDescriptor 63 0 R
+/FirstChar 46
+/LastChar 108
+/Widths 58 0 R
+/Encoding 55 0 R
+/ToUnicode 74 0 R
+>>
+endobj
+75 0 obj
+<<
+/Length 2030      
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: ProcSet (CIDInit)
+%%IncludeResource: ProcSet (CIDInit)
+%%BeginResource: CMap (TeX-ecbx1440-cm-super-t1-0)
+%%Title: (TeX-ecbx1440-cm-super-t1-0 TeX ecbx1440-cm-super-t1 0)
+%%Version: 1.000
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<< /Registry (TeX)
+/Ordering (ecbx1440-cm-super-t1)
+/Supplement 0
+>> def
+/CMapName /TeX-ecbx1440-cm-super-t1-0 def
+/CMapType 2 def
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+13 beginbfrange
+<0E> <0F> <2039>
+<10> <12> <201C>
+<15> <16> <2013>
+<21> <26> <0021>
+<28> <5F> <0028>
+<61> <7E> <0061>
+<98> <99> <0178>
+<C0> <D6> <00C0>
+<D8> <DE> <00D8>
+<E0> <F0> <00E0>
+<F1> <F6> <00F1>
+<F8> <FC> <00F8>
+<FD> <FE> <00FD>
+endbfrange
+94 beginbfchar
+<00> <0060>
+<01> <00B4>
+<02> <02C6>
+<03> <02DC>
+<04> <00A8>
+<05> <02DD>
+<06> <02DA>
+<07> <02C7>
+<08> <02D8>
+<09> <00AF>
+<0A> <02D9>
+<0B> <00B8>
+<0C> <02DB>
+<0D> <201A>
+<13> <00AB>
+<14> <00BB>
+<17> <200C>
+<19> <0131>
+<1A> <0237>
+<1B> <00660066>
+<1C> <00660069>
+<1D> <0066006C>
+<1E> <006600660069>
+<1F> <00660066006C>
+<20> <2423>
+<27> <2019>
+<60> <2018>
+<7F> <002D>
+<80> <0102>
+<81> <0104>
+<82> <0106>
+<83> <010C>
+<84> <010E>
+<85> <011A>
+<86> <0118>
+<87> <011E>
+<88> <0139>
+<89> <013D>
+<8A> <0141>
+<8B> <0143>
+<8C> <0147>
+<8D> <014A>
+<8E> <0150>
+<8F> <0154>
+<90> <0158>
+<91> <015A>
+<92> <0160>
+<93> <015E>
+<94> <0164>
+<95> <0162>
+<96> <0170>
+<97> <016E>
+<9A> <017D>
+<9B> <017B>
+<9C> <0132>
+<9D> <0130>
+<9E> <0111>
+<9F> <00A7>
+<A0> <0103>
+<A1> <0105>
+<A2> <0107>
+<A3> <010D>
+<A4> <010F>
+<A5> <011B>
+<A6> <0119>
+<A7> <011F>
+<A8> <013A>
+<A9> <013E>
+<AA> <0142>
+<AB> <0144>
+<AC> <0148>
+<AD> <014B>
+<AE> <0151>
+<AF> <0155>
+<B0> <0159>
+<B1> <015B>
+<B2> <0161>
+<B3> <015F>
+<B4> <0165>
+<B5> <0163>
+<B6> <0171>
+<B7> <016F>
+<B8> <00FF>
+<B9> <017A>
+<BA> <017E>
+<BB> <017C>
+<BC> <0133>
+<BD> <00A1>
+<BE> <00BF>
+<BF> <00A3>
+<D7> <0152>
+<DF> <00530053>
+<F7> <0153>
+<FF> <00DF>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+44 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /AAUTQH+SFBX1440
+/FontDescriptor 65 0 R
+/FirstChar 49
+/LastChar 99
+/Widths 61 0 R
+/Encoding 55 0 R
+/ToUnicode 75 0 R
+>>
+endobj
+76 0 obj
+<<
+/Length 2030      
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: ProcSet (CIDInit)
+%%IncludeResource: ProcSet (CIDInit)
+%%BeginResource: CMap (TeX-ecrm0600-cm-super-t1-0)
+%%Title: (TeX-ecrm0600-cm-super-t1-0 TeX ecrm0600-cm-super-t1 0)
+%%Version: 1.000
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<< /Registry (TeX)
+/Ordering (ecrm0600-cm-super-t1)
+/Supplement 0
+>> def
+/CMapName /TeX-ecrm0600-cm-super-t1-0 def
+/CMapType 2 def
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+13 beginbfrange
+<0E> <0F> <2039>
+<10> <12> <201C>
+<15> <16> <2013>
+<21> <26> <0021>
+<28> <5F> <0028>
+<61> <7E> <0061>
+<98> <99> <0178>
+<C0> <D6> <00C0>
+<D8> <DE> <00D8>
+<E0> <F0> <00E0>
+<F1> <F6> <00F1>
+<F8> <FC> <00F8>
+<FD> <FE> <00FD>
+endbfrange
+94 beginbfchar
+<00> <0060>
+<01> <00B4>
+<02> <02C6>
+<03> <02DC>
+<04> <00A8>
+<05> <02DD>
+<06> <02DA>
+<07> <02C7>
+<08> <02D8>
+<09> <00AF>
+<0A> <02D9>
+<0B> <00B8>
+<0C> <02DB>
+<0D> <201A>
+<13> <00AB>
+<14> <00BB>
+<17> <200C>
+<19> <0131>
+<1A> <0237>
+<1B> <00660066>
+<1C> <00660069>
+<1D> <0066006C>
+<1E> <006600660069>
+<1F> <00660066006C>
+<20> <2423>
+<27> <2019>
+<60> <2018>
+<7F> <002D>
+<80> <0102>
+<81> <0104>
+<82> <0106>
+<83> <010C>
+<84> <010E>
+<85> <011A>
+<86> <0118>
+<87> <011E>
+<88> <0139>
+<89> <013D>
+<8A> <0141>
+<8B> <0143>
+<8C> <0147>
+<8D> <014A>
+<8E> <0150>
+<8F> <0154>
+<90> <0158>
+<91> <015A>
+<92> <0160>
+<93> <015E>
+<94> <0164>
+<95> <0162>
+<96> <0170>
+<97> <016E>
+<9A> <017D>
+<9B> <017B>
+<9C> <0132>
+<9D> <0130>
+<9E> <0111>
+<9F> <00A7>
+<A0> <0103>
+<A1> <0105>
+<A2> <0107>
+<A3> <010D>
+<A4> <010F>
+<A5> <011B>
+<A6> <0119>
+<A7> <011F>
+<A8> <013A>
+<A9> <013E>
+<AA> <0142>
+<AB> <0144>
+<AC> <0148>
+<AD> <014B>
+<AE> <0151>
+<AF> <0155>
+<B0> <0159>
+<B1> <015B>
+<B2> <0161>
+<B3> <015F>
+<B4> <0165>
+<B5> <0163>
+<B6> <0171>
+<B7> <016F>
+<B8> <00FF>
+<B9> <017A>
+<BA> <017E>
+<BB> <017C>
+<BC> <0133>
+<BD> <00A1>
+<BE> <00BF>
+<BF> <00A3>
+<D7> <0152>
+<DF> <00530053>
+<F7> <0153>
+<FF> <00DF>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+48 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /QNUIBG+SFRM0600
+/FontDescriptor 67 0 R
+/FirstChar 49
+/LastChar 50
+/Widths 57 0 R
+/Encoding 55 0 R
+/ToUnicode 76 0 R
+>>
+endobj
+77 0 obj
+<<
+/Length 2030      
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: ProcSet (CIDInit)
+%%IncludeResource: ProcSet (CIDInit)
+%%BeginResource: CMap (TeX-ecrm0700-cm-super-t1-0)
+%%Title: (TeX-ecrm0700-cm-super-t1-0 TeX ecrm0700-cm-super-t1 0)
+%%Version: 1.000
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<< /Registry (TeX)
+/Ordering (ecrm0700-cm-super-t1)
+/Supplement 0
+>> def
+/CMapName /TeX-ecrm0700-cm-super-t1-0 def
+/CMapType 2 def
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+13 beginbfrange
+<0E> <0F> <2039>
+<10> <12> <201C>
+<15> <16> <2013>
+<21> <26> <0021>
+<28> <5F> <0028>
+<61> <7E> <0061>
+<98> <99> <0178>
+<C0> <D6> <00C0>
+<D8> <DE> <00D8>
+<E0> <F0> <00E0>
+<F1> <F6> <00F1>
+<F8> <FC> <00F8>
+<FD> <FE> <00FD>
+endbfrange
+94 beginbfchar
+<00> <0060>
+<01> <00B4>
+<02> <02C6>
+<03> <02DC>
+<04> <00A8>
+<05> <02DD>
+<06> <02DA>
+<07> <02C7>
+<08> <02D8>
+<09> <00AF>
+<0A> <02D9>
+<0B> <00B8>
+<0C> <02DB>
+<0D> <201A>
+<13> <00AB>
+<14> <00BB>
+<17> <200C>
+<19> <0131>
+<1A> <0237>
+<1B> <00660066>
+<1C> <00660069>
+<1D> <0066006C>
+<1E> <006600660069>
+<1F> <00660066006C>
+<20> <2423>
+<27> <2019>
+<60> <2018>
+<7F> <002D>
+<80> <0102>
+<81> <0104>
+<82> <0106>
+<83> <010C>
+<84> <010E>
+<85> <011A>
+<86> <0118>
+<87> <011E>
+<88> <0139>
+<89> <013D>
+<8A> <0141>
+<8B> <0143>
+<8C> <0147>
+<8D> <014A>
+<8E> <0150>
+<8F> <0154>
+<90> <0158>
+<91> <015A>
+<92> <0160>
+<93> <015E>
+<94> <0164>
+<95> <0162>
+<96> <0170>
+<97> <016E>
+<9A> <017D>
+<9B> <017B>
+<9C> <0132>
+<9D> <0130>
+<9E> <0111>
+<9F> <00A7>
+<A0> <0103>
+<A1> <0105>
+<A2> <0107>
+<A3> <010D>
+<A4> <010F>
+<A5> <011B>
+<A6> <0119>
+<A7> <011F>
+<A8> <013A>
+<A9> <013E>
+<AA> <0142>
+<AB> <0144>
+<AC> <0148>
+<AD> <014B>
+<AE> <0151>
+<AF> <0155>
+<B0> <0159>
+<B1> <015B>
+<B2> <0161>
+<B3> <015F>
+<B4> <0165>
+<B5> <0163>
+<B6> <0171>
+<B7> <016F>
+<B8> <00FF>
+<B9> <017A>
+<BA> <017E>
+<BB> <017C>
+<BC> <0133>
+<BD> <00A1>
+<BE> <00BF>
+<BF> <00A3>
+<D7> <0152>
+<DF> <00530053>
+<F7> <0153>
+<FF> <00DF>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+46 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /JDSMEO+SFRM0700
+/FontDescriptor 69 0 R
+/FirstChar 49
+/LastChar 50
+/Widths 59 0 R
+/Encoding 55 0 R
+/ToUnicode 77 0 R
+>>
+endobj
+78 0 obj
+<<
+/Length 2030      
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: ProcSet (CIDInit)
+%%IncludeResource: ProcSet (CIDInit)
+%%BeginResource: CMap (TeX-ecrm0800-cm-super-t1-0)
+%%Title: (TeX-ecrm0800-cm-super-t1-0 TeX ecrm0800-cm-super-t1 0)
+%%Version: 1.000
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<< /Registry (TeX)
+/Ordering (ecrm0800-cm-super-t1)
+/Supplement 0
+>> def
+/CMapName /TeX-ecrm0800-cm-super-t1-0 def
+/CMapType 2 def
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+13 beginbfrange
+<0E> <0F> <2039>
+<10> <12> <201C>
+<15> <16> <2013>
+<21> <26> <0021>
+<28> <5F> <0028>
+<61> <7E> <0061>
+<98> <99> <0178>
+<C0> <D6> <00C0>
+<D8> <DE> <00D8>
+<E0> <F0> <00E0>
+<F1> <F6> <00F1>
+<F8> <FC> <00F8>
+<FD> <FE> <00FD>
+endbfrange
+94 beginbfchar
+<00> <0060>
+<01> <00B4>
+<02> <02C6>
+<03> <02DC>
+<04> <00A8>
+<05> <02DD>
+<06> <02DA>
+<07> <02C7>
+<08> <02D8>
+<09> <00AF>
+<0A> <02D9>
+<0B> <00B8>
+<0C> <02DB>
+<0D> <201A>
+<13> <00AB>
+<14> <00BB>
+<17> <200C>
+<19> <0131>
+<1A> <0237>
+<1B> <00660066>
+<1C> <00660069>
+<1D> <0066006C>
+<1E> <006600660069>
+<1F> <00660066006C>
+<20> <2423>
+<27> <2019>
+<60> <2018>
+<7F> <002D>
+<80> <0102>
+<81> <0104>
+<82> <0106>
+<83> <010C>
+<84> <010E>
+<85> <011A>
+<86> <0118>
+<87> <011E>
+<88> <0139>
+<89> <013D>
+<8A> <0141>
+<8B> <0143>
+<8C> <0147>
+<8D> <014A>
+<8E> <0150>
+<8F> <0154>
+<90> <0158>
+<91> <015A>
+<92> <0160>
+<93> <015E>
+<94> <0164>
+<95> <0162>
+<96> <0170>
+<97> <016E>
+<9A> <017D>
+<9B> <017B>
+<9C> <0132>
+<9D> <0130>
+<9E> <0111>
+<9F> <00A7>
+<A0> <0103>
+<A1> <0105>
+<A2> <0107>
+<A3> <010D>
+<A4> <010F>
+<A5> <011B>
+<A6> <0119>
+<A7> <011F>
+<A8> <013A>
+<A9> <013E>
+<AA> <0142>
+<AB> <0144>
+<AC> <0148>
+<AD> <014B>
+<AE> <0151>
+<AF> <0155>
+<B0> <0159>
+<B1> <015B>
+<B2> <0161>
+<B3> <015F>
+<B4> <0165>
+<B5> <0163>
+<B6> <0171>
+<B7> <016F>
+<B8> <00FF>
+<B9> <017A>
+<BA> <017E>
+<BB> <017C>
+<BC> <0133>
+<BD> <00A1>
+<BE> <00BF>
+<BF> <00A3>
+<D7> <0152>
+<DF> <00530053>
+<F7> <0153>
+<FF> <00DF>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+49 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /WOWNJR+SFRM0800
+/FontDescriptor 71 0 R
+/FirstChar 97
+/LastChar 99
+/Widths 56 0 R
+/Encoding 55 0 R
+/ToUnicode 78 0 R
+>>
+endobj
+79 0 obj
+<<
+/Length 2030      
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: ProcSet (CIDInit)
+%%IncludeResource: ProcSet (CIDInit)
+%%BeginResource: CMap (TeX-ecrm1000-cm-super-t1-0)
+%%Title: (TeX-ecrm1000-cm-super-t1-0 TeX ecrm1000-cm-super-t1 0)
+%%Version: 1.000
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<< /Registry (TeX)
+/Ordering (ecrm1000-cm-super-t1)
+/Supplement 0
+>> def
+/CMapName /TeX-ecrm1000-cm-super-t1-0 def
+/CMapType 2 def
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+13 beginbfrange
+<0E> <0F> <2039>
+<10> <12> <201C>
+<15> <16> <2013>
+<21> <26> <0021>
+<28> <5F> <0028>
+<61> <7E> <0061>
+<98> <99> <0178>
+<C0> <D6> <00C0>
+<D8> <DE> <00D8>
+<E0> <F0> <00E0>
+<F1> <F6> <00F1>
+<F8> <FC> <00F8>
+<FD> <FE> <00FD>
+endbfrange
+94 beginbfchar
+<00> <0060>
+<01> <00B4>
+<02> <02C6>
+<03> <02DC>
+<04> <00A8>
+<05> <02DD>
+<06> <02DA>
+<07> <02C7>
+<08> <02D8>
+<09> <00AF>
+<0A> <02D9>
+<0B> <00B8>
+<0C> <02DB>
+<0D> <201A>
+<13> <00AB>
+<14> <00BB>
+<17> <200C>
+<19> <0131>
+<1A> <0237>
+<1B> <00660066>
+<1C> <00660069>
+<1D> <0066006C>
+<1E> <006600660069>
+<1F> <00660066006C>
+<20> <2423>
+<27> <2019>
+<60> <2018>
+<7F> <002D>
+<80> <0102>
+<81> <0104>
+<82> <0106>
+<83> <010C>
+<84> <010E>
+<85> <011A>
+<86> <0118>
+<87> <011E>
+<88> <0139>
+<89> <013D>
+<8A> <0141>
+<8B> <0143>
+<8C> <0147>
+<8D> <014A>
+<8E> <0150>
+<8F> <0154>
+<90> <0158>
+<91> <015A>
+<92> <0160>
+<93> <015E>
+<94> <0164>
+<95> <0162>
+<96> <0170>
+<97> <016E>
+<9A> <017D>
+<9B> <017B>
+<9C> <0132>
+<9D> <0130>
+<9E> <0111>
+<9F> <00A7>
+<A0> <0103>
+<A1> <0105>
+<A2> <0107>
+<A3> <010D>
+<A4> <010F>
+<A5> <011B>
+<A6> <0119>
+<A7> <011F>
+<A8> <013A>
+<A9> <013E>
+<AA> <0142>
+<AB> <0144>
+<AC> <0148>
+<AD> <014B>
+<AE> <0151>
+<AF> <0155>
+<B0> <0159>
+<B1> <015B>
+<B2> <0161>
+<B3> <015F>
+<B4> <0165>
+<B5> <0163>
+<B6> <0171>
+<B7> <016F>
+<B8> <00FF>
+<B9> <017A>
+<BA> <017E>
+<BB> <017C>
+<BC> <0133>
+<BD> <00A1>
+<BE> <00BF>
+<BF> <00A3>
+<D7> <0152>
+<DF> <00530053>
+<F7> <0153>
+<FF> <00DF>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+45 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /SSKXDU+SFRM1000
+/FontDescriptor 73 0 R
+/FirstChar 49
+/LastChar 116
+/Widths 60 0 R
+/Encoding 55 0 R
+/ToUnicode 79 0 R
+>>
+endobj
+50 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [15 0 R]
+>>
+endobj
+80 0 obj
+<<
+/Type /Catalog
+/Pages 50 0 R
+/MarkInfo 51 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 41 0 R
+>>
+endobj
+81 0 obj
+<<
+/Producer (pdfTeX)/Creator (TeX)/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z)
+/Trapped /False
+>>
+endobj
+xref
+0 82
+0000000002 65535 f 
+0000013555 00000 n 
+0000000003 00000 f 
+0000000004 00000 f 
+0000000008 00000 f 
+0000018550 00000 n 
+0000013638 00000 n 
+0000014405 00000 n 
+0000000000 00000 f 
+0000015146 00000 n 
+0000015231 00000 n 
+0000015307 00000 n 
+0000015383 00000 n 
+0000015488 00000 n 
+0000015609 00000 n 
+0000013272 00000 n 
+0000015717 00000 n 
+0000015801 00000 n 
+0000015882 00000 n 
+0000015963 00000 n 
+0000016045 00000 n 
+0000016208 00000 n 
+0000016341 00000 n 
+0000016453 00000 n 
+0000016545 00000 n 
+0000016627 00000 n 
+0000016853 00000 n 
+0000016968 00000 n 
+0000017067 00000 n 
+0000017191 00000 n 
+0000017299 00000 n 
+0000017383 00000 n 
+0000017464 00000 n 
+0000017545 00000 n 
+0000017627 00000 n 
+0000017790 00000 n 
+0000017923 00000 n 
+0000018035 00000 n 
+0000018127 00000 n 
+0000018209 00000 n 
+0000018435 00000 n 
+0000000015 00000 n 
+0000013407 00000 n 
+0000011805 00000 n 
+0000074701 00000 n 
+0000083765 00000 n 
+0000079233 00000 n 
+0000072434 00000 n 
+0000076967 00000 n 
+0000081499 00000 n 
+0000083943 00000 n 
+0000013602 00000 n 
+0000013814 00000 n 
+0000014368 00000 n 
+0000014984 00000 n 
+0000070237 00000 n 
+0000018668 00000 n 
+0000018704 00000 n 
+0000018730 00000 n 
+0000019124 00000 n 
+0000019154 00000 n 
+0000019571 00000 n 
+0000019887 00000 n 
+0000028285 00000 n 
+0000028521 00000 n 
+0000032261 00000 n 
+0000032490 00000 n 
+0000047319 00000 n 
+0000047546 00000 n 
+0000049522 00000 n 
+0000049749 00000 n 
+0000059948 00000 n 
+0000060173 00000 n 
+0000070006 00000 n 
+0000070345 00000 n 
+0000072612 00000 n 
+0000074878 00000 n 
+0000077144 00000 n 
+0000079410 00000 n 
+0000081676 00000 n 
+0000084002 00000 n 
+0000084117 00000 n 
+trailer
+<< /Size 82
+/Root 80 0 R
+/Info 81 0 R
+/ID [<9BD18DF3359C1216B83ADB4AA401CC9A> <9BD18DF3359C1216B83ADB4AA401CC9A>] >>
+startxref
+84249
+%%EOF


### PR DESCRIPTION
Resolves tagging issue  [#714](https://github.com/latex3/tagging-project/issues/714) and cleans up a few internals in the handling of Ref keys. 

## Status of pull request
- Ready to merge

## Checklist of required changes before merge will be approved
- [x] Test file(s) added
- [x] Version and date string updated in changed source files
- [n/a] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [n/a] Rollback provided (if necessary)?
- [n/a] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
