### PR TITLE
fix definition of \IfLabelExistsT, \IfLabelExistsF

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -5,6 +5,9 @@ hotfixes). It is provided for convenience only.  It therefore makes no claims
 to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
+2024-09-25 Matthew Bertucci <bertucci@math.utah.edu>
+	* ltproperties.dtx: Fix definitions for \IfLabelExistsT and \IfLabelExistsF
+
 2024-09-17 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
 	* lttagging.dtx: dummy for \tag_suspend:n and \tag_resume:n
 	* lttagging.dtx: declare tagging sockets for floats and caption.

--- a/base/ltproperties.dtx
+++ b/base/ltproperties.dtx
@@ -30,7 +30,7 @@
 %<*driver> 
 % \fi
 \ProvidesFile{ltproperties.dtx}
-             [2024/09/25 v1.0f LaTeX Kernel (Properties)]
+             [2024/09/25 v1.0g LaTeX Kernel (Properties)]
 % \iffalse
 %
 \documentclass[full]{l3doc}
@@ -776,7 +776,9 @@
 %
 % \begin{macro}{\IfLabelExistsTF,\IfLabelExistsT,\IfLabelExistsF}
 % \changes{v1.0e}{2024-04-17}{Renamed \cs{IfLabelExistTF} to
-%                             \cs{IfLabelExistsTF} (gh/1262)} 
+%                             \cs{IfLabelExistsTF} (gh/1262)}
+% \changes{v1.0g}{2024-09-25}{Fixed definitions of \cs{IfLabelExistsT}
+%                                              and \cs{IfLabelExistsF}}
 %    \begin{macrocode}
 \cs_new_eq:NN \IfLabelExistsTF \property_if_recorded:eTF  
 \cs_new:Npn   \IfLabelExistsT #1#2 {\property_if_recorded:eTF {#1}{#2}{} }  

--- a/base/ltproperties.dtx
+++ b/base/ltproperties.dtx
@@ -30,7 +30,7 @@
 %<*driver> 
 % \fi
 \ProvidesFile{ltproperties.dtx}
-             [2024/09/05 v1.0f LaTeX Kernel (Properties)]
+             [2024/09/25 v1.0f LaTeX Kernel (Properties)]
 % \iffalse
 %
 \documentclass[full]{l3doc}
@@ -779,8 +779,8 @@
 %                             \cs{IfLabelExistsTF} (gh/1262)} 
 %    \begin{macrocode}
 \cs_new_eq:NN \IfLabelExistsTF \property_if_recorded:eTF  
-\cs_new:Npn   \IfLabelExistsT #1#2 {\property_if_exist:eTF {#1}{#2}{} }  
-\cs_new:Npn   \IfLabelExistsF #1   {\property_if_exist:eTF {#1}{} }  
+\cs_new:Npn   \IfLabelExistsT #1#2 {\property_if_recorded:eTF {#1}{#2}{} }  
+\cs_new:Npn   \IfLabelExistsF #1   {\property_if_recorded:eTF {#1}{} }  
 %    \end{macrocode}
 % \end{macro} 
 %

--- a/base/testfiles/properties-008-expansion.lvt
+++ b/base/testfiles/properties-008-expansion.lvt
@@ -54,8 +54,8 @@ xxxxx
    \ASSERT{true true false}
     {
       \IfLabelExistsTF {label\labelsuffix}{true}{false} 
-      \IfLabelExistsT {name\propsuffix}{true}
-      \IfLabelExistsF {name\propsuffix XXX}{false}
+      \IfLabelExistsT {name\labelsuffix}{true}
+      \IfLabelExistsF {name\labelsuffix XXX}{false}
     }    
  }
  

--- a/base/testfiles/properties-008-expansion.lvt
+++ b/base/testfiles/properties-008-expansion.lvt
@@ -54,8 +54,8 @@ xxxxx
    \ASSERT{true true false}
     {
       \IfLabelExistsTF {label\labelsuffix}{true}{false} 
-      \IfLabelExistsT {name\labelsuffix}{true}
-      \IfLabelExistsF {name\labelsuffix XXX}{false}
+      \IfLabelExistsT {label\labelsuffix}{true}
+      \IfLabelExistsF {label\labelsuffix XXX}{false}
     }    
  }
  


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

*Pull requests in this repository are intended for LaTeX Team members only.*

# Internal housekeeping

The definitions for `\IfLabelExistsT` and `\IfLabelExistsF` are currently the same as `\IfPropertyExistsT` and `\IfPropertyExistsF` which is wrong. They should be defined with `\property_if_recorded:...` like `\IfLabelExistsTF`.

I changed the date but not the version and did not add a changed entry. Let me know if either is necessary.

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
