### PR TITLE
Remove NonStruct from footnote label

### DIFF
--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -1,3 +1,6 @@
+2024-09-30 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
+	* latex-lab-footnotes.dtx: remove unneeded NonStruct structure.
+
 2024-09-24 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
 	* latex-lab-sec.dtx,latex-lab-footnotes.dtx: 
 	correct and improve footnotes in longtable

--- a/required/latex-lab/latex-lab-footnotes.dtx
+++ b/required/latex-lab/latex-lab-footnotes.dtx
@@ -492,6 +492,10 @@
 % \subsection{Technical details for the tagging}
 %
 % The following sockets are set up for kernel use, when doing tagging:
+% There name and/or function will probably change as they currently
+% mix tagging with the link support.
+% 
+% TODO: review this sockets
 % \begin{description}
 %    \item[\socket{tagsupport/fnmark} (1 argument)]
 %

--- a/required/latex-lab/latex-lab-footnotes.dtx
+++ b/required/latex-lab/latex-lab-footnotes.dtx
@@ -228,7 +228,8 @@
 %
 %    To cater for different layout configurations there are four
 %    sockets that can be set by a package or 
-%    class but there should be only one per document setting them, i.e., if two packages/classes set them they are mutually
+%    class but there should be only one per document setting them, 
+%    i.e., if two packages/classes set them they are mutually
 %    incompatible (or rather the last one wins most likely).
 %    These are:
 %    \begin{description}
@@ -495,7 +496,13 @@
 %    \item[\socket{tagsupport/fnmark} (1 argument)]
 %
 %      \DescribeSocket[noprint]{tagsupport/fnmark}
-%
+% 
+%    The socket is used in \cs{@footnotemark}/\cs{fnote_footnotemark:} 
+%    and takes \cs{@makefnmark} as argument. It prints the mark in the text
+%    and surrounds it with a tagging structure and a link. As such it is 
+%    not solely for tagging and so should not be used with \cs{UseTaggingSocket}
+%    as this would swallow the argument and loose the link support. 
+%    
 %      \fmi{describe and decide on names}
 %
 %
@@ -503,31 +510,45 @@
 %
 %      \DescribeSocket[noprint]{tagsupport/fntext/begin}
 %
+%    This socket is used before the main processing socket 
+%    (so before the \cs{insert} command). It opens the FEnote structure.
+%    As it sets also the tl-var for the current structure and this is used
+%    in destinations it should not use as tagging socket.
+%    
 %
 %    \item[\socket{tagsupport/fntext/end} (no argument)]
 %
 %      \DescribeSocket[noprint]{tagsupport/fntext/end}
 %
+%    This socket is used after the main processing socket 
+%    (so after the \cs{insert} command). It closes the FEnote structure.
 %
 %    \item[\socket{tagsupport/fntext/mark} (1 argument)]
 %
 %      \DescribeSocket[noprint]{tagsupport/fntext/mark}
-%
+%   
+%    This socket is used around the mark in the footnote text.   
+%    It adds tagging support but also link support, so like the other
+%    tagsupport sockets it should be always active.
 %
 %    \item[\socket{tagsupport/fntext/text} (1 argument)]
 %
 %      \DescribeSocket[noprint]{tagsupport/fntext/text}
 %
+%    This socket handles mc-chunks around the text of the footnote. As it
+%    takes an argument (the text) is should not be use as tagging socket either.
 %
 % \end{description}
 %
 %
 % The \emph{footnotemark} should create a \texttt{/Lbl} structure\footnote{to make it easier
-% to identify the role we use \texttt{/footnotemark} which we rolemap to \texttt{/Lbl}} that should contain a \texttt{/Ref} entry pointing
+% to identify the role we use \texttt{/footnotemark} which we rolemap to \texttt{/Lbl}} 
+% that should contain a \texttt{/Ref} entry pointing
 % to the structure of the \emph{footnotetext}.
 %
-% The \emph{footnotetext} should create a \texttt{/FENote}\footnote{We tag it as \texttt{/footnote} and role map it.}
-%  structure with a \texttt{/Ref}
+% The \emph{footnotetext} should create a \texttt{/FENote}%
+% \footnote{We tag it as \texttt{/footnote} and role map it.}
+% structure with a \texttt{/Ref}
 % entry pointing to the structures of \emph{all} marks related to the note.
 % The mark at the begin of the
 % note is in a \texttt{/Lbl}\footnote{We tag it as \texttt{/footnotelabel}.}
@@ -582,8 +603,8 @@
 % with their own structure number as a key in a property.
 %
 % A following \cs{footnotetext} compares its own \cs{@thefnmark} with the values in
-% the prop. If there is a match it stores the structure numbers and removes the entries
-% from the properties (so in a normal document the property will never contain more than
+% the prop. If there is one or more match it stores the structure numbers and removes the entries
+% from the property (so in a normal document the property will never contain more than
 % a few entries).
 %
 % This works well as long as the \cs{footnotemark} commands are issued before the \cs{footnotetext} and
@@ -626,9 +647,9 @@
 %
 % \subsubsection{\cs{footref}}
 %
-% \cs{footref} use internally the same command to set the mark as \cs{footnotemark}, it only
+% \cs{footref} uses internally the same command to set the mark as \cs{footnotemark}, it only
 % defines \cs{@thefnmark} differently. This \cs{@thefnmark} is not suitable for the method described
-% above, as it contains a reference command it can't be used to match a note, also \cs{footref} can
+% above: as it contains a reference command it can't be used to match a note, also \cs{footref} can
 % be used after the note has already been set. \cs{footref} disables therefore the automatic detection.
 %
 % Instead the \cs{label} command is 
@@ -672,7 +693,7 @@
 %
 % A \cs{footnotetext} creates a bunch of destinations (in most cases this sums up to
 % two destinations): one for every structure number in the \texttt{/Ref} (used as target
-% by the mark commands) and one for the structure number of the footnotetest itself
+% by the mark commands) and one for the structure number of the footnotetext itself
 % (used as target by \cs{footref}s commands).
 %
 % \subsection{Implementation details regarding tagging}
@@ -899,8 +920,8 @@
 % This is used to pass the structure number of the note around, e.g.
 % to a label inside the note.
 %    \begin{macrocode}
-\tl_new:N  \l_@@_currentstruct_tl
-\tl_set:Nn \l_@@_currentstruct_tl {1}
+\tl_new:N  \l_@@_currentstruct_tl 
+\tl_set:Nn \l_@@_currentstruct_tl {2} 
 %    \end{macrocode}
 %
 %

--- a/required/latex-lab/latex-lab-footnotes.dtx
+++ b/required/latex-lab/latex-lab-footnotes.dtx
@@ -17,8 +17,8 @@
 %
 % for those people who are interested or want to report an issue.
 %
-\def\ltlabfootnotedate{2024-09-24}
-\def\ltlabfootnoteversion{0.8f}
+\def\ltlabfootnotedate{2024-09-30}
+\def\ltlabfootnoteversion{0.8g}
 
 %<*driver>
 \documentclass{l3doc}
@@ -1997,11 +1997,7 @@
 %    \begin{macrocode}
     \tl_set:Ne \l_@@_currentstruct_tl { \tag_get:n{struct_num} }
 %    \end{macrocode}
-% We want to move the label structure here. So we provide a container
-% It number is |\l__fnote_currentstruct_tl| plus 1.
-%    \begin{macrocode}
-    \tag_struct_begin:n { tag=footnotelabel }\tag_struct_end:
-%    \end{macrocode}
+%
 % after we have opened the structure we can use the structure number to
 % try to detect the connected marks. As with the marks we assume that sometimes
 % no auto detection is done.
@@ -2084,12 +2080,9 @@
      \MakeLinkTarget*{footnote*.\l_@@_currentstruct_tl}
 %    \end{macrocode}
 %    Now we add the tagging commands. We move the structure of the label to
-%    to the container at the begin of the note.
-% \begin{NOTE}{UF}
-%   Check if the NonStruct is really needed. Perhaps we can simply move the mc.
-% \end{NOTE}
+%    the begin of the footnote structure.
 %    \begin{macrocode}
-     \tag_struct_begin:n { tag=NonStruct,parent=\l_@@_currentstruct_tl +1 }
+     \tag_struct_begin:n { tag=footnotelabel,parent=\l_@@_currentstruct_tl,firstkid }
       \tag_mc_begin:n { tag=Lbl }
        #1
       \tag_mc_end:

--- a/required/latex-lab/testfiles-LM/LM-2-2.tlg
+++ b/required/latex-lab/testfiles-LM/LM-2-2.tlg
@@ -744,10 +744,6 @@ Package tagpdf Info: Parent-Child 'P' --> 'Note'.
 Package tagpdf Info: Parent-Child 'P' --> 'Note'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'footnote' on line ...
-Package tagpdf Info: Parent-Child 'Note' --> 'Lbl'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'Note' --> 'footnotelabel' on line ...
-Package tagpdf Info: closing structure 108 tagged /footnotelabel
 Package tagpdf Info: Parent-Child 'Note' --> 'Part'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Note' --> 'text-unit' on line ...
@@ -758,13 +754,13 @@ Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
 Package tagpdf Info: text has been pushed to the mc stack
-Package tagpdf Info: Parent-Child 'Lbl' --> 'NonStruct'.
+Package tagpdf Info: Parent-Child 'Note' --> 'Lbl'.
 (tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'Lbl' --> 'NonStruct' on line ...
+(tagpdf)             Rolemapped from: 'Note' --> 'footnotelabel' on line ...
 Package tagpdf Info: Parent-Child 'Lbl' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Lbl' --> 'MC' on line ...
-Package tagpdf Info: closing structure 111 tagged /NonStruct
+Package tagpdf Info: closing structure 110 tagged /footnotelabel
 Package tagpdf Info: text has been removed from the mc stack
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
@@ -777,8 +773,8 @@ Package tagpdf Info: text has been removed from the mc stack
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 110 tagged /text
-Package tagpdf Info: closing structure 109 tagged /text-unit
+Package tagpdf Info: closing structure 109 tagged /text
+Package tagpdf Info: closing structure 108 tagged /text-unit
 Package tagpdf Info: closing structure 107 tagged /footnote
 Package tagpdf Info: text has been removed from the mc stack
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
@@ -791,7 +787,7 @@ Package tagpdf Info: Parent-Child 'P' --> 'Lbl'.
 Package tagpdf Info: Parent-Child 'Lbl' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Lbl' --> 'MC' on line ...
-Package tagpdf Info: closing structure 112 tagged /footnotemark
+Package tagpdf Info: closing structure 111 tagged /footnotemark
 Package tagpdf Info: text has been removed from the mc stack
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
@@ -805,27 +801,23 @@ Package tagpdf Info: Parent-Child 'Sect' --> 'Note'.
 Package tagpdf Info: Parent-Child 'Sect' --> 'Note'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'footnote' on line ...
+Package tagpdf Info: Parent-Child 'Note' --> 'Part'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'Note' --> 'text-unit' on line ...
+Package tagpdf Info: Parent-Child 'Note' --> 'P'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'Note' --> 'text' on line ...
+Package tagpdf Info: Parent-Child 'P' --> 'MC'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
+Package tagpdf Info: text has been pushed to the mc stack
 Package tagpdf Info: Parent-Child 'Note' --> 'Lbl'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Note' --> 'footnotelabel' on line ...
-Package tagpdf Info: closing structure 114 tagged /footnotelabel
-Package tagpdf Info: Parent-Child 'Note' --> 'Part'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'Note' --> 'text-unit' on line ...
-Package tagpdf Info: Parent-Child 'Note' --> 'P'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'Note' --> 'text' on line ...
-Package tagpdf Info: Parent-Child 'P' --> 'MC'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: text has been pushed to the mc stack
-Package tagpdf Info: Parent-Child 'Lbl' --> 'NonStruct'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'Lbl' --> 'NonStruct' on line ...
 Package tagpdf Info: Parent-Child 'Lbl' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Lbl' --> 'MC' on line ...
-Package tagpdf Info: closing structure 117 tagged /NonStruct
+Package tagpdf Info: closing structure 115 tagged /footnotelabel
 Package tagpdf Info: text has been removed from the mc stack
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
@@ -834,8 +826,8 @@ Package tagpdf Info: text has been pushed to the mc stack
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 116 tagged /text
-Package tagpdf Info: closing structure 115 tagged /text-unit
+Package tagpdf Info: closing structure 114 tagged /text
+Package tagpdf Info: closing structure 113 tagged /text-unit
 Package tagpdf Info: Parent-Child 'Note' --> 'Part'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Note' --> 'text-unit' on line ...
@@ -849,9 +841,9 @@ Package tagpdf Info: text has been removed from the mc stack
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 119 tagged /text
-Package tagpdf Info: closing structure 118 tagged /text-unit
-Package tagpdf Info: closing structure 113 tagged /footnote
+Package tagpdf Info: closing structure 117 tagged /text
+Package tagpdf Info: closing structure 116 tagged /text-unit
+Package tagpdf Info: closing structure 112 tagged /footnote
 Package tagpdf Info: -1 has been removed from the mc stack
 Package tagpdf Info: Parent-Child 'Sect' --> 'Part'.
 (tagpdf)             Relation is 1 (='0..n')
@@ -862,8 +854,8 @@ Package tagpdf Info: Parent-Child 'Sect' --> 'P'.
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 121 tagged /text
-Package tagpdf Info: closing structure 120 tagged /text-unit
+Package tagpdf Info: closing structure 119 tagged /text
+Package tagpdf Info: closing structure 118 tagged /text-unit
 Package tagpdf Info: closing structure 102 tagged /Sect
 Package tagpdf Info: Parent-Child 'Sect' --> 'Sect'.
 (tagpdf)             Relation is 1 (='0..n')
@@ -874,7 +866,7 @@ Package tagpdf Info: Parent-Child 'Sect' --> 'H4'.
 Package tagpdf Info: Parent-Child 'H4' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'H4' --> 'MC' on line ...
-Package tagpdf Info: closing structure 123 tagged /subsubsection
+Package tagpdf Info: closing structure 121 tagged /subsubsection
 Package tagpdf Info: Parent-Child 'Sect' --> 'Part'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'text-unit' on line ...
@@ -894,7 +886,7 @@ Package tagpdf Info: Parent-Child 'P' --> 'Formula'.
 Package tagpdf Info: Parent-Child 'Formula' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Formula' --> 'MC' on line ...
-Package tagpdf Info: closing structure 126 tagged /Formula
+Package tagpdf Info: closing structure 124 tagged /Formula
 Package tagpdf Info: text has been removed from the mc stack
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
@@ -909,7 +901,7 @@ Package tagpdf Info: Parent-Child 'P' --> 'Formula'.
 Package tagpdf Info: Parent-Child 'Formula' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Formula' --> 'MC' on line ...
-Package tagpdf Info: closing structure 127 tagged /Formula
+Package tagpdf Info: closing structure 125 tagged /Formula
 Package tagpdf Info: text has been removed from the mc stack
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
@@ -924,14 +916,14 @@ Package tagpdf Info: Parent-Child 'P' --> 'Formula'.
 Package tagpdf Info: Parent-Child 'Formula' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Formula' --> 'MC' on line ...
-Package tagpdf Info: closing structure 128 tagged /Formula
+Package tagpdf Info: closing structure 126 tagged /Formula
 Package tagpdf Info: text has been removed from the mc stack
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 125 tagged /text
-Package tagpdf Info: closing structure 124 tagged /text-unit
-Package tagpdf Info: closing structure 122 tagged /Sect
+Package tagpdf Info: closing structure 123 tagged /text
+Package tagpdf Info: closing structure 122 tagged /text-unit
+Package tagpdf Info: closing structure 120 tagged /Sect
 Package tagpdf Info: closing structure 69 tagged /Sect
 Package tagpdf Info: Parent-Child 'Sect' --> 'Sect'.
 (tagpdf)             Relation is 1 (='0..n')
@@ -945,11 +937,11 @@ Package tagpdf Info: Parent-Child 'H3' --> 'Lbl'.
 Package tagpdf Info: Parent-Child 'Lbl' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Lbl' --> 'MC' on line ...
-Package tagpdf Info: closing structure 131 tagged /Lbl
+Package tagpdf Info: closing structure 129 tagged /Lbl
 Package tagpdf Info: Parent-Child 'H3' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'H3' --> 'MC' on line ...
-Package tagpdf Info: closing structure 130 tagged /subsection
+Package tagpdf Info: closing structure 128 tagged /subsection
 Package tagpdf Info: Parent-Child 'Sect' --> 'Sect'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'Sect' on line ...
@@ -959,7 +951,7 @@ Package tagpdf Info: Parent-Child 'Sect' --> 'H4'.
 Package tagpdf Info: Parent-Child 'H4' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'H4' --> 'MC' on line ...
-Package tagpdf Info: closing structure 133 tagged /subsubsection
+Package tagpdf Info: closing structure 131 tagged /subsubsection
 Package tagpdf Info: Parent-Child 'Sect' --> 'Part'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'text-unit' on line ...
@@ -969,10 +961,10 @@ Package tagpdf Info: Parent-Child 'Sect' --> 'P'.
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 135 tagged /text
-Package tagpdf Info: closing structure 134 tagged /text-unit
-Package tagpdf Info: closing structure 132 tagged /Sect
-Package tagpdf Info: closing structure 129 tagged /Sect
+Package tagpdf Info: closing structure 133 tagged /text
+Package tagpdf Info: closing structure 132 tagged /text-unit
+Package tagpdf Info: closing structure 130 tagged /Sect
+Package tagpdf Info: closing structure 127 tagged /Sect
 Package tagpdf Info: Parent-Child 'Sect' --> 'Sect'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'Sect' on line ...
@@ -985,11 +977,11 @@ Package tagpdf Info: Parent-Child 'H3' --> 'Lbl'.
 Package tagpdf Info: Parent-Child 'Lbl' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Lbl' --> 'MC' on line ...
-Package tagpdf Info: closing structure 138 tagged /Lbl
+Package tagpdf Info: closing structure 136 tagged /Lbl
 Package tagpdf Info: Parent-Child 'H3' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'H3' --> 'MC' on line ...
-Package tagpdf Info: closing structure 137 tagged /subsection
+Package tagpdf Info: closing structure 135 tagged /subsection
 Package tagpdf Info: Parent-Child 'Sect' --> 'Part'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'text-unit' on line ...
@@ -1006,14 +998,14 @@ Package tagpdf Info: Parent-Child 'P' --> 'Span'.
 Package tagpdf Info: Parent-Child 'Span' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Span' --> 'MC' on line ...
-Package tagpdf Info: closing structure 141 tagged /Span
+Package tagpdf Info: closing structure 139 tagged /Span
 Package tagpdf Info: text has been removed from the mc stack
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 140 tagged /text
-Package tagpdf Info: closing structure 139 tagged /text-unit
-Package tagpdf Info: closing structure 136 tagged /Sect
+Package tagpdf Info: closing structure 138 tagged /text
+Package tagpdf Info: closing structure 137 tagged /text-unit
+Package tagpdf Info: closing structure 134 tagged /Sect
 Package tagpdf Info: Parent-Child 'Sect' --> 'Sect'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'Sect' on line ...
@@ -1026,11 +1018,11 @@ Package tagpdf Info: Parent-Child 'H3' --> 'Lbl'.
 Package tagpdf Info: Parent-Child 'Lbl' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Lbl' --> 'MC' on line ...
-Package tagpdf Info: closing structure 144 tagged /Lbl
+Package tagpdf Info: closing structure 142 tagged /Lbl
 Package tagpdf Info: Parent-Child 'H3' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'H3' --> 'MC' on line ...
-Package tagpdf Info: closing structure 143 tagged /subsection
+Package tagpdf Info: closing structure 141 tagged /subsection
 Package tagpdf Info: Parent-Child 'Sect' --> 'Part'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'text-unit' on line ...
@@ -1040,7 +1032,7 @@ Package tagpdf Info: Parent-Child 'Sect' --> 'P'.
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 146 tagged /text
+Package tagpdf Info: closing structure 144 tagged /text
 Package tagpdf Info: Parent-Child 'Sect' --> 'BlockQuote'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'quote' on line ...
@@ -1053,17 +1045,17 @@ Package tagpdf Info: Parent-Child 'BlockQuote' --> 'P'.
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 149 tagged /text
-Package tagpdf Info: closing structure 148 tagged /text-unit
-Package tagpdf Info: closing structure 147 tagged /quote
+Package tagpdf Info: closing structure 147 tagged /text
+Package tagpdf Info: closing structure 146 tagged /text-unit
+Package tagpdf Info: closing structure 145 tagged /quote
 Package tagpdf Info: Parent-Child 'Sect' --> 'P'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'text' on line ...
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 150 tagged /text
-Package tagpdf Info: closing structure 145 tagged /text-unit
+Package tagpdf Info: closing structure 148 tagged /text
+Package tagpdf Info: closing structure 143 tagged /text-unit
 Package tagpdf Info: Parent-Child 'Sect' --> 'Sect'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'Sect' on line ...
@@ -1073,7 +1065,7 @@ Package tagpdf Info: Parent-Child 'Sect' --> 'H4'.
 Package tagpdf Info: Parent-Child 'H4' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'H4' --> 'MC' on line ...
-Package tagpdf Info: closing structure 152 tagged /subsubsection
+Package tagpdf Info: closing structure 150 tagged /subsubsection
 Package tagpdf Info: Parent-Child 'Sect' --> 'Part'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'text-unit' on line ...
@@ -1083,7 +1075,7 @@ Package tagpdf Info: Parent-Child 'Sect' --> 'P'.
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 154 tagged /text
+Package tagpdf Info: closing structure 152 tagged /text
 The sequence \g__tag_mc_main_marks_seq contains the items (without outer
 braces):
 >  {e+}
@@ -1095,6 +1087,17 @@ The sequence \g__tag_mc_footnote_marks_seq is empty
 Package tagpdf Info: Parent-Child 'Sect' --> 'BlockQuote'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'quote' on line ...
+Package tagpdf Info: Parent-Child 'BlockQuote' --> 'Part'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'BlockQuote' --> 'text-unit' on line ...
+Package tagpdf Info: Parent-Child 'BlockQuote' --> 'P'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'BlockQuote' --> 'text' on line ...
+Package tagpdf Info: Parent-Child 'P' --> 'MC'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
+Package tagpdf Info: closing structure 155 tagged /text
+Package tagpdf Info: closing structure 154 tagged /text-unit
 Package tagpdf Info: Parent-Child 'BlockQuote' --> 'Part'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'BlockQuote' --> 'text-unit' on line ...
@@ -1117,6 +1120,17 @@ Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
 Package tagpdf Info: closing structure 159 tagged /text
 Package tagpdf Info: closing structure 158 tagged /text-unit
+Package tagpdf Info: closing structure 153 tagged /quote
+Package tagpdf Info: Parent-Child 'Sect' --> 'P'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'Sect' --> 'text' on line ...
+Package tagpdf Info: Parent-Child 'P' --> 'MC'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
+Package tagpdf Info: closing structure 160 tagged /text
+Package tagpdf Info: Parent-Child 'Sect' --> 'BlockQuote'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'Sect' --> 'quotation' on line ...
 Package tagpdf Info: Parent-Child 'BlockQuote' --> 'Part'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'BlockQuote' --> 'text-unit' on line ...
@@ -1126,19 +1140,8 @@ Package tagpdf Info: Parent-Child 'BlockQuote' --> 'P'.
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 161 tagged /text
-Package tagpdf Info: closing structure 160 tagged /text-unit
-Package tagpdf Info: closing structure 155 tagged /quote
-Package tagpdf Info: Parent-Child 'Sect' --> 'P'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'Sect' --> 'text' on line ...
-Package tagpdf Info: Parent-Child 'P' --> 'MC'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 162 tagged /text
-Package tagpdf Info: Parent-Child 'Sect' --> 'BlockQuote'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'Sect' --> 'quotation' on line ...
+Package tagpdf Info: closing structure 163 tagged /text
+Package tagpdf Info: closing structure 162 tagged /text-unit
 Package tagpdf Info: Parent-Child 'BlockQuote' --> 'Part'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'BlockQuote' --> 'text-unit' on line ...
@@ -1161,20 +1164,9 @@ Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
 Package tagpdf Info: closing structure 167 tagged /text
 Package tagpdf Info: closing structure 166 tagged /text-unit
-Package tagpdf Info: Parent-Child 'BlockQuote' --> 'Part'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'BlockQuote' --> 'text-unit' on line ...
-Package tagpdf Info: Parent-Child 'BlockQuote' --> 'P'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'BlockQuote' --> 'text' on line ...
-Package tagpdf Info: Parent-Child 'P' --> 'MC'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 169 tagged /text
-Package tagpdf Info: closing structure 168 tagged /text-unit
-Package tagpdf Info: closing structure 163 tagged /quotation
-Package tagpdf Info: closing structure 153 tagged /text-unit
-Package tagpdf Info: closing structure 151 tagged /Sect
+Package tagpdf Info: closing structure 161 tagged /quotation
+Package tagpdf Info: closing structure 151 tagged /text-unit
+Package tagpdf Info: closing structure 149 tagged /Sect
 Package tagpdf Info: Parent-Child 'Sect' --> 'Sect'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'Sect' on line ...
@@ -1184,7 +1176,7 @@ Package tagpdf Info: Parent-Child 'Sect' --> 'H4'.
 Package tagpdf Info: Parent-Child 'H4' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'H4' --> 'MC' on line ...
-Package tagpdf Info: closing structure 171 tagged /subsubsection
+Package tagpdf Info: closing structure 169 tagged /subsubsection
 Package tagpdf Info: Parent-Child 'Sect' --> 'Part'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'text-unit' on line ...
@@ -1194,7 +1186,7 @@ Package tagpdf Info: Parent-Child 'Sect' --> 'P'.
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 173 tagged /text
+Package tagpdf Info: closing structure 171 tagged /text
 Package tagpdf Info: Parent-Child 'Sect' --> 'L'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'itemize' on line ...
@@ -1207,7 +1199,7 @@ Package tagpdf Info: Parent-Child 'LI' --> 'Lbl'.
 Package tagpdf Info: Parent-Child 'Lbl' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Lbl' --> 'MC' on line ...
-Package tagpdf Info: closing structure 176 tagged /Lbl
+Package tagpdf Info: closing structure 174 tagged /Lbl
 Package tagpdf Info: Parent-Child 'LI' --> 'LBody'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'LI' --> 'LBody' on line ...
@@ -1220,10 +1212,10 @@ Package tagpdf Info: Parent-Child 'LBody' --> 'P'.
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 179 tagged /text
-Package tagpdf Info: closing structure 178 tagged /text-unit
-Package tagpdf Info: closing structure 177 tagged /LBody
-Package tagpdf Info: closing structure 175 tagged /LI
+Package tagpdf Info: closing structure 177 tagged /text
+Package tagpdf Info: closing structure 176 tagged /text-unit
+Package tagpdf Info: closing structure 175 tagged /LBody
+Package tagpdf Info: closing structure 173 tagged /LI
 Package tagpdf Info: Parent-Child 'L' --> 'LI'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'L' --> 'LI' on line ...
@@ -1233,7 +1225,7 @@ Package tagpdf Info: Parent-Child 'LI' --> 'Lbl'.
 Package tagpdf Info: Parent-Child 'Lbl' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Lbl' --> 'MC' on line ...
-Package tagpdf Info: closing structure 181 tagged /Lbl
+Package tagpdf Info: closing structure 179 tagged /Lbl
 Package tagpdf Info: Parent-Child 'LI' --> 'LBody'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'LI' --> 'LBody' on line ...
@@ -1246,7 +1238,7 @@ Package tagpdf Info: Parent-Child 'LBody' --> 'P'.
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 184 tagged /text
+Package tagpdf Info: closing structure 182 tagged /text
 Package tagpdf Info: Parent-Child 'LBody' --> 'L'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'LBody' --> 'enumerate' on line ...
@@ -1259,7 +1251,7 @@ Package tagpdf Info: Parent-Child 'LI' --> 'Lbl'.
 Package tagpdf Info: Parent-Child 'Lbl' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Lbl' --> 'MC' on line ...
-Package tagpdf Info: closing structure 187 tagged /Lbl
+Package tagpdf Info: closing structure 185 tagged /Lbl
 Package tagpdf Info: Parent-Child 'LI' --> 'LBody'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'LI' --> 'LBody' on line ...
@@ -1272,10 +1264,10 @@ Package tagpdf Info: Parent-Child 'LBody' --> 'P'.
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 190 tagged /text
-Package tagpdf Info: closing structure 189 tagged /text-unit
-Package tagpdf Info: closing structure 188 tagged /LBody
-Package tagpdf Info: closing structure 186 tagged /LI
+Package tagpdf Info: closing structure 188 tagged /text
+Package tagpdf Info: closing structure 187 tagged /text-unit
+Package tagpdf Info: closing structure 186 tagged /LBody
+Package tagpdf Info: closing structure 184 tagged /LI
 Package tagpdf Info: Parent-Child 'L' --> 'LI'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'L' --> 'LI' on line ...
@@ -1285,7 +1277,7 @@ Package tagpdf Info: Parent-Child 'LI' --> 'Lbl'.
 Package tagpdf Info: Parent-Child 'Lbl' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Lbl' --> 'MC' on line ...
-Package tagpdf Info: closing structure 192 tagged /Lbl
+Package tagpdf Info: closing structure 190 tagged /Lbl
 Package tagpdf Info: Parent-Child 'LI' --> 'LBody'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'LI' --> 'LBody' on line ...
@@ -1298,14 +1290,14 @@ Package tagpdf Info: Parent-Child 'LBody' --> 'P'.
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 195 tagged /text
-Package tagpdf Info: closing structure 194 tagged /text-unit
-Package tagpdf Info: closing structure 193 tagged /LBody
-Package tagpdf Info: closing structure 191 tagged /LI
-Package tagpdf Info: closing structure 185 tagged /enumerate
-Package tagpdf Info: closing structure 183 tagged /text-unit
-Package tagpdf Info: closing structure 182 tagged /LBody
-Package tagpdf Info: closing structure 180 tagged /LI
+Package tagpdf Info: closing structure 193 tagged /text
+Package tagpdf Info: closing structure 192 tagged /text-unit
+Package tagpdf Info: closing structure 191 tagged /LBody
+Package tagpdf Info: closing structure 189 tagged /LI
+Package tagpdf Info: closing structure 183 tagged /enumerate
+Package tagpdf Info: closing structure 181 tagged /text-unit
+Package tagpdf Info: closing structure 180 tagged /LBody
+Package tagpdf Info: closing structure 178 tagged /LI
 Package tagpdf Info: Parent-Child 'L' --> 'LI'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'L' --> 'LI' on line ...
@@ -1315,7 +1307,7 @@ Package tagpdf Info: Parent-Child 'LI' --> 'Lbl'.
 Package tagpdf Info: Parent-Child 'Lbl' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Lbl' --> 'MC' on line ...
-Package tagpdf Info: closing structure 197 tagged /Lbl
+Package tagpdf Info: closing structure 195 tagged /Lbl
 Package tagpdf Info: Parent-Child 'LI' --> 'LBody'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'LI' --> 'LBody' on line ...
@@ -1328,19 +1320,19 @@ Package tagpdf Info: Parent-Child 'LBody' --> 'P'.
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 200 tagged /text
-Package tagpdf Info: closing structure 199 tagged /text-unit
-Package tagpdf Info: closing structure 198 tagged /LBody
-Package tagpdf Info: closing structure 196 tagged /LI
-Package tagpdf Info: closing structure 174 tagged /itemize
+Package tagpdf Info: closing structure 198 tagged /text
+Package tagpdf Info: closing structure 197 tagged /text-unit
+Package tagpdf Info: closing structure 196 tagged /LBody
+Package tagpdf Info: closing structure 194 tagged /LI
+Package tagpdf Info: closing structure 172 tagged /itemize
 Package tagpdf Info: Parent-Child 'Sect' --> 'P'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'text' on line ...
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 201 tagged /text
-Package tagpdf Info: closing structure 172 tagged /text-unit
+Package tagpdf Info: closing structure 199 tagged /text
+Package tagpdf Info: closing structure 170 tagged /text-unit
 Package tagpdf Info: Parent-Child 'Sect' --> 'Part'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'text-unit' on line ...
@@ -1350,7 +1342,7 @@ Package tagpdf Info: Parent-Child 'Sect' --> 'P'.
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 203 tagged /text
+Package tagpdf Info: closing structure 201 tagged /text
 Package tagpdf Info: Parent-Child 'Sect' --> 'L'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'description' on line ...
@@ -1363,7 +1355,7 @@ Package tagpdf Info: Parent-Child 'LI' --> 'Lbl'.
 Package tagpdf Info: Parent-Child 'Lbl' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Lbl' --> 'MC' on line ...
-Package tagpdf Info: closing structure 206 tagged /Lbl
+Package tagpdf Info: closing structure 204 tagged /Lbl
 Package tagpdf Info: Parent-Child 'LI' --> 'LBody'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'LI' --> 'LBody' on line ...
@@ -1376,10 +1368,10 @@ Package tagpdf Info: Parent-Child 'LBody' --> 'P'.
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 209 tagged /text
-Package tagpdf Info: closing structure 208 tagged /text-unit
-Package tagpdf Info: closing structure 207 tagged /LBody
-Package tagpdf Info: closing structure 205 tagged /LI
+Package tagpdf Info: closing structure 207 tagged /text
+Package tagpdf Info: closing structure 206 tagged /text-unit
+Package tagpdf Info: closing structure 205 tagged /LBody
+Package tagpdf Info: closing structure 203 tagged /LI
 Package tagpdf Info: Parent-Child 'L' --> 'LI'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'L' --> 'LI' on line ...
@@ -1389,7 +1381,7 @@ Package tagpdf Info: Parent-Child 'LI' --> 'Lbl'.
 Package tagpdf Info: Parent-Child 'Lbl' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Lbl' --> 'MC' on line ...
-Package tagpdf Info: closing structure 211 tagged /Lbl
+Package tagpdf Info: closing structure 209 tagged /Lbl
 Package tagpdf Info: Parent-Child 'LI' --> 'LBody'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'LI' --> 'LBody' on line ...
@@ -1402,19 +1394,19 @@ Package tagpdf Info: Parent-Child 'LBody' --> 'P'.
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 214 tagged /text
-Package tagpdf Info: closing structure 213 tagged /text-unit
+Package tagpdf Info: closing structure 212 tagged /text
+Package tagpdf Info: closing structure 211 tagged /text-unit
 The sequence \g__tag_mc_main_marks_seq contains the items (without outer
 braces):
 >  {e+}
 >  {100}
->  {150}.
+>  {148}.
 [3]
-Package tagpdf Info: closing structure 212 tagged /LBody
-Package tagpdf Info: closing structure 210 tagged /LI
-Package tagpdf Info: closing structure 204 tagged /description
-Package tagpdf Info: closing structure 202 tagged /text-unit
-Package tagpdf Info: closing structure 170 tagged /Sect
+Package tagpdf Info: closing structure 210 tagged /LBody
+Package tagpdf Info: closing structure 208 tagged /LI
+Package tagpdf Info: closing structure 202 tagged /description
+Package tagpdf Info: closing structure 200 tagged /text-unit
+Package tagpdf Info: closing structure 168 tagged /Sect
 Package tagpdf Info: Parent-Child 'Sect' --> 'Sect'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'Sect' on line ...
@@ -1424,7 +1416,7 @@ Package tagpdf Info: Parent-Child 'Sect' --> 'H4'.
 Package tagpdf Info: Parent-Child 'H4' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'H4' --> 'MC' on line ...
-Package tagpdf Info: closing structure 216 tagged /subsubsection
+Package tagpdf Info: closing structure 214 tagged /subsubsection
 Package tagpdf Info: Parent-Child 'Sect' --> 'Part'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'text-unit' on line ...
@@ -1434,8 +1426,8 @@ Package tagpdf Info: Parent-Child 'Sect' --> 'P'.
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 218 tagged /text
-Package tagpdf Info: closing structure 217 tagged /text-unit
+Package tagpdf Info: closing structure 216 tagged /text
+Package tagpdf Info: closing structure 215 tagged /text-unit
 Package tagpdf Info: Parent-Child 'Sect' --> 'Part'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'text-unit' on line ...
@@ -1451,10 +1443,21 @@ Package tagpdf Info: Parent-Child 'LI' --> 'Lbl'.
 Package tagpdf Info: Parent-Child 'Lbl' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Lbl' --> 'MC' on line ...
-Package tagpdf Info: closing structure 222 tagged /Lbl
+Package tagpdf Info: closing structure 220 tagged /Lbl
 Package tagpdf Info: Parent-Child 'LI' --> 'LBody'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'LI' --> 'LBody' on line ...
+Package tagpdf Info: Parent-Child 'LBody' --> 'Part'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'LBody' --> 'text-unit' on line ...
+Package tagpdf Info: Parent-Child 'LBody' --> 'P'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'LBody' --> 'text' on line ...
+Package tagpdf Info: Parent-Child 'P' --> 'MC'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
+Package tagpdf Info: closing structure 223 tagged /text
+Package tagpdf Info: closing structure 222 tagged /text-unit
 Package tagpdf Info: Parent-Child 'LBody' --> 'Part'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'LBody' --> 'text-unit' on line ...
@@ -1486,6 +1489,18 @@ Package tagpdf Info: Parent-Child 'LBody' --> 'P'.
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
+Package tagpdf Info: text has been pushed to the mc stack
+Package tagpdf Info: Parent-Child 'P' --> 'Span'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'P' --> 'Em' on line ...
+Package tagpdf Info: Parent-Child 'Span' --> 'MC'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'Span' --> 'MC' on line ...
+Package tagpdf Info: closing structure 230 tagged /Em
+Package tagpdf Info: text has been removed from the mc stack
+Package tagpdf Info: Parent-Child 'P' --> 'MC'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
 Package tagpdf Info: closing structure 229 tagged /text
 Package tagpdf Info: closing structure 228 tagged /text-unit
 Package tagpdf Info: Parent-Child 'LBody' --> 'Part'.
@@ -1497,36 +1512,13 @@ Package tagpdf Info: Parent-Child 'LBody' --> 'P'.
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: text has been pushed to the mc stack
-Package tagpdf Info: Parent-Child 'P' --> 'Span'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'P' --> 'Em' on line ...
-Package tagpdf Info: Parent-Child 'Span' --> 'MC'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'Span' --> 'MC' on line ...
-Package tagpdf Info: closing structure 232 tagged /Em
-Package tagpdf Info: text has been removed from the mc stack
-Package tagpdf Info: Parent-Child 'P' --> 'MC'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 231 tagged /text
-Package tagpdf Info: closing structure 230 tagged /text-unit
-Package tagpdf Info: Parent-Child 'LBody' --> 'Part'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'LBody' --> 'text-unit' on line ...
-Package tagpdf Info: Parent-Child 'LBody' --> 'P'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'LBody' --> 'text' on line ...
-Package tagpdf Info: Parent-Child 'P' --> 'MC'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 234 tagged /text
-Package tagpdf Info: closing structure 233 tagged /text-unit
-Package tagpdf Info: closing structure 223 tagged /LBody
-Package tagpdf Info: closing structure 221 tagged /LI
-Package tagpdf Info: closing structure 220 tagged /list
-Package tagpdf Info: closing structure 219 tagged /text-unit
-Package tagpdf Info: closing structure 215 tagged /Sect
+Package tagpdf Info: closing structure 232 tagged /text
+Package tagpdf Info: closing structure 231 tagged /text-unit
+Package tagpdf Info: closing structure 221 tagged /LBody
+Package tagpdf Info: closing structure 219 tagged /LI
+Package tagpdf Info: closing structure 218 tagged /list
+Package tagpdf Info: closing structure 217 tagged /text-unit
+Package tagpdf Info: closing structure 213 tagged /Sect
 Package tagpdf Info: Parent-Child 'Sect' --> 'Sect'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'Sect' on line ...
@@ -1536,10 +1528,27 @@ Package tagpdf Info: Parent-Child 'Sect' --> 'H4'.
 Package tagpdf Info: Parent-Child 'H4' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'H4' --> 'MC' on line ...
-Package tagpdf Info: closing structure 236 tagged /subsubsection
+Package tagpdf Info: closing structure 234 tagged /subsubsection
 Package tagpdf Info: Parent-Child 'Sect' --> 'Part'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'text-unit' on line ...
+Package tagpdf Info: Parent-Child 'Sect' --> 'P'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'Sect' --> 'text' on line ...
+Package tagpdf Info: Parent-Child 'P' --> 'MC'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
+Package tagpdf Info: closing structure 236 tagged /text
+Package tagpdf Info: Parent-Child 'Sect' --> 'Formula'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'Sect' --> 'Formula' on line ...
+====>first-result=macro:->x' + y^2 = z_i^2
+====>first-tmpmathcontent=macro:->
+====>formula has no subparts
+Package tagpdf Info: Parent-Child 'Formula' --> 'MC'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'Formula' --> 'MC' on line ...
+Package tagpdf Info: closing structure 237 tagged /Formula
 Package tagpdf Info: Parent-Child 'Sect' --> 'P'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Sect' --> 'text' on line ...
@@ -1556,6 +1565,16 @@ Package tagpdf Info: Parent-Child 'Sect' --> 'Formula'.
 Package tagpdf Info: Parent-Child 'Formula' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'Formula' --> 'MC' on line ...
+Package tagpdf Info: Parent-Child 'Formula' --> 'Lbl'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'Formula' --> 'Lbl' on line ...
+Package tagpdf Info: Parent-Child 'Lbl' --> 'MC'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'Lbl' --> 'MC' on line ...
+Package tagpdf Info: closing structure 240 tagged /Lbl
+Package tagpdf Info: Parent-Child 'Formula' --> 'MC'.
+(tagpdf)             Relation is 1 (='0..n')
+(tagpdf)             Rolemapped from: 'Formula' --> 'MC' on line ...
 Package tagpdf Info: closing structure 239 tagged /Formula
 Package tagpdf Info: Parent-Child 'Sect' --> 'P'.
 (tagpdf)             Relation is 1 (='0..n')
@@ -1563,38 +1582,11 @@ Package tagpdf Info: Parent-Child 'Sect' --> 'P'.
 Package tagpdf Info: Parent-Child 'P' --> 'MC'.
 (tagpdf)             Relation is 1 (='0..n')
 (tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 240 tagged /text
-Package tagpdf Info: Parent-Child 'Sect' --> 'Formula'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'Sect' --> 'Formula' on line ...
-====>first-result=macro:->x' + y^2 = z_i^2
-====>first-tmpmathcontent=macro:->
-====>formula has no subparts
-Package tagpdf Info: Parent-Child 'Formula' --> 'MC'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'Formula' --> 'MC' on line ...
-Package tagpdf Info: Parent-Child 'Formula' --> 'Lbl'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'Formula' --> 'Lbl' on line ...
-Package tagpdf Info: Parent-Child 'Lbl' --> 'MC'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'Lbl' --> 'MC' on line ...
-Package tagpdf Info: closing structure 242 tagged /Lbl
-Package tagpdf Info: Parent-Child 'Formula' --> 'MC'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'Formula' --> 'MC' on line ...
-Package tagpdf Info: closing structure 241 tagged /Formula
-Package tagpdf Info: Parent-Child 'Sect' --> 'P'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'Sect' --> 'text' on line ...
-Package tagpdf Info: Parent-Child 'P' --> 'MC'.
-(tagpdf)             Relation is 1 (='0..n')
-(tagpdf)             Rolemapped from: 'P' --> 'MC' on line ...
-Package tagpdf Info: closing structure 243 tagged /text
-Package tagpdf Info: closing structure 237 tagged /text-unit
+Package tagpdf Info: closing structure 241 tagged /text
+Package tagpdf Info: closing structure 235 tagged /text-unit
 The sequence \g__tag_mc_main_marks_seq contains the items (without outer
 braces):
 >  {e+}
 >  {125}
->  {203}.
+>  {201}.
 [4]

--- a/required/latex-lab/testfiles-OR-luatex/footmisc-003.tlg
+++ b/required/latex-lab/testfiles-OR-luatex/footmisc-003.tlg
@@ -101,7 +101,7 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\pdfliteral page <lua data reference ...>
 .....\pdfliteral page <lua data reference ...>
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 3 } action struct name{footnote*.14} goto name{footnote*.14}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 3 } action struct name{footnote*.13} goto name{footnote*.13}
 .....\hbox(8.14003+0.0)x4.48613, direction TLT
 ......\mathon
 ......\hbox(0.0+0.0)x0.0, direction TLT
@@ -169,14 +169,14 @@ Completed box being shipped out [1]
 ......\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
 .......\pdfliteral page <lua data reference ...>
 .......\pdfliteral page <lua data reference ...>
-.......\pdfdest name{footnote*.14} xyz
-.......\pdfdest name{footnote*.14} xyz
+.......\pdfdest name{footnote*.13} xyz
+.......\pdfdest name{footnote*.13} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0, direction TLT
 ......\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
-.......\pdfdest name{footnote*.16} xyz
-.......\pdfdest name{footnote*.16} xyz
+.......\pdfdest name{footnote*.15} xyz
+.......\pdfdest name{footnote*.15} xyz
 .......\penalty 10000
 .....\hbox(6.68999+0.0)x18.00005, glue set 13.83344fil, direction TLT
 ......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -272,7 +272,7 @@ Completed box being shipped out [2]
 .....\penalty 10000
 .....\pdfliteral page <lua data reference ...>
 .....\pdfliteral page <lua data reference ...>
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 4 } action struct name{footnote*.23} goto name{footnote*.23}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 4 } action struct name{footnote*.21} goto name{footnote*.21}
 .....\hbox(8.14003+0.0)x4.48613, direction TLT
 ......\mathon
 ......\hbox(0.0+0.0)x0.0, direction TLT
@@ -300,14 +300,14 @@ Completed box being shipped out [2]
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0, direction TLT
 ......\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
-.......\pdfdest name{footnote*.23} xyz
-.......\pdfdest name{footnote*.23} xyz
+.......\pdfdest name{footnote*.21} xyz
+.......\pdfdest name{footnote*.21} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0, direction TLT
 ......\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
-.......\pdfdest name{footnote*.25} xyz
-.......\pdfdest name{footnote*.25} xyz
+.......\pdfdest name{footnote*.23} xyz
+.......\pdfdest name{footnote*.23} xyz
 .......\penalty 10000
 .....\hbox(6.68999+0.0)x18.00005, glue set 13.83344fil, direction TLT
 ......\glue 0.0 plus 1.0fil minus 1.0fil

--- a/required/latex-lab/testfiles-OR-luatex/footmisc-004.tlg
+++ b/required/latex-lab/testfiles-OR-luatex/footmisc-004.tlg
@@ -105,7 +105,7 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\pdfliteral page <lua data reference ...>
 .....\pdfliteral page <lua data reference ...>
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 3 } action struct name{footnote*.14} goto name{footnote*.14}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 3 } action struct name{footnote*.13} goto name{footnote*.13}
 .....\hbox(8.14003+0.0)x4.48613, direction TLT
 ......\mathon
 ......\hbox(0.0+0.0)x0.0, direction TLT
@@ -173,14 +173,14 @@ Completed box being shipped out [1]
 ......\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
 .......\pdfliteral page <lua data reference ...>
 .......\pdfliteral page <lua data reference ...>
-.......\pdfdest name{footnote*.14} xyz
-.......\pdfdest name{footnote*.14} xyz
+.......\pdfdest name{footnote*.13} xyz
+.......\pdfdest name{footnote*.13} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0, direction TLT
 ......\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
-.......\pdfdest name{footnote*.16} xyz
-.......\pdfdest name{footnote*.16} xyz
+.......\pdfdest name{footnote*.15} xyz
+.......\pdfdest name{footnote*.15} xyz
 .......\penalty 10000
 .....\hbox(6.68999+0.0)x18.00005, glue set 13.83344fil, direction TLT
 ......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -278,7 +278,7 @@ Completed box being shipped out [2]
 .....\penalty 10000
 .....\pdfliteral page <lua data reference ...>
 .....\pdfliteral page <lua data reference ...>
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 4 } action struct name{footnote*.23} goto name{footnote*.23}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 4 } action struct name{footnote*.21} goto name{footnote*.21}
 .....\hbox(8.14003+0.0)x4.48613, direction TLT
 ......\mathon
 ......\hbox(0.0+0.0)x0.0, direction TLT
@@ -306,14 +306,14 @@ Completed box being shipped out [2]
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0, direction TLT
 ......\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
-.......\pdfdest name{footnote*.23} xyz
-.......\pdfdest name{footnote*.23} xyz
+.......\pdfdest name{footnote*.21} xyz
+.......\pdfdest name{footnote*.21} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0, direction TLT
 ......\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
-.......\pdfdest name{footnote*.25} xyz
-.......\pdfdest name{footnote*.25} xyz
+.......\pdfdest name{footnote*.23} xyz
+.......\pdfdest name{footnote*.23} xyz
 .......\penalty 10000
 .....\hbox(6.68999+0.0)x18.00005, glue set 13.83344fil, direction TLT
 ......\glue 0.0 plus 1.0fil minus 1.0fil

--- a/required/latex-lab/testfiles-OR-luatex/footmisc-009-multiple-tagging.tlg
+++ b/required/latex-lab/testfiles-OR-luatex/footmisc-009-multiple-tagging.tlg
@@ -92,7 +92,7 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\pdfliteral page <lua data reference ...>
 .....\pdfliteral page <lua data reference ...>
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 2 } action struct name{footnote*.12} goto name{footnote*.12}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 2 } action struct name{footnote*.11} goto name{footnote*.11}
 .....\hbox(8.14003+0.0)x4.48613, direction TLT
 ......\mathon
 ......\hbox(0.0+0.0)x0.0, direction TLT
@@ -115,7 +115,7 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\pdfliteral page <lua data reference ...>
 .....\pdfliteral page <lua data reference ...>
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 3 } action struct name{footnote*.19} goto name{footnote*.19}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 3 } action struct name{footnote*.17} goto name{footnote*.17}
 .....\hbox(8.14003+0.0)x4.48613, direction TLT
 ......\mathon
 ......\hbox(0.0+0.0)x0.0, direction TLT
@@ -149,7 +149,7 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\pdfliteral page <lua data reference ...>
 .....\pdfliteral page <lua data reference ...>
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 4 } action struct name{footnote*.28} goto name{footnote*.28}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 4 } action struct name{footnote*.25} goto name{footnote*.25}
 .....\hbox(8.48885+0.0)x4.05469, direction TLT
 ......\mathon
 ......\hbox(0.0+0.0)x0.0, direction TLT
@@ -170,7 +170,7 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\pdfliteral page <lua data reference ...>
 .....\pdfliteral page <lua data reference ...>
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 5 } action struct name{footnote*.35} goto name{footnote*.35}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 5 } action struct name{footnote*.31} goto name{footnote*.31}
 .....\hbox(8.48885+0.0)x4.05469, direction TLT
 ......\mathon
 ......\hbox(0.0+0.0)x0.0, direction TLT
@@ -193,7 +193,7 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\pdfliteral page <lua data reference ...>
 .....\pdfliteral page <lua data reference ...>
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 6 } action struct name{footnote*.14} goto name{footnote*.14}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 6 } action struct name{footnote*.13} goto name{footnote*.13}
 .....\hbox(8.14003+0.0)x4.48613, direction TLT
 ......\mathon
 ......\hbox(0.0+0.0)x0.0, direction TLT
@@ -221,7 +221,7 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\pdfliteral page <lua data reference ...>
 .....\pdfliteral page <lua data reference ...>
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 7 } action struct name{footnote*.51} goto name{footnote*.51}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 7 } action struct name{footnote*.45} goto name{footnote*.45}
 .....\hbox(8.48885+0.0)x5.34604, direction TLT
 ......\mathon
 ......\hbox(0.0+0.0)x0.0, direction TLT
@@ -325,14 +325,14 @@ Completed box being shipped out [1]
 ......\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
 .......\pdfliteral page <lua data reference ...>
 .......\pdfliteral page <lua data reference ...>
-.......\pdfdest name{footnote*.12} xyz
-.......\pdfdest name{footnote*.12} xyz
+.......\pdfdest name{footnote*.11} xyz
+.......\pdfdest name{footnote*.11} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0, direction TLT
 ......\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
-.......\pdfdest name{footnote*.14} xyz
-.......\pdfdest name{footnote*.14} xyz
+.......\pdfdest name{footnote*.13} xyz
+.......\pdfdest name{footnote*.13} xyz
 .......\penalty 10000
 .....\hbox(6.68999+0.0)x18.00005, glue set 13.83344fil, direction TLT
 ......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -348,8 +348,8 @@ Completed box being shipped out [1]
 ......\pdfliteral page <lua data reference ...>
 ......\pdfliteral page <lua data reference ...>
 ......\rule(6.65+0.0)x0.0
-.....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{14}}}
-.....\write1{\newlabel{foo}{{2}{\thepage }{}{footnote*.14}{}}}
+.....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{13}}}
+.....\write1{\newlabel{foo}{{2}{\thepage }{}{footnote*.13}{}}}
 .....\OT1/cmr/m/n/8 B
 .....\penalty 10000
 .....\rule(0.0+2.85002)x0.0
@@ -367,14 +367,14 @@ Completed box being shipped out [1]
 ......\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
 .......\pdfliteral page <lua data reference ...>
 .......\pdfliteral page <lua data reference ...>
-.......\pdfdest name{footnote*.19} xyz
-.......\pdfdest name{footnote*.19} xyz
+.......\pdfdest name{footnote*.17} xyz
+.......\pdfdest name{footnote*.17} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0, direction TLT
 ......\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
-.......\pdfdest name{footnote*.21} xyz
-.......\pdfdest name{footnote*.21} xyz
+.......\pdfdest name{footnote*.19} xyz
+.......\pdfdest name{footnote*.19} xyz
 .......\penalty 10000
 .....\hbox(6.68999+0.0)x18.00005, glue set 13.83344fil, direction TLT
 ......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -407,14 +407,14 @@ Completed box being shipped out [1]
 ......\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
 .......\pdfliteral page <lua data reference ...>
 .......\pdfliteral page <lua data reference ...>
-.......\pdfdest name{footnote*.28} xyz
-.......\pdfdest name{footnote*.28} xyz
+.......\pdfdest name{footnote*.25} xyz
+.......\pdfdest name{footnote*.25} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0, direction TLT
 ......\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
-.......\pdfdest name{footnote*.30} xyz
-.......\pdfdest name{footnote*.30} xyz
+.......\pdfdest name{footnote*.27} xyz
+.......\pdfdest name{footnote*.27} xyz
 .......\penalty 10000
 .....\hbox(6.98898+0.0)x18.00005, glue set 14.22308fil, direction TLT
 ......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -447,14 +447,14 @@ Completed box being shipped out [1]
 ......\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
 .......\pdfliteral page <lua data reference ...>
 .......\pdfliteral page <lua data reference ...>
-.......\pdfdest name{footnote*.35} xyz
-.......\pdfdest name{footnote*.35} xyz
+.......\pdfdest name{footnote*.31} xyz
+.......\pdfdest name{footnote*.31} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0, direction TLT
 ......\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
-.......\pdfdest name{footnote*.37} xyz
-.......\pdfdest name{footnote*.37} xyz
+.......\pdfdest name{footnote*.33} xyz
+.......\pdfdest name{footnote*.33} xyz
 .......\penalty 10000
 .....\hbox(6.98898+0.0)x18.00005, glue set 14.22308fil, direction TLT
 ......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -487,8 +487,8 @@ Completed box being shipped out [1]
 ......\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
 .......\pdfliteral page <lua data reference ...>
 .......\pdfliteral page <lua data reference ...>
-.......\pdfdest name{footnote*.44} xyz
-.......\pdfdest name{footnote*.44} xyz
+.......\pdfdest name{footnote*.39} xyz
+.......\pdfdest name{footnote*.39} xyz
 .......\penalty 10000
 .....\hbox(6.98898+0.0)x18.00005, glue set 14.22308fil, direction TLT
 ......\glue 0.0 plus 1.0fil minus 1.0fil
@@ -521,14 +521,14 @@ Completed box being shipped out [1]
 ......\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
 .......\pdfliteral page <lua data reference ...>
 .......\pdfliteral page <lua data reference ...>
-.......\pdfdest name{footnote*.51} xyz
-.......\pdfdest name{footnote*.51} xyz
+.......\pdfdest name{footnote*.45} xyz
+.......\pdfdest name{footnote*.45} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0, direction TLT
 ......\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
-.......\pdfdest name{footnote*.53} xyz
-.......\pdfdest name{footnote*.53} xyz
+.......\pdfdest name{footnote*.47} xyz
+.......\pdfdest name{footnote*.47} xyz
 .......\penalty 10000
 .....\hbox(6.98898+0.0)x18.00005, glue set 13.0567fil, direction TLT
 ......\glue 0.0 plus 1.0fil minus 1.0fil

--- a/required/latex-lab/testfiles-OR-luatex/footmisc-009-multiple.tlg
+++ b/required/latex-lab/testfiles-OR-luatex/footmisc-009-multiple.tlg
@@ -230,7 +230,7 @@ Completed box being shipped out [1]
 ......\mathoff
 ....\hbox(6.65+0.0)x0.0, direction TLT
 .....\rule(6.65+0.0)x0.0
-....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{7}}}
+....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{6}}}
 ....\write1{\newlabel{foo}{{2}{\thepage }{}{}{}}}
 ....\OT1/cmr/m/n/8 B
 ....\penalty 10000

--- a/required/latex-lab/testfiles-OR-luatex/footmisc-010-setspace-tagging.tlg
+++ b/required/latex-lab/testfiles-OR-luatex/footmisc-010-setspace-tagging.tlg
@@ -1279,7 +1279,7 @@ Completed box being shipped out [1]
 .....\pdfliteral page <lua data reference ...>
 .....\pdfliteral page <lua data reference ...>
 .....\rule(6.65+0.0)x0.0
-....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{14}}}
+....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{13}}}
 ....\write1{\newlabel{foo}{{2}{\thepage }{}{}{}}}
 ....\OT1/cmr/m/n/8 B
 ....\penalty 10000

--- a/required/latex-lab/testfiles-OR-luatex/footmisc-010-setspace.tlg
+++ b/required/latex-lab/testfiles-OR-luatex/footmisc-010-setspace.tlg
@@ -1132,7 +1132,7 @@ Completed box being shipped out [1]
 ......\mathoff
 ....\hbox(6.65+0.0)x0.0, direction TLT
 .....\rule(6.65+0.0)x0.0
-....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{7}}}
+....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{6}}}
 ....\write1{\newlabel{foo}{{2}{\thepage }{}{}{}}}
 ....\OT1/cmr/m/n/8 B
 ....\penalty 10000

--- a/required/latex-lab/testfiles-OR-luatex/footmisc-011-para.tlg
+++ b/required/latex-lab/testfiles-OR-luatex/footmisc-011-para.tlg
@@ -187,7 +187,7 @@ Completed box being shipped out [1]
 ....\pdfliteral page <lua data reference ...>
 ....\TU/lmr/m/n/10  
 ....\glue -1.63
-....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{10}}}
+....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{9}}}
 ....\write1{\newlabel{foo}{{2}{\thepage }{}{}{}}}
 ....\penalty 10000
 ....\glue 0.0

--- a/required/latex-lab/testfiles-OR-luatex/footmisc-012-side-hyperref.tlg
+++ b/required/latex-lab/testfiles-OR-luatex/footmisc-012-side-hyperref.tlg
@@ -73,7 +73,7 @@ Completed box being shipped out [1]
 ......\mathoff
 .....\pdfendlink
 .....\penalty 10000
-.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.6}
+.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.5}
 .....\hbox(8.14003+0.0)x4.48613, direction TLT
 ......\mathon
 ......\hbox(0.0+0.0)x0.0, direction TLT
@@ -82,7 +82,7 @@ Completed box being shipped out [1]
 ......\mathoff
 .....\pdfendlink
 .....\penalty 10000
-.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.10}
+.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.8}
 .....\hbox(8.14003+0.0)x4.48613, direction TLT
 ......\mathon
 ......\hbox(0.0+0.0)x0.0, direction TLT
@@ -228,12 +228,12 @@ Completed box being shipped out [1]
 .........\penalty 10000
 .........\hbox(0.0+0.0)x0.0, direction TLT
 ..........\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
-...........\pdfdest name{footnote*.6} xyz
+...........\pdfdest name{footnote*.5} xyz
 ...........\penalty 10000
 .........\penalty 10000
 .........\hbox(0.0+0.0)x0.0, direction TLT
 ..........\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
-...........\pdfdest name{footnote*.7} xyz
+...........\pdfdest name{footnote*.6} xyz
 ...........\penalty 10000
 .........\hbox(6.68999+0.0)x18.00005, glue set 13.83344fil, direction TLT
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -243,8 +243,8 @@ Completed box being shipped out [1]
 ...........\hbox(3.86665+0.0)x4.16661, shifted -2.82333, direction TLT
 ............\OT1/cmr/m/n/6 2
 ...........\mathoff
-.........\write1{\new@label@record{__fnote/foo}{{fnote/struct}{7}}}
-.........\write1{\newlabel{foo}{{2}{\thepage }{}{footnote*.7}{}}}
+.........\write1{\new@label@record{__fnote/foo}{{fnote/struct}{6}}}
+.........\write1{\newlabel{foo}{{2}{\thepage }{}{footnote*.6}{}}}
 .........\OT1/cmr/m/n/8 B
 .........\penalty 10000
 .........\glue(\parfillskip) 0.0 plus 1.0fil
@@ -271,12 +271,12 @@ Completed box being shipped out [1]
 .........\penalty 10000
 .........\hbox(0.0+0.0)x0.0, direction TLT
 ..........\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
-...........\pdfdest name{footnote*.10} xyz
+...........\pdfdest name{footnote*.8} xyz
 ...........\penalty 10000
 .........\penalty 10000
 .........\hbox(0.0+0.0)x0.0, direction TLT
 ..........\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
-...........\pdfdest name{footnote*.11} xyz
+...........\pdfdest name{footnote*.9} xyz
 ...........\penalty 10000
 .........\hbox(6.68999+0.0)x18.00005, glue set 13.83344fil, direction TLT
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -633,7 +633,7 @@ Completed box being shipped out [1]
 .....\OT1/cmr/m/n/10 s
 .....\OT1/cmr/m/n/10 t
 .....\penalty 10000
-.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.14}
+.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.11}
 .....\hbox(8.48885+0.0)x4.05469, direction TLT
 ......\mathon
 ......\hbox(0.0+0.0)x0.0, direction TLT
@@ -663,12 +663,12 @@ Completed box being shipped out [1]
 .........\penalty 10000
 .........\hbox(0.0+0.0)x0.0, direction TLT
 ..........\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
-...........\pdfdest name{footnote*.14} xyz
+...........\pdfdest name{footnote*.11} xyz
 ...........\penalty 10000
 .........\penalty 10000
 .........\hbox(0.0+0.0)x0.0, direction TLT
 ..........\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
-...........\pdfdest name{footnote*.15} xyz
+...........\pdfdest name{footnote*.12} xyz
 ...........\penalty 10000
 .........\hbox(6.98898+0.0)x18.00005, glue set 14.22308fil, direction TLT
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
@@ -695,7 +695,7 @@ Completed box being shipped out [1]
 .....\OT1/cmr/m/n/10 s
 .....\OT1/cmr/m/n/10 o
 .....\penalty 10000
-.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.18}
+.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.14}
 .....\hbox(8.48885+0.0)x4.05469, direction TLT
 ......\mathon
 ......\hbox(0.0+0.0)x0.0, direction TLT
@@ -704,7 +704,7 @@ Completed box being shipped out [1]
 ......\mathoff
 .....\pdfendlink
 .....\penalty 10000
-.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.7}
+.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.6}
 .....\hbox(8.14003+0.0)x4.48613, direction TLT
 ......\mathon
 ......\hbox(0.0+0.0)x0.0, direction TLT
@@ -733,12 +733,12 @@ Completed box being shipped out [1]
 .........\penalty 10000
 .........\hbox(0.0+0.0)x0.0, direction TLT
 ..........\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
-...........\pdfdest name{footnote*.18} xyz
+...........\pdfdest name{footnote*.14} xyz
 ...........\penalty 10000
 .........\penalty 10000
 .........\hbox(0.0+0.0)x0.0, direction TLT
 ..........\hbox(0.0+0.0)x0.0, shifted -9.5, direction TLT
-...........\pdfdest name{footnote*.19} xyz
+...........\pdfdest name{footnote*.15} xyz
 ...........\penalty 10000
 .........\hbox(6.98898+0.0)x18.00005, glue set 14.22308fil, direction TLT
 ..........\glue 0.0 plus 1.0fil minus 1.0fil

--- a/required/latex-lab/testfiles-OR-luatex/footmisc-012-side.tlg
+++ b/required/latex-lab/testfiles-OR-luatex/footmisc-012-side.tlg
@@ -205,7 +205,7 @@ Completed box being shipped out [1]
 ..........\hbox(3.86665+0.0)x4.16661, shifted -2.82333, direction TLT
 ...........\OT1/cmr/m/n/6 2
 ..........\mathoff
-........\write1{\new@label@record{__fnote/foo}{{fnote/struct}{7}}}
+........\write1{\new@label@record{__fnote/foo}{{fnote/struct}{6}}}
 ........\write1{\newlabel{foo}{{2}{\thepage }{}{}{}}}
 ........\OT1/cmr/m/n/8 B
 ........\penalty 10000

--- a/required/latex-lab/testfiles-OR-luatex/footmisc-014-hang.tlg
+++ b/required/latex-lab/testfiles-OR-luatex/footmisc-014-hang.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -63,7 +63,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext

--- a/required/latex-lab/testfiles-OR-luatex/memoir-001.tpf
+++ b/required/latex-lab/testfiles-OR-luatex/memoir-001.tpf
@@ -1,6 +1,6 @@
 %PDF-1.5
 %Ã’¡‘≈ÿ–ƒ∆
-54 0 obj
+44 0 obj
 << /Type /Metadata /Subtype /XML /Length 11692 >>      
 stream
 <?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
@@ -234,7 +234,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-57 0 obj
+47 0 obj
 << /Length 17830 >>      
 stream
 /opacity1 gs
@@ -612,184 +612,154 @@ EMC
 EMC
 endstream
 endobj
-56 0 obj
-<< /Type /Page /Contents 57 0 R /Resources 55 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 63 0 R >>
+46 0 obj
+<< /Type /Page /Contents 47 0 R /Resources 45 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 53 0 R >>
 endobj
-55 0 obj
-<< /ExtGState 1 0 R /Font << /F19 58 0 R /F31 59 0 R /F43 60 0 R /F41 61 0 R /F15 62 0 R >> /ProcSet [ /PDF /Text ] >>
+45 0 obj
+<< /ExtGState 1 0 R /Font << /F19 48 0 R /F31 49 0 R /F43 50 0 R /F41 51 0 R /F15 52 0 R >> /ProcSet [ /PDF /Text ] >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-64 0 obj
+54 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 11 0 R 12 0 R 16 0 R 20 0 R 24 0 R 28 0 R 32 0 R 36 0 R 40 0 R 11 0 R 11 0 R 45 0 R 46 0 R 45 0 R 50 0 R 15 0 R 13 0 R 13 0 R 19 0 R 17 0 R 17 0 R 23 0 R 21 0 R 21 0 R 27 0 R 25 0 R 25 0 R 31 0 R 29 0 R 29 0 R 35 0 R 33 0 R 33 0 R 39 0 R 37 0 R 37 0 R 43 0 R 41 0 R 41 0 R 49 0 R 47 0 R 47 0 R 53 0 R 51 0 R] 
+<< /Nums [0 [ 11 0 R 12 0 R 15 0 R 18 0 R 21 0 R 24 0 R 27 0 R 30 0 R 33 0 R 11 0 R 11 0 R 37 0 R 38 0 R 37 0 R 41 0 R 14 0 R 13 0 R 13 0 R 17 0 R 16 0 R 16 0 R 20 0 R 19 0 R 19 0 R 23 0 R 22 0 R 22 0 R 26 0 R 25 0 R 25 0 R 29 0 R 28 0 R 28 0 R 32 0 R 31 0 R 31 0 R 35 0 R 34 0 R 34 0 R 40 0 R 39 0 R 39 0 R 43 0 R 42 0 R] 
 ] >>
 endobj
-65 0 obj
-<< /Limits [(ID.002) (ID.046)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 15 0 R (ID.009) 16 0 R (ID.010) 17 0 R (ID.011) 18 0 R (ID.012) 19 0 R (ID.013) 20 0 R (ID.014) 21 0 R (ID.015) 22 0 R (ID.016) 23 0 R (ID.017) 24 0 R (ID.018) 25 0 R (ID.019) 26 0 R (ID.020) 27 0 R (ID.021) 28 0 R (ID.022) 29 0 R (ID.023) 30 0 R (ID.024) 31 0 R (ID.025) 32 0 R (ID.026) 33 0 R (ID.027) 34 0 R (ID.028) 35 0 R (ID.029) 36 0 R (ID.030) 37 0 R (ID.031) 38 0 R (ID.032) 39 0 R (ID.033) 40 0 R (ID.034) 41 0 R (ID.035) 42 0 R (ID.036) 43 0 R (ID.037) 44 0 R (ID.038) 45 0 R (ID.039) 46 0 R (ID.040) 47 0 R (ID.041) 48 0 R (ID.042) 49 0 R (ID.043) 50 0 R (ID.044) 51 0 R (ID.045) 52 0 R (ID.046) 53 0 R ] >>
+55 0 obj
+<< /Limits [(ID.002) (ID.036)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 15 0 R (ID.009) 16 0 R (ID.010) 17 0 R (ID.011) 18 0 R (ID.012) 19 0 R (ID.013) 20 0 R (ID.014) 21 0 R (ID.015) 22 0 R (ID.016) 23 0 R (ID.017) 24 0 R (ID.018) 25 0 R (ID.019) 26 0 R (ID.020) 27 0 R (ID.021) 28 0 R (ID.022) 29 0 R (ID.023) 30 0 R (ID.024) 31 0 R (ID.025) 32 0 R (ID.026) 33 0 R (ID.027) 34 0 R (ID.028) 35 0 R (ID.029) 36 0 R (ID.030) 37 0 R (ID.031) 38 0 R (ID.032) 39 0 R (ID.033) 40 0 R (ID.034) 41 0 R (ID.035) 42 0 R (ID.036) 43 0 R ] >>
 endobj
-66 0 obj
-<< /Kids [65 0 R] >>
+56 0 obj
+<< /Kids [55 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H2 /subsection /H3 /subsubsection /H4 /paragraph /H5 /subparagraph /H6 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect /chapter /H1  >>
 endobj
 9 0 obj
-<<  /Type /StructElem /S /Document /P 5 0 R /K [10 0 R 44 0 R] /ID (ID.002) >>
+<<  /Type /StructElem /S /Document /P 5 0 R /K [10 0 R 36 0 R] /ID (ID.002) >>
 endobj
 10 0 obj
 <<  /Type /StructElem /S /text-unit /P 9 0 R /K 11 0 R /ID (ID.003) >>
 endobj
 11 0 obj
-<<  /Type /StructElem /S /text /P 10 0 R /K [<</Type /MCR /Pg 56 0 R /MCID 0>>  12 0 R  13 0 R  16 0 R  17 0 R  20 0 R  21 0 R  24 0 R  25 0 R  28 0 R  29 0 R  32 0 R  33 0 R  36 0 R  37 0 R  40 0 R  41 0 R <</Type /MCR /Pg 56 0 R /MCID 9>> <</Type /MCR /Pg 56 0 R /MCID 10>> ] /ID (ID.004) >>
+<<  /Type /StructElem /S /text /P 10 0 R /K [<</Type /MCR /Pg 46 0 R /MCID 0>>  12 0 R  13 0 R  15 0 R  16 0 R  18 0 R  19 0 R  21 0 R  22 0 R  24 0 R  25 0 R  27 0 R  28 0 R  30 0 R  31 0 R  33 0 R  34 0 R <</Type /MCR /Pg 46 0 R /MCID 9>> <</Type /MCR /Pg 46 0 R /MCID 10>> ] /ID (ID.004) >>
 endobj
 12 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 13 0 R ] /K <</Type /MCR /Pg 56 0 R /MCID 1>>  /ID (ID.005) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 13 0 R ] /K <</Type /MCR /Pg 46 0 R /MCID 1>>  /ID (ID.005) >>
 endobj
 13 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 12 0 R ] /K [14 0 R <</Type /MCR /Pg 56 0 R /MCID 16>> <</Type /MCR /Pg 56 0 R /MCID 17>> ] /ID (ID.006) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 12 0 R ] /K [14 0 R <</Type /MCR /Pg 46 0 R /MCID 16>> <</Type /MCR /Pg 46 0 R /MCID 17>> ] /ID (ID.006) >>
 endobj
 14 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 13 0 R /K 15 0 R /ID (ID.007) >>
+<<  /Type /StructElem /S /footnotelabel /P 13 0 R /K <</Type /MCR /Pg 46 0 R /MCID 15>>  /ID (ID.007) >>
 endobj
 15 0 obj
-<<  /Type /StructElem /S /NonStruct /P 14 0 R /K <</Type /MCR /Pg 56 0 R /MCID 15>>  /ID (ID.008) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 16 0 R ] /K <</Type /MCR /Pg 46 0 R /MCID 2>>  /ID (ID.008) >>
 endobj
 16 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 17 0 R ] /K <</Type /MCR /Pg 56 0 R /MCID 2>>  /ID (ID.009) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 15 0 R ] /K [17 0 R <</Type /MCR /Pg 46 0 R /MCID 19>> <</Type /MCR /Pg 46 0 R /MCID 20>> ] /ID (ID.009) >>
 endobj
 17 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 16 0 R ] /K [18 0 R <</Type /MCR /Pg 56 0 R /MCID 19>> <</Type /MCR /Pg 56 0 R /MCID 20>> ] /ID (ID.010) >>
+<<  /Type /StructElem /S /footnotelabel /P 16 0 R /K <</Type /MCR /Pg 46 0 R /MCID 18>>  /ID (ID.010) >>
 endobj
 18 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 17 0 R /K 19 0 R /ID (ID.011) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 19 0 R ] /K <</Type /MCR /Pg 46 0 R /MCID 3>>  /ID (ID.011) >>
 endobj
 19 0 obj
-<<  /Type /StructElem /S /NonStruct /P 18 0 R /K <</Type /MCR /Pg 56 0 R /MCID 18>>  /ID (ID.012) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 18 0 R ] /K [20 0 R <</Type /MCR /Pg 46 0 R /MCID 22>> <</Type /MCR /Pg 46 0 R /MCID 23>> ] /ID (ID.012) >>
 endobj
 20 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 21 0 R ] /K <</Type /MCR /Pg 56 0 R /MCID 3>>  /ID (ID.013) >>
+<<  /Type /StructElem /S /footnotelabel /P 19 0 R /K <</Type /MCR /Pg 46 0 R /MCID 21>>  /ID (ID.013) >>
 endobj
 21 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 20 0 R ] /K [22 0 R <</Type /MCR /Pg 56 0 R /MCID 22>> <</Type /MCR /Pg 56 0 R /MCID 23>> ] /ID (ID.014) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 22 0 R ] /K <</Type /MCR /Pg 46 0 R /MCID 4>>  /ID (ID.014) >>
 endobj
 22 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 21 0 R /K 23 0 R /ID (ID.015) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 21 0 R ] /K [23 0 R <</Type /MCR /Pg 46 0 R /MCID 25>> <</Type /MCR /Pg 46 0 R /MCID 26>> ] /ID (ID.015) >>
 endobj
 23 0 obj
-<<  /Type /StructElem /S /NonStruct /P 22 0 R /K <</Type /MCR /Pg 56 0 R /MCID 21>>  /ID (ID.016) >>
+<<  /Type /StructElem /S /footnotelabel /P 22 0 R /K <</Type /MCR /Pg 46 0 R /MCID 24>>  /ID (ID.016) >>
 endobj
 24 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 25 0 R ] /K <</Type /MCR /Pg 56 0 R /MCID 4>>  /ID (ID.017) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 25 0 R ] /K <</Type /MCR /Pg 46 0 R /MCID 5>>  /ID (ID.017) >>
 endobj
 25 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 24 0 R ] /K [26 0 R <</Type /MCR /Pg 56 0 R /MCID 25>> <</Type /MCR /Pg 56 0 R /MCID 26>> ] /ID (ID.018) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 24 0 R ] /K [26 0 R <</Type /MCR /Pg 46 0 R /MCID 28>> <</Type /MCR /Pg 46 0 R /MCID 29>> ] /ID (ID.018) >>
 endobj
 26 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 25 0 R /K 27 0 R /ID (ID.019) >>
+<<  /Type /StructElem /S /footnotelabel /P 25 0 R /K <</Type /MCR /Pg 46 0 R /MCID 27>>  /ID (ID.019) >>
 endobj
 27 0 obj
-<<  /Type /StructElem /S /NonStruct /P 26 0 R /K <</Type /MCR /Pg 56 0 R /MCID 24>>  /ID (ID.020) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 28 0 R ] /K <</Type /MCR /Pg 46 0 R /MCID 6>>  /ID (ID.020) >>
 endobj
 28 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 29 0 R ] /K <</Type /MCR /Pg 56 0 R /MCID 5>>  /ID (ID.021) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 27 0 R ] /K [29 0 R <</Type /MCR /Pg 46 0 R /MCID 31>> <</Type /MCR /Pg 46 0 R /MCID 32>> ] /ID (ID.021) >>
 endobj
 29 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 28 0 R ] /K [30 0 R <</Type /MCR /Pg 56 0 R /MCID 28>> <</Type /MCR /Pg 56 0 R /MCID 29>> ] /ID (ID.022) >>
+<<  /Type /StructElem /S /footnotelabel /P 28 0 R /K <</Type /MCR /Pg 46 0 R /MCID 30>>  /ID (ID.022) >>
 endobj
 30 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 29 0 R /K 31 0 R /ID (ID.023) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 31 0 R ] /K <</Type /MCR /Pg 46 0 R /MCID 7>>  /ID (ID.023) >>
 endobj
 31 0 obj
-<<  /Type /StructElem /S /NonStruct /P 30 0 R /K <</Type /MCR /Pg 56 0 R /MCID 27>>  /ID (ID.024) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 30 0 R ] /K [32 0 R <</Type /MCR /Pg 46 0 R /MCID 34>> <</Type /MCR /Pg 46 0 R /MCID 35>> ] /ID (ID.024) >>
 endobj
 32 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 33 0 R ] /K <</Type /MCR /Pg 56 0 R /MCID 6>>  /ID (ID.025) >>
+<<  /Type /StructElem /S /footnotelabel /P 31 0 R /K <</Type /MCR /Pg 46 0 R /MCID 33>>  /ID (ID.025) >>
 endobj
 33 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 32 0 R ] /K [34 0 R <</Type /MCR /Pg 56 0 R /MCID 31>> <</Type /MCR /Pg 56 0 R /MCID 32>> ] /ID (ID.026) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 34 0 R ] /K <</Type /MCR /Pg 46 0 R /MCID 8>>  /ID (ID.026) >>
 endobj
 34 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 33 0 R /K 35 0 R /ID (ID.027) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 33 0 R ] /K [35 0 R <</Type /MCR /Pg 46 0 R /MCID 37>> <</Type /MCR /Pg 46 0 R /MCID 38>> ] /ID (ID.027) >>
 endobj
 35 0 obj
-<<  /Type /StructElem /S /NonStruct /P 34 0 R /K <</Type /MCR /Pg 56 0 R /MCID 30>>  /ID (ID.028) >>
+<<  /Type /StructElem /S /footnotelabel /P 34 0 R /K <</Type /MCR /Pg 46 0 R /MCID 36>>  /ID (ID.028) >>
 endobj
 36 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 37 0 R ] /K <</Type /MCR /Pg 56 0 R /MCID 7>>  /ID (ID.029) >>
+<<  /Type /StructElem /S /text-unit /P 9 0 R /K 37 0 R /ID (ID.029) >>
 endobj
 37 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 36 0 R ] /K [38 0 R <</Type /MCR /Pg 56 0 R /MCID 34>> <</Type /MCR /Pg 56 0 R /MCID 35>> ] /ID (ID.030) >>
+<<  /Type /StructElem /S /text /P 36 0 R /K [<</Type /MCR /Pg 46 0 R /MCID 11>>  38 0 R  39 0 R <</Type /MCR /Pg 46 0 R /MCID 13>>  41 0 R  42 0 R ] /ID (ID.030) >>
 endobj
 38 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 37 0 R /K 39 0 R /ID (ID.031) >>
+<<  /Type /StructElem /S /footnotemark /P 37 0 R /Ref [ 39 0 R ] /K <</Type /MCR /Pg 46 0 R /MCID 12>>  /ID (ID.031) >>
 endobj
 39 0 obj
-<<  /Type /StructElem /S /NonStruct /P 38 0 R /K <</Type /MCR /Pg 56 0 R /MCID 33>>  /ID (ID.032) >>
+<<  /Type /StructElem /S /footnote /P 37 0 R /Ref [ 38 0 R ] /K [40 0 R <</Type /MCR /Pg 46 0 R /MCID 40>> <</Type /MCR /Pg 46 0 R /MCID 41>> ] /ID (ID.032) >>
 endobj
 40 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 41 0 R ] /K <</Type /MCR /Pg 56 0 R /MCID 8>>  /ID (ID.033) >>
+<<  /Type /StructElem /S /footnotelabel /P 39 0 R /K <</Type /MCR /Pg 46 0 R /MCID 39>>  /ID (ID.033) >>
 endobj
 41 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 40 0 R ] /K [42 0 R <</Type /MCR /Pg 56 0 R /MCID 37>> <</Type /MCR /Pg 56 0 R /MCID 38>> ] /ID (ID.034) >>
+<<  /Type /StructElem /S /footnotemark /P 37 0 R /Ref [ 42 0 R ] /K <</Type /MCR /Pg 46 0 R /MCID 14>>  /ID (ID.034) >>
 endobj
 42 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 41 0 R /K 43 0 R /ID (ID.035) >>
+<<  /Type /StructElem /S /footnote /P 37 0 R /Ref [ 41 0 R ] /K [43 0 R <</Type /MCR /Pg 46 0 R /MCID 43>> ] /ID (ID.035) >>
 endobj
 43 0 obj
-<<  /Type /StructElem /S /NonStruct /P 42 0 R /K <</Type /MCR /Pg 56 0 R /MCID 36>>  /ID (ID.036) >>
-endobj
-44 0 obj
-<<  /Type /StructElem /S /text-unit /P 9 0 R /K 45 0 R /ID (ID.037) >>
-endobj
-45 0 obj
-<<  /Type /StructElem /S /text /P 44 0 R /K [<</Type /MCR /Pg 56 0 R /MCID 11>>  46 0 R  47 0 R <</Type /MCR /Pg 56 0 R /MCID 13>>  50 0 R  51 0 R ] /ID (ID.038) >>
-endobj
-46 0 obj
-<<  /Type /StructElem /S /footnotemark /P 45 0 R /Ref [ 47 0 R ] /K <</Type /MCR /Pg 56 0 R /MCID 12>>  /ID (ID.039) >>
-endobj
-47 0 obj
-<<  /Type /StructElem /S /footnote /P 45 0 R /Ref [ 46 0 R ] /K [48 0 R <</Type /MCR /Pg 56 0 R /MCID 40>> <</Type /MCR /Pg 56 0 R /MCID 41>> ] /ID (ID.040) >>
-endobj
-48 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 47 0 R /K 49 0 R /ID (ID.041) >>
-endobj
-49 0 obj
-<<  /Type /StructElem /S /NonStruct /P 48 0 R /K <</Type /MCR /Pg 56 0 R /MCID 39>>  /ID (ID.042) >>
-endobj
-50 0 obj
-<<  /Type /StructElem /S /footnotemark /P 45 0 R /Ref [ 51 0 R ] /K <</Type /MCR /Pg 56 0 R /MCID 14>>  /ID (ID.043) >>
-endobj
-51 0 obj
-<<  /Type /StructElem /S /footnote /P 45 0 R /Ref [ 50 0 R ] /K [52 0 R <</Type /MCR /Pg 56 0 R /MCID 43>> ] /ID (ID.044) >>
-endobj
-52 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 51 0 R /K 53 0 R /ID (ID.045) >>
-endobj
-53 0 obj
-<<  /Type /StructElem /S /NonStruct /P 52 0 R /K <</Type /MCR /Pg 56 0 R /MCID 42>>  /ID (ID.046) >>
+<<  /Type /StructElem /S /footnotelabel /P 42 0 R /K <</Type /MCR /Pg 46 0 R /MCID 42>>  /ID (ID.036) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 66 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
+<<  /Type /StructTreeRoot /IDTree 56 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
 endobj
-67 0 obj
+57 0 obj
 [ 35 [ 556 ] 50 [ 444 ] 72 [ 278 ] 98 [ 394 ] 103 [ 333 ] 105 [ 389 ] 109 [ 556 ] 116 [ 528 ] ]
 endobj
-69 0 obj
+59 0 obj
 << /Length 15 >>         
 [BINARY STREAM]
 endobj
-70 0 obj
+60 0 obj
 << /Subtype /CIDFontType0C /Length 1364 >>       
 [BINARY STREAM]
 endobj
-68 0 obj
-<< /Type /FontDescriptor /FontName /PFHSGM+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 70 0 R /CIDSet 69 0 R >>
+58 0 obj
+<< /Type /FontDescriptor /FontName /PFHSGM+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 60 0 R /CIDSet 59 0 R >>
 endobj
-71 0 obj
+61 0 obj
 << /Length 790 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -832,27 +802,27 @@ end
 %%EOF
 endstream
 endobj
+52 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /PFHSGM+LMRoman10-Regular /DescendantFonts [ 62 0 R ] /ToUnicode 61 0 R >>
+endobj
 62 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /PFHSGM+LMRoman10-Regular /DescendantFonts [ 72 0 R ] /ToUnicode 71 0 R >>
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /PFHSGM+LMRoman10-Regular /FontDescriptor 58 0 R /W 57 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-72 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /PFHSGM+LMRoman10-Regular /FontDescriptor 68 0 R /W 67 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-73 0 obj
+63 0 obj
 [ 51 [ 569 ] 56 [ 569 569 ] 78 [ 569 ] 82 [ 569 ] 100 [ 569 569 ] 106 [ 569 569 ] 121 [ 569 ] ]
 endobj
-75 0 obj
+65 0 obj
 << /Length 16 >>         
 [BINARY STREAM]
 endobj
-76 0 obj
+66 0 obj
 << /Subtype /CIDFontType0C /Length 1781 >>       
 [BINARY STREAM]
 endobj
-74 0 obj
-<< /Type /FontDescriptor /FontName /TFIASI+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 76 0 R /CIDSet 75 0 R >>
+64 0 obj
+<< /Type /FontDescriptor /FontName /TFIASI+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 66 0 R /CIDSet 65 0 R >>
 endobj
-77 0 obj
+67 0 obj
 << /Length 814 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -897,27 +867,27 @@ end
 %%EOF
 endstream
 endobj
-61 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /TFIASI+LMRoman7-Regular /DescendantFonts [ 78 0 R ] /ToUnicode 77 0 R >>
+51 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /TFIASI+LMRoman7-Regular /DescendantFonts [ 68 0 R ] /ToUnicode 67 0 R >>
 endobj
-78 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /TFIASI+LMRoman7-Regular /FontDescriptor 74 0 R /W 73 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+68 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /TFIASI+LMRoman7-Regular /FontDescriptor 64 0 R /W 63 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-79 0 obj
+69 0 obj
 [ 45 [ 352 ] ]
 endobj
-81 0 obj
+71 0 obj
 << /Length 6 >>          
 [BINARY STREAM]
 endobj
-82 0 obj
+72 0 obj
 << /Subtype /CIDFontType0C /Length 557 >>        
 [BINARY STREAM]
 endobj
-80 0 obj
-<< /Type /FontDescriptor /FontName /KPNAGD+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 82 0 R /CIDSet 81 0 R >>
+70 0 obj
+<< /Type /FontDescriptor /FontName /KPNAGD+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 72 0 R /CIDSet 71 0 R >>
 endobj
-83 0 obj
+73 0 obj
 << /Length 687 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -953,27 +923,27 @@ end
 %%EOF
 endstream
 endobj
-60 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /KPNAGD+LMRoman6-Regular /DescendantFonts [ 84 0 R ] /ToUnicode 83 0 R >>
+50 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /KPNAGD+LMRoman6-Regular /DescendantFonts [ 74 0 R ] /ToUnicode 73 0 R >>
 endobj
-84 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /KPNAGD+LMRoman6-Regular /FontDescriptor 80 0 R /W 79 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+74 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /KPNAGD+LMRoman6-Regular /FontDescriptor 70 0 R /W 69 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-85 0 obj
+75 0 obj
 [ 51 [ 531 ] 56 [ 531 531 ] 78 [ 531 ] 82 [ 531 ] 100 [ 531 531 ] 106 [ 531 531 ] 121 [ 531 ] ]
 endobj
-87 0 obj
+77 0 obj
 << /Length 16 >>         
 [BINARY STREAM]
 endobj
-88 0 obj
+78 0 obj
 << /Subtype /CIDFontType0C /Length 1834 >>       
 [BINARY STREAM]
 endobj
-86 0 obj
-<< /Type /FontDescriptor /FontName /ROUWXH+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 88 0 R /CIDSet 87 0 R >>
+76 0 obj
+<< /Type /FontDescriptor /FontName /ROUWXH+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 78 0 R /CIDSet 77 0 R >>
 endobj
-89 0 obj
+79 0 obj
 << /Length 814 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -1018,27 +988,27 @@ end
 %%EOF
 endstream
 endobj
-59 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /ROUWXH+LMRoman8-Regular /DescendantFonts [ 90 0 R ] /ToUnicode 89 0 R >>
+49 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /ROUWXH+LMRoman8-Regular /DescendantFonts [ 80 0 R ] /ToUnicode 79 0 R >>
 endobj
-90 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /ROUWXH+LMRoman8-Regular /FontDescriptor 86 0 R /W 85 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+80 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /ROUWXH+LMRoman8-Regular /FontDescriptor 76 0 R /W 75 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-91 0 obj
+81 0 obj
 [ 27 [ 734 490 ] 35 [ 544 ] 42 [ 707 435 ] 45 [ 272 748 544 ] 50 [ 435 ] 55 [ 299 ] 59 [ 490 ] 63 [ 544 ] 65 [ 353 272 ] 68 [ 299 ] 71 [ 612 272 ] 74 [ 897 816 734 544 ] 81 [ 490 490 666 544 ] 88 [ 272 ] 91 [ 517 ] 96 [ 381 544 386 ] 103 [ 326 ] 105 [ 381 ] 108 [ 734 544 ] 112 [ 517 ] 114 [ 707 ] 118 [ 517 ] 542 [ 326 ] ]
 endobj
-93 0 obj
+83 0 obj
 << /Length 68 >>         
 [BINARY STREAM]
 endobj
-94 0 obj
+84 0 obj
 << /Subtype /CIDFontType0C /Length 4910 >>       
 [BINARY STREAM]
 endobj
-92 0 obj
-<< /Type /FontDescriptor /FontName /VAAKBA+LMRoman12-Regular /Flags 4 /FontBBox [ -422 -280 1394 1127 ] /Ascent 1127 /CapHeight 683 /Descent -280 /ItalicAngle 0 /StemV 91 /XHeight 431 /FontFile3 94 0 R /CIDSet 93 0 R >>
+82 0 obj
+<< /Type /FontDescriptor /FontName /VAAKBA+LMRoman12-Regular /Flags 4 /FontBBox [ -422 -280 1394 1127 ] /Ascent 1127 /CapHeight 683 /Descent -280 /ItalicAngle 0 /StemV 91 /XHeight 431 /FontFile3 84 0 R /CIDSet 83 0 R >>
 endobj
-95 0 obj
+85 0 obj
 << /Length 1211 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -1111,124 +1081,114 @@ end
 %%EOF
 endstream
 endobj
-58 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /VAAKBA+LMRoman12-Regular /DescendantFonts [ 96 0 R ] /ToUnicode 95 0 R >>
+48 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /VAAKBA+LMRoman12-Regular /DescendantFonts [ 86 0 R ] /ToUnicode 85 0 R >>
 endobj
-96 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /VAAKBA+LMRoman12-Regular /FontDescriptor 92 0 R /W 91 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+86 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /VAAKBA+LMRoman12-Regular /FontDescriptor 82 0 R /W 81 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-63 0 obj
-<< /Type /Pages  /Count 1 /Kids [ 56 0 R ] >>
+53 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 46 0 R ] >>
 endobj
-97 0 obj
-<< /Type /Catalog /Pages 63 0 R /MarkInfo 64 0 R/Lang (en)/Metadata 54 0 R/StructTreeRoot 5 0 R >>
+87 0 obj
+<< /Type /Catalog /Pages 53 0 R /MarkInfo 54 0 R/Lang (en)/Metadata 44 0 R/StructTreeRoot 5 0 R >>
 endobj
-98 0 obj
+88 0 obj
 << /Producer (LuaTeX)/Creator (TeX)/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 99
+0 89
 0000000002 65535 f 
 0000029962 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000037722 00000 n 
+0000036682 00000 n 
 0000030045 00000 n 
-0000031204 00000 n 
+0000031044 00000 n 
 0000000000 00000 f 
-0000031796 00000 n 
-0000031890 00000 n 
-0000031977 00000 n 
-0000032287 00000 n 
-0000032422 00000 n 
-0000032598 00000 n 
-0000032690 00000 n 
-0000032807 00000 n 
-0000032942 00000 n 
-0000033118 00000 n 
-0000033210 00000 n 
-0000033327 00000 n 
-0000033462 00000 n 
-0000033638 00000 n 
-0000033730 00000 n 
-0000033847 00000 n 
-0000033982 00000 n 
-0000034158 00000 n 
-0000034250 00000 n 
-0000034367 00000 n 
-0000034502 00000 n 
-0000034678 00000 n 
-0000034770 00000 n 
-0000034887 00000 n 
-0000035022 00000 n 
-0000035198 00000 n 
-0000035290 00000 n 
-0000035407 00000 n 
-0000035542 00000 n 
-0000035718 00000 n 
-0000035810 00000 n 
-0000035927 00000 n 
-0000036062 00000 n 
-0000036238 00000 n 
-0000036330 00000 n 
-0000036447 00000 n 
-0000036534 00000 n 
-0000036715 00000 n 
-0000036851 00000 n 
-0000037027 00000 n 
-0000037119 00000 n 
-0000037236 00000 n 
-0000037372 00000 n 
-0000037513 00000 n 
-0000037605 00000 n 
+0000031636 00000 n 
+0000031730 00000 n 
+0000031817 00000 n 
+0000032127 00000 n 
+0000032262 00000 n 
+0000032438 00000 n 
+0000032559 00000 n 
+0000032694 00000 n 
+0000032870 00000 n 
+0000032991 00000 n 
+0000033126 00000 n 
+0000033302 00000 n 
+0000033423 00000 n 
+0000033558 00000 n 
+0000033734 00000 n 
+0000033855 00000 n 
+0000033990 00000 n 
+0000034166 00000 n 
+0000034287 00000 n 
+0000034422 00000 n 
+0000034598 00000 n 
+0000034719 00000 n 
+0000034854 00000 n 
+0000035030 00000 n 
+0000035151 00000 n 
+0000035286 00000 n 
+0000035462 00000 n 
+0000035583 00000 n 
+0000035670 00000 n 
+0000035851 00000 n 
+0000035987 00000 n 
+0000036163 00000 n 
+0000036284 00000 n 
+0000036420 00000 n 
+0000036561 00000 n 
 0000000020 00000 n 
 0000029827 00000 n 
 0000029692 00000 n 
 0000011802 00000 n 
-0000057022 00000 n 
-0000049701 00000 n 
-0000046134 00000 n 
-0000044061 00000 n 
-0000040544 00000 n 
-0000057376 00000 n 
+0000055982 00000 n 
+0000048661 00000 n 
+0000045094 00000 n 
+0000043021 00000 n 
+0000039504 00000 n 
+0000056336 00000 n 
 0000030009 00000 n 
 0000030389 00000 n 
-0000031167 00000 n 
-0000037823 00000 n 
-0000039458 00000 n 
-0000037935 00000 n 
-0000038010 00000 n 
-0000039694 00000 n 
-0000040698 00000 n 
-0000040898 00000 n 
-0000042951 00000 n 
-0000041010 00000 n 
-0000041086 00000 n 
-0000043187 00000 n 
-0000044214 00000 n 
-0000044413 00000 n 
-0000045151 00000 n 
-0000044444 00000 n 
-0000044510 00000 n 
-0000045387 00000 n 
-0000046287 00000 n 
-0000046486 00000 n 
-0000048592 00000 n 
-0000046598 00000 n 
-0000046674 00000 n 
-0000048827 00000 n 
-0000049854 00000 n 
-0000050053 00000 n 
-0000055515 00000 n 
-0000050393 00000 n 
-0000050521 00000 n 
-0000055751 00000 n 
-0000057176 00000 n 
-0000057438 00000 n 
-0000057553 00000 n 
+0000031007 00000 n 
+0000036783 00000 n 
+0000038418 00000 n 
+0000036895 00000 n 
+0000036970 00000 n 
+0000038654 00000 n 
+0000039658 00000 n 
+0000039858 00000 n 
+0000041911 00000 n 
+0000039970 00000 n 
+0000040046 00000 n 
+0000042147 00000 n 
+0000043174 00000 n 
+0000043373 00000 n 
+0000044111 00000 n 
+0000043404 00000 n 
+0000043470 00000 n 
+0000044347 00000 n 
+0000045247 00000 n 
+0000045446 00000 n 
+0000047552 00000 n 
+0000045558 00000 n 
+0000045634 00000 n 
+0000047787 00000 n 
+0000048814 00000 n 
+0000049013 00000 n 
+0000054475 00000 n 
+0000049353 00000 n 
+0000049481 00000 n 
+0000054711 00000 n 
+0000056136 00000 n 
+0000056398 00000 n 
+0000056513 00000 n 
 trailer
-<< /Size 99 /Root 97 0 R /Info 98 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 89 /Root 87 0 R /Info 88 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-57685
+56645
 %%EOF

--- a/required/latex-lab/testfiles-OR-luatex/scrartcl-001.tpf
+++ b/required/latex-lab/testfiles-OR-luatex/scrartcl-001.tpf
@@ -3,13 +3,13 @@
 16 0 obj
 << /Type/OBJR/Obj 15 0 R/Pg 9 0 R >>
 endobj
-25 0 obj
-<< /Type/OBJR/Obj 24 0 R/Pg 9 0 R >>
+24 0 obj
+<< /Type/OBJR/Obj 23 0 R/Pg 9 0 R >>
 endobj
-34 0 obj
-<< /Type/OBJR/Obj 33 0 R/Pg 9 0 R >>
+32 0 obj
+<< /Type/OBJR/Obj 31 0 R/Pg 9 0 R >>
 endobj
-40 0 obj
+37 0 obj
 << /Type /Metadata /Subtype /XML /Length 11708 >>      
 stream
 <?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>
@@ -243,7 +243,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-42 0 obj
+39 0 obj
 << /Length 1435 >>       
 stream
 /opacity1 gs
@@ -344,89 +344,89 @@ EMC
 endstream
 endobj
 9 0 obj
-<< /Type /Page /Contents 42 0 R /Resources 41 0 R /MediaBox [ 0 0 595.276 841.89 ] /StructParents 0/Tabs /S /Parent 63 0 R /Annots 64 0 R >>
-endobj
-64 0 obj
-[ 15 0 R 24 0 R 33 0 R ]
-endobj
-15 0 obj
-<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 1  /Rect [ 91.549 758.781 121.194 771.089 ]/A  << /S /GoTo /D (footnote*.5) /SD 50 0 R >> >>
-endobj
-24 0 obj
-<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 2  /Rect [ 129.28 758.781 158.925 771.089 ]/A  << /S /GoTo /D (footnote*.12) /SD 56 0 R >> >>
-endobj
-33 0 obj
-<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 3  /Rect [ 167.01 758.781 196.655 771.089 ]/A  << /S /GoTo /D (footnote*.19) /SD 60 0 R >> >>
-endobj
-43 0 obj
-<< /D [ 9 0 R /XYZ 73.409 812.458 null ] >>
-endobj
-44 0 obj
-[ 10 0 R /XYZ 73.409 812.458 null ]
-endobj
-45 0 obj
-<< /D [ 9 0 R /XYZ 74.409 771.732 null ] >>
-endobj
-46 0 obj
-[ 10 0 R /XYZ 74.409 771.732 null ]
-endobj
-49 0 obj
-<< /D [ 9 0 R /XYZ 134.185 724.837 null ] >>
-endobj
-50 0 obj
-[ 20 0 R /XYZ 134.185 724.837 null ]
-endobj
-51 0 obj
-<< /D [ 9 0 R /XYZ 134.185 724.837 null ] >>
-endobj
-52 0 obj
-[ 20 0 R /XYZ 134.185 724.837 null ]
-endobj
-55 0 obj
-<< /D [ 9 0 R /XYZ 134.185 712.405 null ] >>
-endobj
-56 0 obj
-[ 29 0 R /XYZ 134.185 712.405 null ]
-endobj
-57 0 obj
-<< /D [ 9 0 R /XYZ 134.185 712.405 null ] >>
-endobj
-58 0 obj
-[ 29 0 R /XYZ 134.185 712.405 null ]
-endobj
-59 0 obj
-<< /D [ 9 0 R /XYZ 134.185 699.972 null ] >>
-endobj
-60 0 obj
-[ 38 0 R /XYZ 134.185 699.972 null ]
+<< /Type /Page /Contents 39 0 R /Resources 38 0 R /MediaBox [ 0 0 595.276 841.89 ] /StructParents 0/Tabs /S /Parent 60 0 R /Annots 61 0 R >>
 endobj
 61 0 obj
-<< /D [ 9 0 R /XYZ 134.185 699.972 null ] >>
+[ 15 0 R 23 0 R 31 0 R ]
 endobj
-62 0 obj
-[ 38 0 R /XYZ 134.185 699.972 null ]
+15 0 obj
+<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 1  /Rect [ 91.549 758.781 121.194 771.089 ]/A  << /S /GoTo /D (footnote*.5) /SD 47 0 R >> >>
+endobj
+23 0 obj
+<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 2  /Rect [ 129.28 758.781 158.925 771.089 ]/A  << /S /GoTo /D (footnote*.11) /SD 53 0 R >> >>
+endobj
+31 0 obj
+<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 3  /Rect [ 167.01 758.781 196.655 771.089 ]/A  << /S /GoTo /D (footnote*.17) /SD 57 0 R >> >>
+endobj
+40 0 obj
+<< /D [ 9 0 R /XYZ 73.409 812.458 null ] >>
 endobj
 41 0 obj
-<< /ExtGState 1 0 R /Font << /F17 47 0 R /F28 48 0 R /F40 53 0 R /F15 54 0 R >> /ProcSet [ /PDF /Text ] >>
+[ 10 0 R /XYZ 73.409 812.458 null ]
+endobj
+42 0 obj
+<< /D [ 9 0 R /XYZ 74.409 771.732 null ] >>
+endobj
+43 0 obj
+[ 10 0 R /XYZ 74.409 771.732 null ]
+endobj
+46 0 obj
+<< /D [ 9 0 R /XYZ 134.185 724.837 null ] >>
+endobj
+47 0 obj
+[ 19 0 R /XYZ 134.185 724.837 null ]
+endobj
+48 0 obj
+<< /D [ 9 0 R /XYZ 134.185 724.837 null ] >>
+endobj
+49 0 obj
+[ 19 0 R /XYZ 134.185 724.837 null ]
+endobj
+52 0 obj
+<< /D [ 9 0 R /XYZ 134.185 712.405 null ] >>
+endobj
+53 0 obj
+[ 27 0 R /XYZ 134.185 712.405 null ]
+endobj
+54 0 obj
+<< /D [ 9 0 R /XYZ 134.185 712.405 null ] >>
+endobj
+55 0 obj
+[ 27 0 R /XYZ 134.185 712.405 null ]
+endobj
+56 0 obj
+<< /D [ 9 0 R /XYZ 134.185 699.972 null ] >>
+endobj
+57 0 obj
+[ 35 0 R /XYZ 134.185 699.972 null ]
+endobj
+58 0 obj
+<< /D [ 9 0 R /XYZ 134.185 699.972 null ] >>
+endobj
+59 0 obj
+[ 35 0 R /XYZ 134.185 699.972 null ]
+endobj
+38 0 obj
+<< /ExtGState 1 0 R /Font << /F17 44 0 R /F28 45 0 R /F40 50 0 R /F15 51 0 R >> /ProcSet [ /PDF /Text ] >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-65 0 obj
+62 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 12 0 R 14 0 R 12 0 R 23 0 R 12 0 R 32 0 R 21 0 R 20 0 R 30 0 R 29 0 R 39 0 R 38 0 R] 
+<< /Nums [0 [ 12 0 R 14 0 R 12 0 R 22 0 R 12 0 R 30 0 R 20 0 R 19 0 R 28 0 R 27 0 R 36 0 R 35 0 R] 
 1 14 0 R
-2 23 0 R
-3 32 0 R
+2 22 0 R
+3 30 0 R
 ] >>
 endobj
-66 0 obj
-<< /Limits [(ID.002) (ID.025)]/Names [(ID.002) 10 0 R (ID.003) 11 0 R (ID.004) 12 0 R (ID.005) 13 0 R (ID.006) 14 0 R (ID.007) 17 0 R (ID.008) 18 0 R (ID.009) 19 0 R (ID.010) 20 0 R (ID.011) 21 0 R (ID.012) 22 0 R (ID.013) 23 0 R (ID.014) 26 0 R (ID.015) 27 0 R (ID.016) 28 0 R (ID.017) 29 0 R (ID.018) 30 0 R (ID.019) 31 0 R (ID.020) 32 0 R (ID.021) 35 0 R (ID.022) 36 0 R (ID.023) 37 0 R (ID.024) 38 0 R (ID.025) 39 0 R ] >>
+63 0 obj
+<< /Limits [(ID.002) (ID.022)]/Names [(ID.002) 10 0 R (ID.003) 11 0 R (ID.004) 12 0 R (ID.005) 13 0 R (ID.006) 14 0 R (ID.007) 17 0 R (ID.008) 18 0 R (ID.009) 19 0 R (ID.010) 20 0 R (ID.011) 21 0 R (ID.012) 22 0 R (ID.013) 25 0 R (ID.014) 26 0 R (ID.015) 27 0 R (ID.016) 28 0 R (ID.017) 29 0 R (ID.018) 30 0 R (ID.019) 33 0 R (ID.020) 34 0 R (ID.021) 35 0 R (ID.022) 36 0 R ] >>
 endobj
-67 0 obj
-<< /Kids [66 0 R] >>
+64 0 obj
+<< /Kids [63 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
@@ -438,7 +438,7 @@ endobj
 <<  /Type /StructElem /S /text-unit /P 10 0 R /K 12 0 R /ID (ID.003) >>
 endobj
 12 0 obj
-<<  /Type /StructElem /S /text /P 11 0 R /K [<</Type /MCR /Pg 9 0 R /MCID 0>>  13 0 R  17 0 R <</Type /MCR /Pg 9 0 R /MCID 2>>  22 0 R  26 0 R <</Type /MCR /Pg 9 0 R /MCID 4>>  31 0 R  35 0 R ] /ID (ID.004) >>
+<<  /Type /StructElem /S /text /P 11 0 R /K [<</Type /MCR /Pg 9 0 R /MCID 0>>  13 0 R  17 0 R <</Type /MCR /Pg 9 0 R /MCID 2>>  21 0 R  25 0 R <</Type /MCR /Pg 9 0 R /MCID 4>>  29 0 R  33 0 R ] /ID (ID.004) >>
 endobj
 13 0 obj
 <<  /Type /StructElem /S /footnotemark /P 12 0 R /Ref [ 17 0 R ] /K [ 14 0 R ] /ID (ID.005) >>
@@ -447,80 +447,71 @@ endobj
 <<  /Type /StructElem /S /Link /P 13 0 R /K [<</Type /MCR /Pg 9 0 R /MCID 1>>  16 0 R] /ID (ID.006) >>
 endobj
 17 0 obj
-<<  /Type /StructElem /S /footnote /P 12 0 R /Ref [ 13 0 R ] /K [18 0 R 19 0 R] /ID (ID.007) >>
+<<  /Type /StructElem /S /footnote /P 12 0 R /Ref [ 13 0 R ] /K [20 0 R 18 0 R] /ID (ID.007) >>
 endobj
 18 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 17 0 R /K 21 0 R /ID (ID.008) >>
+<<  /Type /StructElem /S /text-unit /P 17 0 R /K 19 0 R /ID (ID.008) >>
 endobj
 19 0 obj
-<<  /Type /StructElem /S /text-unit /P 17 0 R /K 20 0 R /ID (ID.009) >>
+<<  /Type /StructElem /S /text /P 18 0 R /K [  <</Type /MCR /Pg 9 0 R /MCID 7>>  ] /ID (ID.009) >>
 endobj
 20 0 obj
-<<  /Type /StructElem /S /text /P 19 0 R /K [  <</Type /MCR /Pg 9 0 R /MCID 7>>  ] /ID (ID.010) >>
+<<  /Type /StructElem /S /footnotelabel /P 17 0 R /K <</Type /MCR /Pg 9 0 R /MCID 6>>  /ID (ID.010) >>
 endobj
 21 0 obj
-<<  /Type /StructElem /S /NonStruct /P 18 0 R /K <</Type /MCR /Pg 9 0 R /MCID 6>>  /ID (ID.011) >>
+<<  /Type /StructElem /S /footnotemark /P 12 0 R /Ref [ 25 0 R ] /K [ 22 0 R ] /ID (ID.011) >>
 endobj
 22 0 obj
-<<  /Type /StructElem /S /footnotemark /P 12 0 R /Ref [ 26 0 R ] /K [ 23 0 R ] /ID (ID.012) >>
+<<  /Type /StructElem /S /Link /P 21 0 R /K [<</Type /MCR /Pg 9 0 R /MCID 3>>  24 0 R] /ID (ID.012) >>
 endobj
-23 0 obj
-<<  /Type /StructElem /S /Link /P 22 0 R /K [<</Type /MCR /Pg 9 0 R /MCID 3>>  25 0 R] /ID (ID.013) >>
+25 0 obj
+<<  /Type /StructElem /S /footnote /P 12 0 R /Ref [ 21 0 R ] /K [28 0 R 26 0 R] /ID (ID.013) >>
 endobj
 26 0 obj
-<<  /Type /StructElem /S /footnote /P 12 0 R /Ref [ 22 0 R ] /K [27 0 R 28 0 R] /ID (ID.014) >>
+<<  /Type /StructElem /S /text-unit /P 25 0 R /K 27 0 R /ID (ID.014) >>
 endobj
 27 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 26 0 R /K 30 0 R /ID (ID.015) >>
+<<  /Type /StructElem /S /text /P 26 0 R /K [  <</Type /MCR /Pg 9 0 R /MCID 9>>  ] /ID (ID.015) >>
 endobj
 28 0 obj
-<<  /Type /StructElem /S /text-unit /P 26 0 R /K 29 0 R /ID (ID.016) >>
+<<  /Type /StructElem /S /footnotelabel /P 25 0 R /K <</Type /MCR /Pg 9 0 R /MCID 8>>  /ID (ID.016) >>
 endobj
 29 0 obj
-<<  /Type /StructElem /S /text /P 28 0 R /K [  <</Type /MCR /Pg 9 0 R /MCID 9>>  ] /ID (ID.017) >>
+<<  /Type /StructElem /S /footnotemark /P 12 0 R /Ref [ 33 0 R ] /K [ 30 0 R ] /ID (ID.017) >>
 endobj
 30 0 obj
-<<  /Type /StructElem /S /NonStruct /P 27 0 R /K <</Type /MCR /Pg 9 0 R /MCID 8>>  /ID (ID.018) >>
+<<  /Type /StructElem /S /Link /P 29 0 R /K [<</Type /MCR /Pg 9 0 R /MCID 5>>  32 0 R] /ID (ID.018) >>
 endobj
-31 0 obj
-<<  /Type /StructElem /S /footnotemark /P 12 0 R /Ref [ 35 0 R ] /K [ 32 0 R ] /ID (ID.019) >>
+33 0 obj
+<<  /Type /StructElem /S /footnote /P 12 0 R /Ref [ 29 0 R ] /K [36 0 R 34 0 R] /ID (ID.019) >>
 endobj
-32 0 obj
-<<  /Type /StructElem /S /Link /P 31 0 R /K [<</Type /MCR /Pg 9 0 R /MCID 5>>  34 0 R] /ID (ID.020) >>
+34 0 obj
+<<  /Type /StructElem /S /text-unit /P 33 0 R /K 35 0 R /ID (ID.020) >>
 endobj
 35 0 obj
-<<  /Type /StructElem /S /footnote /P 12 0 R /Ref [ 31 0 R ] /K [36 0 R 37 0 R] /ID (ID.021) >>
+<<  /Type /StructElem /S /text /P 34 0 R /K [  <</Type /MCR /Pg 9 0 R /MCID 11>>  ] /ID (ID.021) >>
 endobj
 36 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 35 0 R /K 39 0 R /ID (ID.022) >>
-endobj
-37 0 obj
-<<  /Type /StructElem /S /text-unit /P 35 0 R /K 38 0 R /ID (ID.023) >>
-endobj
-38 0 obj
-<<  /Type /StructElem /S /text /P 37 0 R /K [  <</Type /MCR /Pg 9 0 R /MCID 11>>  ] /ID (ID.024) >>
-endobj
-39 0 obj
-<<  /Type /StructElem /S /NonStruct /P 36 0 R /K <</Type /MCR /Pg 9 0 R /MCID 10>>  /ID (ID.025) >>
+<<  /Type /StructElem /S /footnotelabel /P 33 0 R /K <</Type /MCR /Pg 9 0 R /MCID 10>>  /ID (ID.022) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 67 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 10 0 R >>
+<<  /Type /StructTreeRoot /IDTree 64 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 10 0 R >>
 endobj
-68 0 obj
+65 0 obj
 [ 50 [ 444 ] 98 [ 394 ] 105 [ 389 ] ]
 endobj
-70 0 obj
+67 0 obj
 << /Length 14 >>         
 [BINARY STREAM]
 endobj
-71 0 obj
+68 0 obj
 << /Subtype /CIDFontType0C /Length 867 >>        
 [BINARY STREAM]
 endobj
-69 0 obj
-<< /Type /FontDescriptor /FontName /JAOKTN+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 71 0 R /CIDSet 70 0 R >>
+66 0 obj
+<< /Type /FontDescriptor /FontName /JAOKTN+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 68 0 R /CIDSet 67 0 R >>
 endobj
-72 0 obj
+69 0 obj
 << /Length 720 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -558,27 +549,27 @@ end
 %%EOF
 endstream
 endobj
-54 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JAOKTN+LMRoman10-Regular /DescendantFonts [ 73 0 R ] /ToUnicode 72 0 R >>
+51 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JAOKTN+LMRoman10-Regular /DescendantFonts [ 70 0 R ] /ToUnicode 69 0 R >>
 endobj
-73 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JAOKTN+LMRoman10-Regular /FontDescriptor 69 0 R /W 68 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+70 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JAOKTN+LMRoman10-Regular /FontDescriptor 66 0 R /W 65 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-74 0 obj
+71 0 obj
 [ 54 [ 737 ] 76 [ 843 ] 82 [ 569 ] 85 [ 446 446 ] 106 [ 569 569 ] ]
 endobj
-76 0 obj
+73 0 obj
 << /Length 14 >>         
 [BINARY STREAM]
 endobj
-77 0 obj
+74 0 obj
 << /Subtype /CIDFontType0C /Length 1238 >>       
 [BINARY STREAM]
 endobj
-75 0 obj
-<< /Type /FontDescriptor /FontName /ROOXCE+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 77 0 R /CIDSet 76 0 R >>
+72 0 obj
+<< /Type /FontDescriptor /FontName /ROOXCE+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 74 0 R /CIDSet 73 0 R >>
 endobj
-78 0 obj
+75 0 obj
 << /Length 771 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -620,27 +611,27 @@ end
 %%EOF
 endstream
 endobj
-53 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /ROOXCE+LMRoman7-Regular /DescendantFonts [ 79 0 R ] /ToUnicode 78 0 R >>
+50 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /ROOXCE+LMRoman7-Regular /DescendantFonts [ 76 0 R ] /ToUnicode 75 0 R >>
 endobj
-79 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /ROOXCE+LMRoman7-Regular /FontDescriptor 75 0 R /W 74 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+76 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /ROOXCE+LMRoman7-Regular /FontDescriptor 72 0 R /W 71 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-80 0 obj
+77 0 obj
 [ 54 [ 693 ] 76 [ 796 ] 82 [ 531 ] 85 [ 413 413 ] 106 [ 531 531 ] 118 [ 561 ] ]
 endobj
-82 0 obj
+79 0 obj
 << /Length 15 >>         
 [BINARY STREAM]
 endobj
-83 0 obj
+80 0 obj
 << /Subtype /CIDFontType0C /Length 1442 >>       
 [BINARY STREAM]
 endobj
-81 0 obj
-<< /Type /FontDescriptor /FontName /TCAZKZ+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 83 0 R /CIDSet 82 0 R >>
+78 0 obj
+<< /Type /FontDescriptor /FontName /TCAZKZ+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 80 0 R /CIDSet 79 0 R >>
 endobj
-84 0 obj
+81 0 obj
 << /Length 785 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -683,27 +674,27 @@ end
 %%EOF
 endstream
 endobj
-48 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /TCAZKZ+LMRoman8-Regular /DescendantFonts [ 85 0 R ] /ToUnicode 84 0 R >>
+45 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /TCAZKZ+LMRoman8-Regular /DescendantFonts [ 82 0 R ] /ToUnicode 81 0 R >>
 endobj
-85 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /TCAZKZ+LMRoman8-Regular /FontDescriptor 81 0 R /W 80 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+82 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /TCAZKZ+LMRoman8-Regular /FontDescriptor 78 0 R /W 77 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-86 0 obj
+83 0 obj
 [ 82 [ 490 ] 103 [ 326 ] 116 [ 517 ] ]
 endobj
-88 0 obj
+85 0 obj
 << /Length 15 >>         
 [BINARY STREAM]
 endobj
-89 0 obj
+86 0 obj
 << /Subtype /CIDFontType0C /Length 777 >>        
 [BINARY STREAM]
 endobj
-87 0 obj
-<< /Type /FontDescriptor /FontName /KNKDVS+LMRoman12-Regular /Flags 4 /FontBBox [ -422 -280 1394 1127 ] /Ascent 1127 /CapHeight 683 /Descent -280 /ItalicAngle 0 /StemV 91 /XHeight 431 /FontFile3 89 0 R /CIDSet 88 0 R >>
+84 0 obj
+<< /Type /FontDescriptor /FontName /KNKDVS+LMRoman12-Regular /Flags 4 /FontBBox [ -422 -280 1394 1127 ] /Ascent 1127 /CapHeight 683 /Descent -280 /ItalicAngle 0 /StemV 91 /XHeight 431 /FontFile3 86 0 R /CIDSet 85 0 R >>
 endobj
-90 0 obj
+87 0 obj
 << /Length 720 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -741,69 +732,66 @@ end
 %%EOF
 endstream
 endobj
-47 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /KNKDVS+LMRoman12-Regular /DescendantFonts [ 91 0 R ] /ToUnicode 90 0 R >>
+44 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /KNKDVS+LMRoman12-Regular /DescendantFonts [ 88 0 R ] /ToUnicode 87 0 R >>
 endobj
-91 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /KNKDVS+LMRoman12-Regular /FontDescriptor 87 0 R /W 86 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+88 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /KNKDVS+LMRoman12-Regular /FontDescriptor 84 0 R /W 83 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-63 0 obj
+60 0 obj
 << /Type /Pages  /Count 1 /Kids [ 9 0 R ] >>
 endobj
+89 0 obj
+<< /Names [ (Doc-Start) 42 0 R (footnote*.11) 52 0 R (footnote*.13) 54 0 R (footnote*.17) 56 0 R (footnote*.19) 58 0 R (footnote*.5) 46 0 R (footnote*.7) 48 0 R (page.1) 40 0 R ] /Limits [ (Doc-Start) (page.1) ] >>
+endobj
+90 0 obj
+<< /Dests 89 0 R >>
+endobj
+91 0 obj
+<< /Type /Catalog /Pages 60 0 R /Names 90 0 R /MarkInfo 62 0 R/PageMode /UseOutlines/OpenAction <</S/GoTo /D [9 0 R /Fit] /SD [10 0 R/Fit]>>/Lang (en)/PageLabels <</Nums[0<</S/D>>]>>/Metadata 37 0 R/StructTreeRoot 5 0 R >>
+endobj
 92 0 obj
-<< /Names [ (Doc-Start) 45 0 R (footnote*.12) 55 0 R (footnote*.14) 57 0 R (footnote*.19) 59 0 R (footnote*.21) 61 0 R (footnote*.5) 49 0 R (footnote*.7) 51 0 R (page.1) 43 0 R ] /Limits [ (Doc-Start) (page.1) ] >>
-endobj
-93 0 obj
-<< /Dests 92 0 R >>
-endobj
-94 0 obj
-<< /Type /Catalog /Pages 63 0 R /Names 93 0 R /MarkInfo 65 0 R/PageMode /UseOutlines/OpenAction <</S/GoTo /D [9 0 R /Fit] /SD [10 0 R/Fit]>>/Lang (en)/PageLabels <</Nums[0<</S/D>>]>>/Metadata 40 0 R/StructTreeRoot 5 0 R >>
-endobj
-95 0 obj
 << /Producer (LuaTeX)/Creator <FEFF004C006100540065005800200077006900740068002000680079007000650072007200650066>/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 96
+0 93
 0000000002 65535 f 
 0000015359 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000019306 00000 n 
+0000018994 00000 n 
 0000015442 00000 n 
-0000016069 00000 n 
+0000016021 00000 n 
 0000000000 00000 f 
 0000013472 00000 n 
-0000016648 00000 n 
-0000016734 00000 n 
-0000016822 00000 n 
-0000017048 00000 n 
-0000017159 00000 n 
+0000016600 00000 n 
+0000016686 00000 n 
+0000016774 00000 n 
+0000017000 00000 n 
+0000017111 00000 n 
 0000013669 00000 n 
 0000000020 00000 n 
-0000017278 00000 n 
-0000017390 00000 n 
-0000017482 00000 n 
-0000017570 00000 n 
-0000017685 00000 n 
-0000017800 00000 n 
-0000017911 00000 n 
+0000017230 00000 n 
+0000017342 00000 n 
+0000017430 00000 n 
+0000017545 00000 n 
+0000017664 00000 n 
+0000017775 00000 n 
 0000013888 00000 n 
 0000000073 00000 n 
-0000018030 00000 n 
-0000018142 00000 n 
-0000018234 00000 n 
-0000018322 00000 n 
-0000018437 00000 n 
-0000018552 00000 n 
-0000018663 00000 n 
+0000017894 00000 n 
+0000018006 00000 n 
+0000018094 00000 n 
+0000018209 00000 n 
+0000018328 00000 n 
+0000018439 00000 n 
 0000014108 00000 n 
 0000000126 00000 n 
-0000018782 00000 n 
-0000018894 00000 n 
-0000018986 00000 n 
-0000019074 00000 n 
-0000019190 00000 n 
+0000018558 00000 n 
+0000018670 00000 n 
+0000018758 00000 n 
+0000018874 00000 n 
 0000000179 00000 n 
 0000015236 00000 n 
 0000011977 00000 n 
@@ -811,14 +799,14 @@ xref
 0000014388 00000 n 
 0000014440 00000 n 
 0000014500 00000 n 
-0000029892 00000 n 
-0000027533 00000 n 
+0000029580 00000 n 
+0000027221 00000 n 
 0000014552 00000 n 
 0000014613 00000 n 
 0000014666 00000 n 
 0000014727 00000 n 
-0000024404 00000 n 
-0000021503 00000 n 
+0000024092 00000 n 
+0000021191 00000 n 
 0000014780 00000 n 
 0000014841 00000 n 
 0000014894 00000 n 
@@ -827,41 +815,41 @@ xref
 0000015069 00000 n 
 0000015122 00000 n 
 0000015183 00000 n 
-0000030246 00000 n 
+0000029934 00000 n 
 0000013628 00000 n 
 0000015406 00000 n 
 0000015589 00000 n 
-0000016032 00000 n 
-0000019408 00000 n 
-0000020487 00000 n 
-0000019462 00000 n 
-0000019536 00000 n 
-0000020723 00000 n 
-0000021657 00000 n 
-0000021857 00000 n 
-0000023337 00000 n 
-0000021941 00000 n 
-0000022015 00000 n 
-0000023573 00000 n 
-0000024557 00000 n 
-0000024756 00000 n 
-0000026453 00000 n 
-0000024852 00000 n 
-0000024927 00000 n 
-0000026688 00000 n 
-0000027686 00000 n 
-0000027885 00000 n 
-0000028876 00000 n 
-0000027940 00000 n 
-0000028015 00000 n 
-0000029112 00000 n 
-0000030046 00000 n 
-0000030307 00000 n 
-0000030538 00000 n 
-0000030574 00000 n 
-0000030813 00000 n 
+0000015984 00000 n 
+0000019096 00000 n 
+0000020175 00000 n 
+0000019150 00000 n 
+0000019224 00000 n 
+0000020411 00000 n 
+0000021345 00000 n 
+0000021545 00000 n 
+0000023025 00000 n 
+0000021629 00000 n 
+0000021703 00000 n 
+0000023261 00000 n 
+0000024245 00000 n 
+0000024444 00000 n 
+0000026141 00000 n 
+0000024540 00000 n 
+0000024615 00000 n 
+0000026376 00000 n 
+0000027374 00000 n 
+0000027573 00000 n 
+0000028564 00000 n 
+0000027628 00000 n 
+0000027703 00000 n 
+0000028800 00000 n 
+0000029734 00000 n 
+0000029995 00000 n 
+0000030226 00000 n 
+0000030262 00000 n 
+0000030501 00000 n 
 trailer
-<< /Size 96 /Root 94 0 R /Info 95 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 93 /Root 91 0 R /Info 92 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-31022
+30710
 %%EOF

--- a/required/latex-lab/testfiles-OR-luatex/test-minipage.tpf
+++ b/required/latex-lab/testfiles-OR-luatex/test-minipage.tpf
@@ -3,10 +3,10 @@
 21 0 obj
 << /Type/OBJR/Obj 20 0 R/Pg 9 0 R >>
 endobj
-30 0 obj
-<< /Type/OBJR/Obj 29 0 R/Pg 9 0 R >>
+29 0 obj
+<< /Type/OBJR/Obj 28 0 R/Pg 9 0 R >>
 endobj
-39 0 obj
+37 0 obj
 << /Type /Metadata /Subtype /XML /Length 11709 >>      
 stream
 <?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>
@@ -240,7 +240,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-41 0 obj
+39 0 obj
 << /Length 1204 >>       
 stream
 /opacity1 gs
@@ -331,79 +331,79 @@ EMC
 endstream
 endobj
 9 0 obj
-<< /Type /Page /Contents 41 0 R /Resources 40 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 58 0 R /Annots 59 0 R >>
+<< /Type /Page /Contents 39 0 R /Resources 38 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 56 0 R /Annots 57 0 R >>
 endobj
-59 0 obj
-[ 20 0 R 29 0 R ]
+57 0 obj
+[ 20 0 R 28 0 R ]
 endobj
 20 0 obj
-<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 1  /Rect [ 162.939 646.568 169.398 657.126 ]/A  << /S /GoTo /D (footnote*.10) /SD 49 0 R >> >>
+<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 1  /Rect [ 162.939 646.568 169.398 657.126 ]/A  << /S /GoTo /D (footnote*.10) /SD 47 0 R >> >>
 endobj
-29 0 obj
-<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 2  /Rect [ 185.109 646.568 192 657.126 ]/A  << /S /GoTo /D (footnote*.17) /SD 55 0 R >> >>
+28 0 obj
+<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 2  /Rect [ 185.109 646.568 192 657.126 ]/A  << /S /GoTo /D (footnote*.16) /SD 53 0 R >> >>
 endobj
-42 0 obj
+40 0 obj
 << /D [ 9 0 R /XYZ 132.768 705.06 null ] >>
 endobj
-43 0 obj
+41 0 obj
 [ 10 0 R /XYZ 132.768 705.06 null ]
 endobj
-44 0 obj
+42 0 obj
 << /D [ 9 0 R /XYZ 133.768 667.198 null ] >>
 endobj
-45 0 obj
+43 0 obj
 [ 10 0 R /XYZ 133.768 667.198 null ]
+endobj
+46 0 obj
+<< /D [ 9 0 R /XYZ 148.712 641.438 null ] >>
+endobj
+47 0 obj
+[ 24 0 R /XYZ 148.712 641.438 null ]
 endobj
 48 0 obj
 << /D [ 9 0 R /XYZ 148.712 641.438 null ] >>
 endobj
 49 0 obj
-[ 25 0 R /XYZ 148.712 641.438 null ]
+[ 24 0 R /XYZ 148.712 641.438 null ]
 endobj
-50 0 obj
-<< /D [ 9 0 R /XYZ 148.712 641.438 null ] >>
+52 0 obj
+<< /D [ 9 0 R /XYZ 148.712 631.637 null ] >>
 endobj
-51 0 obj
-[ 25 0 R /XYZ 148.712 641.438 null ]
+53 0 obj
+[ 32 0 R /XYZ 148.712 631.637 null ]
 endobj
 54 0 obj
 << /D [ 9 0 R /XYZ 148.712 631.637 null ] >>
 endobj
 55 0 obj
-[ 34 0 R /XYZ 148.712 631.637 null ]
+[ 32 0 R /XYZ 148.712 631.637 null ]
 endobj
-56 0 obj
-<< /D [ 9 0 R /XYZ 148.712 631.637 null ] >>
-endobj
-57 0 obj
-[ 34 0 R /XYZ 148.712 631.637 null ]
-endobj
-40 0 obj
-<< /ExtGState 1 0 R /Font << /F15 46 0 R /F27 47 0 R /F37 52 0 R /F29 53 0 R >> /ProcSet [ /PDF /Text ] >>
+38 0 obj
+<< /ExtGState 1 0 R /Font << /F15 44 0 R /F27 45 0 R /F37 50 0 R /F29 51 0 R >> /ProcSet [ /PDF /Text ] >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-60 0 obj
+58 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 12 0 R 17 0 R 19 0 R 17 0 R 28 0 R 26 0 R 25 0 R 35 0 R 34 0 R 38 0 R] 
+<< /Nums [0 [ 12 0 R 17 0 R 19 0 R 17 0 R 27 0 R 25 0 R 24 0 R 33 0 R 32 0 R 36 0 R] 
 1 19 0 R
-2 28 0 R
+2 27 0 R
 ] >>
 endobj
-61 0 obj
-<< /Limits [(ID.002) (ID.026)]/Names [(ID.002) 10 0 R (ID.003) 11 0 R (ID.004) 12 0 R (ID.005) 13 0 R (ID.006) 14 0 R (ID.007) 15 0 R (ID.008) 16 0 R (ID.009) 17 0 R (ID.010) 18 0 R (ID.011) 19 0 R (ID.012) 22 0 R (ID.013) 23 0 R (ID.014) 24 0 R (ID.015) 25 0 R (ID.016) 26 0 R (ID.017) 27 0 R (ID.018) 28 0 R (ID.019) 31 0 R (ID.020) 32 0 R (ID.021) 33 0 R (ID.022) 34 0 R (ID.023) 35 0 R (ID.024) 36 0 R (ID.025) 37 0 R (ID.026) 38 0 R ] >>
+59 0 obj
+<< /Limits [(ID.002) (ID.024)]/Names [(ID.002) 10 0 R (ID.003) 11 0 R (ID.004) 12 0 R (ID.005) 13 0 R (ID.006) 14 0 R (ID.007) 15 0 R (ID.008) 16 0 R (ID.009) 17 0 R (ID.010) 18 0 R (ID.011) 19 0 R (ID.012) 22 0 R (ID.013) 23 0 R (ID.014) 24 0 R (ID.015) 25 0 R (ID.016) 26 0 R (ID.017) 27 0 R (ID.018) 30 0 R (ID.019) 31 0 R (ID.020) 32 0 R (ID.021) 33 0 R (ID.022) 34 0 R (ID.023) 35 0 R (ID.024) 36 0 R ] >>
 endobj
-62 0 obj
-<< /Kids [61 0 R] >>
+60 0 obj
+<< /Kids [59 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
 endobj
 10 0 obj
-<<  /Type /StructElem /S /Document /P 5 0 R /K [11 0 R 13 0 R 37 0 R] /ID (ID.002) >>
+<<  /Type /StructElem /S /Document /P 5 0 R /K [11 0 R 13 0 R 35 0 R] /ID (ID.002) >>
 endobj
 11 0 obj
 <<  /Type /StructElem /S /text-unit /P 10 0 R /K 12 0 R /ID (ID.003) >>
@@ -412,7 +412,7 @@ endobj
 <<  /Type /StructElem /S /text /P 11 0 R /K <</Type /MCR /Pg 9 0 R /MCID 0>>  /ID (ID.004) >>
 endobj
 13 0 obj
-<<  /Type /StructElem /S /text-unit /P 10 0 R /K [14 0 R 15 0 R 36 0 R] /ID (ID.005) >>
+<<  /Type /StructElem /S /text-unit /P 10 0 R /K [14 0 R 15 0 R 34 0 R] /ID (ID.005) >>
 endobj
 14 0 obj
 <<  /Type /StructElem /S /text /P 13 0 R /ID (ID.006) >>
@@ -424,7 +424,7 @@ endobj
 <<  /Type /StructElem /S /text-unit /P 15 0 R /K 17 0 R /ID (ID.008) >>
 endobj
 17 0 obj
-<<  /Type /StructElem /S /text /P 16 0 R /K [<</Type /MCR /Pg 9 0 R /MCID 1>>  18 0 R  22 0 R <</Type /MCR /Pg 9 0 R /MCID 3>>  27 0 R  31 0 R ] /ID (ID.009) >>
+<<  /Type /StructElem /S /text /P 16 0 R /K [<</Type /MCR /Pg 9 0 R /MCID 1>>  18 0 R  22 0 R <</Type /MCR /Pg 9 0 R /MCID 3>>  26 0 R  30 0 R ] /ID (ID.009) >>
 endobj
 18 0 obj
 <<  /Type /StructElem /S /footnotemark /P 17 0 R /Ref [ 22 0 R ] /K [ 19 0 R ] /ID (ID.010) >>
@@ -433,68 +433,62 @@ endobj
 <<  /Type /StructElem /S /Link /P 18 0 R /K [<</Type /MCR /Pg 9 0 R /MCID 2>>  21 0 R] /ID (ID.011) >>
 endobj
 22 0 obj
-<<  /Type /StructElem /S /footnote /P 17 0 R /Ref [ 18 0 R ] /K [23 0 R 24 0 R] /ID (ID.012) >>
+<<  /Type /StructElem /S /footnote /P 17 0 R /Ref [ 18 0 R ] /K [25 0 R 23 0 R] /ID (ID.012) >>
 endobj
 23 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 22 0 R /K 26 0 R /ID (ID.013) >>
+<<  /Type /StructElem /S /text-unit /P 22 0 R /K 24 0 R /ID (ID.013) >>
 endobj
 24 0 obj
-<<  /Type /StructElem /S /text-unit /P 22 0 R /K 25 0 R /ID (ID.014) >>
+<<  /Type /StructElem /S /text /P 23 0 R /K [  <</Type /MCR /Pg 9 0 R /MCID 6>>  ] /ID (ID.014) >>
 endobj
 25 0 obj
-<<  /Type /StructElem /S /text /P 24 0 R /K [  <</Type /MCR /Pg 9 0 R /MCID 6>>  ] /ID (ID.015) >>
+<<  /Type /StructElem /S /footnotelabel /P 22 0 R /K <</Type /MCR /Pg 9 0 R /MCID 5>>  /ID (ID.015) >>
 endobj
 26 0 obj
-<<  /Type /StructElem /S /NonStruct /P 23 0 R /K <</Type /MCR /Pg 9 0 R /MCID 5>>  /ID (ID.016) >>
+<<  /Type /StructElem /S /footnotemark /P 17 0 R /Ref [ 30 0 R ] /K [ 27 0 R ] /ID (ID.016) >>
 endobj
 27 0 obj
-<<  /Type /StructElem /S /footnotemark /P 17 0 R /Ref [ 31 0 R ] /K [ 28 0 R ] /ID (ID.017) >>
+<<  /Type /StructElem /S /Link /P 26 0 R /K [<</Type /MCR /Pg 9 0 R /MCID 4>>  29 0 R] /ID (ID.017) >>
 endobj
-28 0 obj
-<<  /Type /StructElem /S /Link /P 27 0 R /K [<</Type /MCR /Pg 9 0 R /MCID 4>>  30 0 R] /ID (ID.018) >>
+30 0 obj
+<<  /Type /StructElem /S /footnote /P 17 0 R /Ref [ 26 0 R ] /K [33 0 R 31 0 R] /ID (ID.018) >>
 endobj
 31 0 obj
-<<  /Type /StructElem /S /footnote /P 17 0 R /Ref [ 27 0 R ] /K [32 0 R 33 0 R] /ID (ID.019) >>
+<<  /Type /StructElem /S /text-unit /P 30 0 R /K 32 0 R /ID (ID.019) >>
 endobj
 32 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 31 0 R /K 35 0 R /ID (ID.020) >>
+<<  /Type /StructElem /S /text /P 31 0 R /K [  <</Type /MCR /Pg 9 0 R /MCID 8>>  ] /ID (ID.020) >>
 endobj
 33 0 obj
-<<  /Type /StructElem /S /text-unit /P 31 0 R /K 34 0 R /ID (ID.021) >>
+<<  /Type /StructElem /S /footnotelabel /P 30 0 R /K <</Type /MCR /Pg 9 0 R /MCID 7>>  /ID (ID.021) >>
 endobj
 34 0 obj
-<<  /Type /StructElem /S /text /P 33 0 R /K [  <</Type /MCR /Pg 9 0 R /MCID 8>>  ] /ID (ID.022) >>
+<<  /Type /StructElem /S /text /P 13 0 R /ID (ID.022) >>
 endobj
 35 0 obj
-<<  /Type /StructElem /S /NonStruct /P 32 0 R /K <</Type /MCR /Pg 9 0 R /MCID 7>>  /ID (ID.023) >>
+<<  /Type /StructElem /S /text-unit /P 10 0 R /K 36 0 R /ID (ID.023) >>
 endobj
 36 0 obj
-<<  /Type /StructElem /S /text /P 13 0 R /ID (ID.024) >>
-endobj
-37 0 obj
-<<  /Type /StructElem /S /text-unit /P 10 0 R /K 38 0 R /ID (ID.025) >>
-endobj
-38 0 obj
-<<  /Type /StructElem /S /text /P 37 0 R /K <</Type /MCR /Pg 9 0 R /MCID 9>>  /ID (ID.026) >>
+<<  /Type /StructElem /S /text /P 35 0 R /K <</Type /MCR /Pg 9 0 R /MCID 9>>  /ID (ID.024) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 62 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 10 0 R >>
+<<  /Type /StructTreeRoot /IDTree 60 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 10 0 R >>
 endobj
-63 0 obj
+61 0 obj
 [ 28 [ 531 ] 35 [ 590 ] 116 [ 561 ] ]
 endobj
-65 0 obj
+63 0 obj
 << /Length 15 >>         
 [BINARY STREAM]
 endobj
-66 0 obj
+64 0 obj
 << /Subtype /CIDFontType0C /Length 957 >>        
 [BINARY STREAM]
 endobj
-64 0 obj
-<< /Type /FontDescriptor /FontName /ELTNDZ+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 66 0 R /CIDSet 65 0 R >>
+62 0 obj
+<< /Type /FontDescriptor /FontName /ELTNDZ+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 64 0 R /CIDSet 63 0 R >>
 endobj
-67 0 obj
+65 0 obj
 << /Length 715 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -532,27 +526,27 @@ end
 %%EOF
 endstream
 endobj
-53 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /ELTNDZ+LMRoman8-Regular /DescendantFonts [ 68 0 R ] /ToUnicode 67 0 R >>
+51 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /ELTNDZ+LMRoman8-Regular /DescendantFonts [ 66 0 R ] /ToUnicode 65 0 R >>
 endobj
-68 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /ELTNDZ+LMRoman8-Regular /FontDescriptor 64 0 R /W 63 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+66 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /ELTNDZ+LMRoman8-Regular /FontDescriptor 62 0 R /W 61 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-69 0 obj
+67 0 obj
 [ 28 [ 611 ] 35 [ 676 ] ]
 endobj
-71 0 obj
+69 0 obj
 << /Length 5 >>          
 [BINARY STREAM]
 endobj
-72 0 obj
+70 0 obj
 << /Subtype /CIDFontType0C /Length 760 >>        
 [BINARY STREAM]
 endobj
-70 0 obj
-<< /Type /FontDescriptor /FontName /PUZCFD+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 72 0 R /CIDSet 71 0 R >>
+68 0 obj
+<< /Type /FontDescriptor /FontName /PUZCFD+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 70 0 R /CIDSet 69 0 R >>
 endobj
-73 0 obj
+71 0 obj
 << /Length 701 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -589,27 +583,27 @@ end
 %%EOF
 endstream
 endobj
-52 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /PUZCFD+LMRoman6-Regular /DescendantFonts [ 74 0 R ] /ToUnicode 73 0 R >>
+50 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /PUZCFD+LMRoman6-Regular /DescendantFonts [ 72 0 R ] /ToUnicode 71 0 R >>
 endobj
-74 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /PUZCFD+LMRoman6-Regular /FontDescriptor 70 0 R /W 69 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+72 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /PUZCFD+LMRoman6-Regular /FontDescriptor 68 0 R /W 67 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-75 0 obj
+73 0 obj
 [ 28 [ 569 ] 35 [ 631 ] ]
 endobj
-77 0 obj
+75 0 obj
 << /Length 5 >>          
 [BINARY STREAM]
 endobj
-78 0 obj
+76 0 obj
 << /Subtype /CIDFontType0C /Length 764 >>        
 [BINARY STREAM]
 endobj
-76 0 obj
-<< /Type /FontDescriptor /FontName /ONTSIM+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 78 0 R /CIDSet 77 0 R >>
+74 0 obj
+<< /Type /FontDescriptor /FontName /ONTSIM+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 76 0 R /CIDSet 75 0 R >>
 endobj
-79 0 obj
+77 0 obj
 << /Length 701 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -646,27 +640,27 @@ end
 %%EOF
 endstream
 endobj
-47 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /ONTSIM+LMRoman7-Regular /DescendantFonts [ 80 0 R ] /ToUnicode 79 0 R >>
+45 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /ONTSIM+LMRoman7-Regular /DescendantFonts [ 78 0 R ] /ToUnicode 77 0 R >>
 endobj
-80 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /ONTSIM+LMRoman7-Regular /FontDescriptor 76 0 R /W 75 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+78 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /ONTSIM+LMRoman7-Regular /FontDescriptor 74 0 R /W 73 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-81 0 obj
+79 0 obj
 [ 28 [ 500 ] 35 [ 556 ] 43 [ 444 ] 47 [ 556 ] 50 [ 444 ] 82 [ 500 ] 103 [ 333 ] ]
 endobj
-83 0 obj
+81 0 obj
 << /Length 13 >>         
 [BINARY STREAM]
 endobj
-84 0 obj
+82 0 obj
 << /Subtype /CIDFontType0C /Length 1207 >>       
 [BINARY STREAM]
 endobj
-82 0 obj
-<< /Type /FontDescriptor /FontName /TNFHFC+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 84 0 R /CIDSet 83 0 R >>
+80 0 obj
+<< /Type /FontDescriptor /FontName /TNFHFC+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 82 0 R /CIDSet 81 0 R >>
 endobj
-85 0 obj
+83 0 obj
 << /Length 776 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -708,68 +702,66 @@ end
 %%EOF
 endstream
 endobj
-46 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /TNFHFC+LMRoman10-Regular /DescendantFonts [ 86 0 R ] /ToUnicode 85 0 R >>
+44 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /TNFHFC+LMRoman10-Regular /DescendantFonts [ 84 0 R ] /ToUnicode 83 0 R >>
 endobj
-86 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /TNFHFC+LMRoman10-Regular /FontDescriptor 82 0 R /W 81 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+84 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /TNFHFC+LMRoman10-Regular /FontDescriptor 80 0 R /W 79 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-58 0 obj
+56 0 obj
 << /Type /Pages  /Count 1 /Kids [ 9 0 R ] >>
 endobj
+85 0 obj
+<< /Names [ (Doc-Start) 42 0 R (footnote*.10) 46 0 R (footnote*.12) 48 0 R (footnote*.16) 52 0 R (footnote*.18) 54 0 R (page.1) 40 0 R ] /Limits [ (Doc-Start) (page.1) ] >>
+endobj
+86 0 obj
+<< /Dests 85 0 R >>
+endobj
 87 0 obj
-<< /Names [ (Doc-Start) 44 0 R (footnote*.10) 48 0 R (footnote*.12) 50 0 R (footnote*.17) 54 0 R (footnote*.19) 56 0 R (page.1) 42 0 R ] /Limits [ (Doc-Start) (page.1) ] >>
+<< /Type /Catalog /Pages 56 0 R /Names 86 0 R /MarkInfo 58 0 R/PageMode /UseOutlines/OpenAction <</S/GoTo /D [9 0 R /Fit] /SD [10 0 R/Fit]>>/Lang (en)/PageLabels <</Nums[0<</S/D>>]>>/Metadata 37 0 R/StructTreeRoot 5 0 R >>
 endobj
 88 0 obj
-<< /Dests 87 0 R >>
-endobj
-89 0 obj
-<< /Type /Catalog /Pages 58 0 R /Names 88 0 R /MarkInfo 60 0 R/PageMode /UseOutlines/OpenAction <</S/GoTo /D [9 0 R /Fit] /SD [10 0 R/Fit]>>/Lang (en)/PageLabels <</Nums[0<</S/D>>]>>/Metadata 39 0 R/StructTreeRoot 5 0 R >>
-endobj
-90 0 obj
 << /Producer (LuaTeX)/Creator <FEFF004C006100540065005800200077006900740068002000680079007000650072007200650066>/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 91
+0 89
 0000000002 65535 f 
 0000014615 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000018496 00000 n 
+0000018288 00000 n 
 0000014698 00000 n 
-0000015318 00000 n 
+0000015286 00000 n 
 0000000000 00000 f 
 0000013189 00000 n 
-0000015897 00000 n 
-0000015999 00000 n 
-0000016087 00000 n 
-0000016197 00000 n 
-0000016301 00000 n 
-0000016374 00000 n 
-0000016456 00000 n 
-0000016544 00000 n 
-0000016721 00000 n 
-0000016832 00000 n 
+0000015865 00000 n 
+0000015967 00000 n 
+0000016055 00000 n 
+0000016165 00000 n 
+0000016269 00000 n 
+0000016342 00000 n 
+0000016424 00000 n 
+0000016512 00000 n 
+0000016689 00000 n 
+0000016800 00000 n 
 0000013372 00000 n 
 0000000020 00000 n 
-0000016951 00000 n 
-0000017063 00000 n 
-0000017155 00000 n 
-0000017243 00000 n 
-0000017358 00000 n 
-0000017473 00000 n 
-0000017584 00000 n 
+0000016919 00000 n 
+0000017031 00000 n 
+0000017119 00000 n 
+0000017234 00000 n 
+0000017353 00000 n 
+0000017464 00000 n 
 0000013593 00000 n 
 0000000073 00000 n 
-0000017703 00000 n 
-0000017815 00000 n 
-0000017907 00000 n 
-0000017995 00000 n 
-0000018110 00000 n 
-0000018225 00000 n 
-0000018298 00000 n 
-0000018386 00000 n 
+0000017583 00000 n 
+0000017695 00000 n 
+0000017783 00000 n 
+0000017898 00000 n 
+0000018017 00000 n 
+0000018090 00000 n 
+0000018178 00000 n 
 0000000126 00000 n 
 0000014492 00000 n 
 0000011925 00000 n 
@@ -777,53 +769,53 @@ xref
 0000013870 00000 n 
 0000013922 00000 n 
 0000013983 00000 n 
-0000028268 00000 n 
-0000025382 00000 n 
+0000028060 00000 n 
+0000025174 00000 n 
 0000014036 00000 n 
 0000014097 00000 n 
 0000014150 00000 n 
 0000014211 00000 n 
-0000023078 00000 n 
-0000020778 00000 n 
+0000022870 00000 n 
+0000020570 00000 n 
 0000014264 00000 n 
 0000014325 00000 n 
 0000014378 00000 n 
 0000014439 00000 n 
-0000028622 00000 n 
+0000028414 00000 n 
 0000013338 00000 n 
 0000014662 00000 n 
 0000014822 00000 n 
-0000015281 00000 n 
-0000018598 00000 n 
-0000019768 00000 n 
-0000018652 00000 n 
-0000018727 00000 n 
-0000020003 00000 n 
-0000020931 00000 n 
-0000021130 00000 n 
-0000022081 00000 n 
-0000021172 00000 n 
-0000021237 00000 n 
-0000022317 00000 n 
-0000023231 00000 n 
-0000023430 00000 n 
-0000024385 00000 n 
-0000023472 00000 n 
-0000023537 00000 n 
-0000024621 00000 n 
-0000025535 00000 n 
-0000025734 00000 n 
-0000027196 00000 n 
-0000025832 00000 n 
-0000025905 00000 n 
-0000027432 00000 n 
-0000028422 00000 n 
-0000028683 00000 n 
-0000028872 00000 n 
-0000028908 00000 n 
-0000029147 00000 n 
+0000015249 00000 n 
+0000018390 00000 n 
+0000019560 00000 n 
+0000018444 00000 n 
+0000018519 00000 n 
+0000019795 00000 n 
+0000020723 00000 n 
+0000020922 00000 n 
+0000021873 00000 n 
+0000020964 00000 n 
+0000021029 00000 n 
+0000022109 00000 n 
+0000023023 00000 n 
+0000023222 00000 n 
+0000024177 00000 n 
+0000023264 00000 n 
+0000023329 00000 n 
+0000024413 00000 n 
+0000025327 00000 n 
+0000025526 00000 n 
+0000026988 00000 n 
+0000025624 00000 n 
+0000025697 00000 n 
+0000027224 00000 n 
+0000028214 00000 n 
+0000028475 00000 n 
+0000028664 00000 n 
+0000028700 00000 n 
+0000028939 00000 n 
 trailer
-<< /Size 91 /Root 89 0 R /Info 90 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 89 /Root 87 0 R /Info 88 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-29356
+29148
 %%EOF

--- a/required/latex-lab/testfiles-OR-luatex/test1.tpf
+++ b/required/latex-lab/testfiles-OR-luatex/test1.tpf
@@ -1,6 +1,6 @@
 %PDF-1.5
 %Ã’¡‘≈ÿ–ƒ∆
-20 0 obj
+19 0 obj
 << /Length 595 >>        
 stream
 /opacity1 gs
@@ -48,76 +48,73 @@ EMC
 EMC
 endstream
 endobj
-19 0 obj
-<< /Type /Page /Contents 20 0 R /Resources 18 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 25 0 R >>
-endobj
 18 0 obj
-<< /ExtGState 1 0 R /Font << /F15 21 0 R /F27 22 0 R /F37 23 0 R /F29 24 0 R >> /ProcSet [ /PDF /Text ] >>
+<< /Type /Page /Contents 19 0 R /Resources 17 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 24 0 R >>
+endobj
+17 0 obj
+<< /ExtGState 1 0 R /Font << /F15 20 0 R /F27 21 0 R /F37 22 0 R /F29 23 0 R >> /ProcSet [ /PDF /Text ] >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-26 0 obj
+25 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 11 0 R 12 0 R 17 0 R 16 0 R] 
+<< /Nums [0 [ 11 0 R 12 0 R 16 0 R 15 0 R] 
 ] >>
 endobj
-27 0 obj
-<< /Limits [(ID.002) (ID.010)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 15 0 R (ID.009) 16 0 R (ID.010) 17 0 R ] >>
+26 0 obj
+<< /Limits [(ID.02) (ID.09)]/Names [(ID.02) 9 0 R (ID.03) 10 0 R (ID.04) 11 0 R (ID.05) 12 0 R (ID.06) 13 0 R (ID.07) 14 0 R (ID.08) 15 0 R (ID.09) 16 0 R ] >>
 endobj
-28 0 obj
-<< /Kids [27 0 R] >>
+27 0 obj
+<< /Kids [26 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
 endobj
 9 0 obj
-<<  /Type /StructElem /S /Document /P 5 0 R /K 10 0 R /ID (ID.002) >>
+<<  /Type /StructElem /S /Document /P 5 0 R /K 10 0 R /ID (ID.02) >>
 endobj
 10 0 obj
-<<  /Type /StructElem /S /text-unit /P 9 0 R /K 11 0 R /ID (ID.003) >>
+<<  /Type /StructElem /S /text-unit /P 9 0 R /K 11 0 R /ID (ID.03) >>
 endobj
 11 0 obj
-<<  /Type /StructElem /S /text /P 10 0 R /K [<</Type /MCR /Pg 19 0 R /MCID 0>>  12 0 R  13 0 R ] /ID (ID.004) >>
+<<  /Type /StructElem /S /text /P 10 0 R /K [<</Type /MCR /Pg 18 0 R /MCID 0>>  12 0 R  13 0 R ] /ID (ID.04) >>
 endobj
 12 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 13 0 R ] /K <</Type /MCR /Pg 19 0 R /MCID 1>>  /ID (ID.005) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 13 0 R ] /K <</Type /MCR /Pg 18 0 R /MCID 1>>  /ID (ID.05) >>
 endobj
 13 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 12 0 R ] /K [14 0 R 15 0 R] /ID (ID.006) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 12 0 R ] /K [16 0 R 14 0 R] /ID (ID.06) >>
 endobj
 14 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 13 0 R /K 17 0 R /ID (ID.007) >>
+<<  /Type /StructElem /S /text-unit /P 13 0 R /K 15 0 R /ID (ID.07) >>
 endobj
 15 0 obj
-<<  /Type /StructElem /S /text-unit /P 13 0 R /K 16 0 R /ID (ID.008) >>
+<<  /Type /StructElem /S /text /P 14 0 R /K [  <</Type /MCR /Pg 18 0 R /MCID 3>>  ] /ID (ID.08) >>
 endobj
 16 0 obj
-<<  /Type /StructElem /S /text /P 15 0 R /K [  <</Type /MCR /Pg 19 0 R /MCID 3>>  ] /ID (ID.009) >>
-endobj
-17 0 obj
-<<  /Type /StructElem /S /NonStruct /P 14 0 R /K <</Type /MCR /Pg 19 0 R /MCID 2>>  /ID (ID.010) >>
+<<  /Type /StructElem /S /footnotelabel /P 13 0 R /K <</Type /MCR /Pg 18 0 R /MCID 2>>  /ID (ID.09) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 28 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
+<<  /Type /StructTreeRoot /IDTree 27 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
 endobj
-29 0 obj
+28 0 obj
 [ 35 [ 590 ] 72 [ 295 ] 109 [ 590 ] ]
 endobj
-31 0 obj
+30 0 obj
 << /Length 14 >>         
 [BINARY STREAM]
 endobj
-32 0 obj
+31 0 obj
 << /Subtype /CIDFontType0C /Length 794 >>        
 [BINARY STREAM]
 endobj
-30 0 obj
-<< /Type /FontDescriptor /FontName /IDQSZL+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 32 0 R /CIDSet 31 0 R >>
+29 0 obj
+<< /Type /FontDescriptor /FontName /IDQSZL+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 31 0 R /CIDSet 30 0 R >>
 endobj
-33 0 obj
+32 0 obj
 << /Length 715 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -155,27 +152,27 @@ end
 %%EOF
 endstream
 endobj
-24 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /IDQSZL+LMRoman8-Regular /DescendantFonts [ 34 0 R ] /ToUnicode 33 0 R >>
+23 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /IDQSZL+LMRoman8-Regular /DescendantFonts [ 33 0 R ] /ToUnicode 32 0 R >>
+endobj
+33 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /IDQSZL+LMRoman8-Regular /FontDescriptor 29 0 R /W 28 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 34 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /IDQSZL+LMRoman8-Regular /FontDescriptor 30 0 R /W 29 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-35 0 obj
 [ 82 [ 611 ] ]
 endobj
-37 0 obj
+36 0 obj
 << /Length 11 >>         
 [BINARY STREAM]
 endobj
-38 0 obj
+37 0 obj
 << /Subtype /CIDFontType0C /Length 569 >>        
 [BINARY STREAM]
 endobj
-36 0 obj
-<< /Type /FontDescriptor /FontName /JHITRX+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 38 0 R /CIDSet 37 0 R >>
+35 0 obj
+<< /Type /FontDescriptor /FontName /JHITRX+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 37 0 R /CIDSet 36 0 R >>
 endobj
-39 0 obj
+38 0 obj
 << /Length 687 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -211,27 +208,27 @@ end
 %%EOF
 endstream
 endobj
-23 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JHITRX+LMRoman6-Regular /DescendantFonts [ 40 0 R ] /ToUnicode 39 0 R >>
+22 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JHITRX+LMRoman6-Regular /DescendantFonts [ 39 0 R ] /ToUnicode 38 0 R >>
+endobj
+39 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JHITRX+LMRoman6-Regular /FontDescriptor 35 0 R /W 34 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 40 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JHITRX+LMRoman6-Regular /FontDescriptor 36 0 R /W 35 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-41 0 obj
 [ 82 [ 569 ] ]
 endobj
-43 0 obj
+42 0 obj
 << /Length 11 >>         
 [BINARY STREAM]
 endobj
-44 0 obj
+43 0 obj
 << /Subtype /CIDFontType0C /Length 566 >>        
 [BINARY STREAM]
 endobj
-42 0 obj
-<< /Type /FontDescriptor /FontName /JEFPUV+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 44 0 R /CIDSet 43 0 R >>
+41 0 obj
+<< /Type /FontDescriptor /FontName /JEFPUV+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 43 0 R /CIDSet 42 0 R >>
 endobj
-45 0 obj
+44 0 obj
 << /Length 687 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -267,27 +264,27 @@ end
 %%EOF
 endstream
 endobj
-22 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JEFPUV+LMRoman7-Regular /DescendantFonts [ 46 0 R ] /ToUnicode 45 0 R >>
+21 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JEFPUV+LMRoman7-Regular /DescendantFonts [ 45 0 R ] /ToUnicode 44 0 R >>
+endobj
+45 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JEFPUV+LMRoman7-Regular /FontDescriptor 41 0 R /W 40 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 46 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JEFPUV+LMRoman7-Regular /FontDescriptor 42 0 R /W 41 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-47 0 obj
 [ 28 [ 500 ] 35 [ 556 ] 43 [ 444 ] 82 [ 500 ] ]
 endobj
-49 0 obj
+48 0 obj
 << /Length 11 >>         
 [BINARY STREAM]
 endobj
-50 0 obj
+49 0 obj
 << /Subtype /CIDFontType0C /Length 955 >>        
 [BINARY STREAM]
 endobj
-48 0 obj
-<< /Type /FontDescriptor /FontName /NSMWQI+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 50 0 R /CIDSet 49 0 R >>
+47 0 obj
+<< /Type /FontDescriptor /FontName /NSMWQI+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 49 0 R /CIDSet 48 0 R >>
 endobj
-51 0 obj
+50 0 obj
 << /Length 734 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -326,80 +323,79 @@ end
 %%EOF
 endstream
 endobj
-21 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NSMWQI+LMRoman10-Regular /DescendantFonts [ 52 0 R ] /ToUnicode 51 0 R >>
+20 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NSMWQI+LMRoman10-Regular /DescendantFonts [ 51 0 R ] /ToUnicode 50 0 R >>
+endobj
+51 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NSMWQI+LMRoman10-Regular /FontDescriptor 47 0 R /W 46 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+endobj
+24 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 18 0 R ] >>
 endobj
 52 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NSMWQI+LMRoman10-Regular /FontDescriptor 48 0 R /W 47 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-25 0 obj
-<< /Type /Pages  /Count 1 /Kids [ 19 0 R ] >>
+<< /Type /Catalog /Pages 24 0 R /MarkInfo 25 0 R/Lang (en)/StructTreeRoot 5 0 R >>
 endobj
 53 0 obj
-<< /Type /Catalog /Pages 25 0 R /MarkInfo 26 0 R/Lang (en)/StructTreeRoot 5 0 R >>
-endobj
-54 0 obj
 << /Producer (LuaTeX)/Creator (TeX) /CreationDate (D:20160520090000Z) /ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 55
+0 54
 0000000002 65535 f 
 0000000933 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000002858 00000 n 
+0000002736 00000 n 
 0000001016 00000 n 
-0000001319 00000 n 
+0000001293 00000 n 
 0000000000 00000 f 
-0000001898 00000 n 
-0000001983 00000 n 
-0000002070 00000 n 
-0000002199 00000 n 
-0000002334 00000 n 
-0000002446 00000 n 
-0000002538 00000 n 
-0000002626 00000 n 
-0000002742 00000 n 
+0000001872 00000 n 
+0000001956 00000 n 
+0000002042 00000 n 
+0000002170 00000 n 
+0000002304 00000 n 
+0000002415 00000 n 
+0000002502 00000 n 
+0000002617 00000 n 
 0000000810 00000 n 
 0000000675 00000 n 
 0000000020 00000 n 
-0000011708 00000 n 
-0000009152 00000 n 
-0000007065 00000 n 
-0000004975 00000 n 
-0000012062 00000 n 
+0000011586 00000 n 
+0000009030 00000 n 
+0000006943 00000 n 
+0000004853 00000 n 
+0000011940 00000 n 
 0000000980 00000 n 
 0000001080 00000 n 
-0000001282 00000 n 
-0000002959 00000 n 
-0000003965 00000 n 
-0000003013 00000 n 
-0000003087 00000 n 
-0000004200 00000 n 
-0000005128 00000 n 
-0000005327 00000 n 
-0000006082 00000 n 
-0000005358 00000 n 
-0000005429 00000 n 
-0000006318 00000 n 
-0000007218 00000 n 
-0000007417 00000 n 
-0000008169 00000 n 
-0000007448 00000 n 
-0000007519 00000 n 
-0000008405 00000 n 
-0000009305 00000 n 
-0000009504 00000 n 
-0000010678 00000 n 
-0000009568 00000 n 
-0000009639 00000 n 
-0000010914 00000 n 
-0000011862 00000 n 
-0000012124 00000 n 
-0000012223 00000 n 
+0000001256 00000 n 
+0000002837 00000 n 
+0000003843 00000 n 
+0000002891 00000 n 
+0000002965 00000 n 
+0000004078 00000 n 
+0000005006 00000 n 
+0000005205 00000 n 
+0000005960 00000 n 
+0000005236 00000 n 
+0000005307 00000 n 
+0000006196 00000 n 
+0000007096 00000 n 
+0000007295 00000 n 
+0000008047 00000 n 
+0000007326 00000 n 
+0000007397 00000 n 
+0000008283 00000 n 
+0000009183 00000 n 
+0000009382 00000 n 
+0000010556 00000 n 
+0000009446 00000 n 
+0000009517 00000 n 
+0000010792 00000 n 
+0000011740 00000 n 
+0000012002 00000 n 
+0000012101 00000 n 
 trailer
-<< /Size 55 /Root 53 0 R /Info 54 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 54 /Root 52 0 R /Info 53 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-12357
+12235
 %%EOF

--- a/required/latex-lab/testfiles-OR-luatex/test10.tpf
+++ b/required/latex-lab/testfiles-OR-luatex/test10.tpf
@@ -6,10 +6,10 @@ endobj
 32 0 obj
 << /Type/OBJR/Obj 31 0 R/Pg 21 0 R >>
 endobj
-41 0 obj
-<< /Type/OBJR/Obj 40 0 R/Pg 21 0 R >>
+40 0 obj
+<< /Type/OBJR/Obj 39 0 R/Pg 21 0 R >>
 endobj
-43 0 obj
+42 0 obj
 << /Length 968 >>        
 stream
 /opacity1 gs
@@ -82,65 +82,65 @@ EMC
 endstream
 endobj
 21 0 obj
-<< /Type /Page /Contents 43 0 R /Resources 42 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 56 0 R /Annots 57 0 R >>
+<< /Type /Page /Contents 42 0 R /Resources 41 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 55 0 R /Annots 56 0 R >>
 endobj
-57 0 obj
-[ 27 0 R 31 0 R 40 0 R ]
+56 0 obj
+[ 27 0 R 31 0 R 39 0 R ]
 endobj
 27 0 obj
-<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 1  /Rect [ 167.641 656.13 174.1 666.478 ]/A  << /S /GoTo /D (footnote*.9) /SD 53 0 R >> >>
+<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 1  /Rect [ 167.641 656.13 174.1 666.478 ]/A  << /S /GoTo /D (footnote*.9) /SD 52 0 R >> >>
 endobj
 31 0 obj
-<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 2  /Rect [ 197.582 656.13 204.041 666.478 ]/A  << /S /GoTo /D (footnote*.7) /SD 51 0 R >> >>
+<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 2  /Rect [ 197.582 656.13 204.041 666.478 ]/A  << /S /GoTo /D (footnote*.7) /SD 50 0 R >> >>
 endobj
-40 0 obj
-<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 3  /Rect [ 223.06 656.13 229.518 666.478 ]/A  << /S /GoTo /D (footnote*.9) /SD 53 0 R >> >>
+39 0 obj
+<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 3  /Rect [ 223.06 656.13 229.518 666.478 ]/A  << /S /GoTo /D (footnote*.9) /SD 52 0 R >> >>
 endobj
-44 0 obj
+43 0 obj
 << /D [ 21 0 R /XYZ 132.768 705.06 null ] >>
 endobj
-45 0 obj
+44 0 obj
 [ 22 0 R /XYZ 132.768 705.06 null ]
 endobj
-46 0 obj
+45 0 obj
 << /D [ 21 0 R /XYZ 133.768 667.198 null ] >>
 endobj
-47 0 obj
+46 0 obj
 [ 22 0 R /XYZ 133.768 667.198 null ]
 endobj
-50 0 obj
+49 0 obj
 << /D [ 21 0 R /XYZ 133.768 650.946 null ] >>
+endobj
+50 0 obj
+[ 35 0 R /XYZ 133.768 650.946 null ]
 endobj
 51 0 obj
-[ 36 0 R /XYZ 133.768 650.946 null ]
-endobj
-52 0 obj
 << /D [ 21 0 R /XYZ 133.768 650.946 null ] >>
 endobj
-53 0 obj
-[ 36 0 R /XYZ 133.768 650.946 null ]
+52 0 obj
+[ 35 0 R /XYZ 133.768 650.946 null ]
 endobj
-42 0 obj
-<< /ExtGState 1 0 R /Font << /F15 48 0 R /F27 49 0 R /F37 54 0 R /F29 55 0 R >> >>
+41 0 obj
+<< /ExtGState 1 0 R /Font << /F15 47 0 R /F27 48 0 R /F37 53 0 R /F29 54 0 R >> >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-58 0 obj
+57 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 24 0 R 26 0 R 24 0 R 30 0 R 24 0 R 39 0 R 37 0 R 36 0 R] 
+<< /Nums [0 [ 24 0 R 26 0 R 24 0 R 30 0 R 24 0 R 38 0 R 36 0 R 35 0 R] 
 1 26 0 R
 2 30 0 R
-3 39 0 R
+3 38 0 R
 ] >>
 endobj
-59 0 obj
-<< /Limits [(ID.002) (ID.015)]/Names [(ID.002) 22 0 R (ID.003) 23 0 R (ID.004) 24 0 R (ID.005) 25 0 R (ID.006) 26 0 R (ID.007) 29 0 R (ID.008) 30 0 R (ID.009) 33 0 R (ID.010) 34 0 R (ID.011) 35 0 R (ID.012) 36 0 R (ID.013) 37 0 R (ID.014) 38 0 R (ID.015) 39 0 R ] >>
+58 0 obj
+<< /Limits [(ID.002) (ID.014)]/Names [(ID.002) 22 0 R (ID.003) 23 0 R (ID.004) 24 0 R (ID.005) 25 0 R (ID.006) 26 0 R (ID.007) 29 0 R (ID.008) 30 0 R (ID.009) 33 0 R (ID.010) 34 0 R (ID.011) 35 0 R (ID.012) 36 0 R (ID.013) 37 0 R (ID.014) 38 0 R ] >>
 endobj
-60 0 obj
-<< /Kids [59 0 R] >>
+59 0 obj
+<< /Kids [58 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
@@ -179,7 +179,7 @@ endobj
 <<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 22 0 R /K 24 0 R /ID (ID.003) >>
 endobj
 24 0 obj
-<<  /Type /StructElem /S /text /NS 15 0 R  /P 23 0 R /K [<</Type /MCR /Pg 21 0 R /MCID 0>>  25 0 R <</Type /MCR /Pg 21 0 R /MCID 2>>  29 0 R  33 0 R <</Type /MCR /Pg 21 0 R /MCID 4>>  38 0 R ] /ID (ID.004) >>
+<<  /Type /StructElem /S /text /NS 15 0 R  /P 23 0 R /K [<</Type /MCR /Pg 21 0 R /MCID 0>>  25 0 R <</Type /MCR /Pg 21 0 R /MCID 2>>  29 0 R  33 0 R <</Type /MCR /Pg 21 0 R /MCID 4>>  37 0 R ] /ID (ID.004) >>
 endobj
 25 0 obj
 <<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 24 0 R /Ref [ 33 0 R ] /K [ 26 0 R ] /ID (ID.005) >>
@@ -194,40 +194,37 @@ endobj
 <<  /Type /StructElem /S /Link /NS 11 0 R  /P 29 0 R /K [<</Type /MCR /Pg 21 0 R /MCID 3>>  32 0 R] /ID (ID.008) >>
 endobj
 33 0 obj
-<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 24 0 R /Ref [ 29 0 R 25 0 R 38 0 R ] /K [34 0 R 35 0 R] /ID (ID.009) >>
+<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 24 0 R /Ref [ 29 0 R 25 0 R 37 0 R ] /K [36 0 R 34 0 R] /ID (ID.009) >>
 endobj
 34 0 obj
-<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 33 0 R /K 37 0 R /ID (ID.010) >>
+<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 33 0 R /K 35 0 R /ID (ID.010) >>
 endobj
 35 0 obj
-<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 33 0 R /K 36 0 R /ID (ID.011) >>
+<<  /Type /StructElem /S /text /NS 15 0 R  /P 34 0 R /K [  <</Type /MCR /Pg 21 0 R /MCID 7>>  ] /ID (ID.011) >>
 endobj
 36 0 obj
-<<  /Type /StructElem /S /text /NS 15 0 R  /P 35 0 R /K [  <</Type /MCR /Pg 21 0 R /MCID 7>>  ] /ID (ID.012) >>
+<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 33 0 R /K <</Type /MCR /Pg 21 0 R /MCID 6>>  /ID (ID.012) >>
 endobj
 37 0 obj
-<<  /Type /StructElem /S /NonStruct /NS 11 0 R  /P 34 0 R /K <</Type /MCR /Pg 21 0 R /MCID 6>>  /ID (ID.013) >>
+<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 24 0 R /Ref [ 33 0 R ] /K [ 38 0 R ] /ID (ID.013) >>
 endobj
 38 0 obj
-<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 24 0 R /Ref [ 33 0 R ] /K [ 39 0 R ] /ID (ID.014) >>
-endobj
-39 0 obj
-<<  /Type /StructElem /S /Link /NS 11 0 R  /P 38 0 R /K [<</Type /MCR /Pg 21 0 R /MCID 5>>  41 0 R] /ID (ID.015) >>
+<<  /Type /StructElem /S /Link /NS 11 0 R  /P 37 0 R /K [<</Type /MCR /Pg 21 0 R /MCID 5>>  40 0 R] /ID (ID.014) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 60 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 22 0 R >>
+<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 59 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 22 0 R >>
 endobj
-61 0 obj
+60 0 obj
 [ 28 [ 531 ] 35 [ 590 ] 43 [ 472 ] ]
 endobj
-63 0 obj
+62 0 obj
 << /Subtype /CIDFontType0C /Length 878 >>        
 [BINARY STREAM]
 endobj
-62 0 obj
-<< /Type /FontDescriptor /FontName /NMCSWH+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 63 0 R >>
+61 0 obj
+<< /Type /FontDescriptor /FontName /NMCSWH+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 62 0 R >>
 endobj
-64 0 obj
+63 0 obj
 << /Length 715 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -265,23 +262,23 @@ end
 %%EOF
 endstream
 endobj
-55 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NMCSWH+LMRoman8-Regular /DescendantFonts [ 65 0 R ] /ToUnicode 64 0 R >>
+54 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NMCSWH+LMRoman8-Regular /DescendantFonts [ 64 0 R ] /ToUnicode 63 0 R >>
+endobj
+64 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NMCSWH+LMRoman8-Regular /FontDescriptor 61 0 R /W 60 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 65 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NMCSWH+LMRoman8-Regular /FontDescriptor 62 0 R /W 61 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-66 0 obj
 [ 82 [ 611 ] ]
 endobj
-68 0 obj
+67 0 obj
 << /Subtype /CIDFontType0C /Length 569 >>        
 [BINARY STREAM]
 endobj
-67 0 obj
-<< /Type /FontDescriptor /FontName /JHITRX+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 68 0 R >>
+66 0 obj
+<< /Type /FontDescriptor /FontName /JHITRX+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 67 0 R >>
 endobj
-69 0 obj
+68 0 obj
 << /Length 687 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -317,23 +314,23 @@ end
 %%EOF
 endstream
 endobj
-54 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JHITRX+LMRoman6-Regular /DescendantFonts [ 70 0 R ] /ToUnicode 69 0 R >>
+53 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JHITRX+LMRoman6-Regular /DescendantFonts [ 69 0 R ] /ToUnicode 68 0 R >>
+endobj
+69 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JHITRX+LMRoman6-Regular /FontDescriptor 66 0 R /W 65 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 70 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JHITRX+LMRoman6-Regular /FontDescriptor 67 0 R /W 66 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-71 0 obj
 [ 82 [ 569 ] ]
 endobj
-73 0 obj
+72 0 obj
 << /Subtype /CIDFontType0C /Length 566 >>        
 [BINARY STREAM]
 endobj
-72 0 obj
-<< /Type /FontDescriptor /FontName /JEFPUV+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 73 0 R >>
+71 0 obj
+<< /Type /FontDescriptor /FontName /JEFPUV+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 72 0 R >>
 endobj
-74 0 obj
+73 0 obj
 << /Length 687 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -369,23 +366,23 @@ end
 %%EOF
 endstream
 endobj
-49 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JEFPUV+LMRoman7-Regular /DescendantFonts [ 75 0 R ] /ToUnicode 74 0 R >>
+48 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JEFPUV+LMRoman7-Regular /DescendantFonts [ 74 0 R ] /ToUnicode 73 0 R >>
+endobj
+74 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JEFPUV+LMRoman7-Regular /FontDescriptor 71 0 R /W 70 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 75 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JEFPUV+LMRoman7-Regular /FontDescriptor 72 0 R /W 71 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-76 0 obj
 [ 28 [ 500 ] 35 [ 556 ] 43 [ 444 ] 82 [ 500 ] 103 [ 333 ] ]
 endobj
-78 0 obj
+77 0 obj
 << /Subtype /CIDFontType0C /Length 962 >>        
 [BINARY STREAM]
 endobj
-77 0 obj
-<< /Type /FontDescriptor /FontName /MKEZUM+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 78 0 R >>
+76 0 obj
+<< /Type /FontDescriptor /FontName /MKEZUM+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 77 0 R >>
 endobj
-79 0 obj
+78 0 obj
 << /Length 748 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -425,69 +422,68 @@ end
 %%EOF
 endstream
 endobj
-48 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /MKEZUM+LMRoman10-Regular /DescendantFonts [ 80 0 R ] /ToUnicode 79 0 R >>
+47 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /MKEZUM+LMRoman10-Regular /DescendantFonts [ 79 0 R ] /ToUnicode 78 0 R >>
 endobj
-80 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /MKEZUM+LMRoman10-Regular /FontDescriptor 77 0 R /W 76 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+79 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /MKEZUM+LMRoman10-Regular /FontDescriptor 76 0 R /W 75 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-56 0 obj
+55 0 obj
 << /Type /Pages  /Count 1 /Kids [ 21 0 R ] >>
 endobj
+80 0 obj
+<< /Names [ (Doc-Start) 45 0 R (footnote*.7) 49 0 R (footnote*.9) 51 0 R (page.1) 43 0 R ] /Limits [ (Doc-Start) (page.1) ] >>
+endobj
 81 0 obj
-<< /Names [ (Doc-Start) 46 0 R (footnote*.7) 50 0 R (footnote*.9) 52 0 R (page.1) 44 0 R ] /Limits [ (Doc-Start) (page.1) ] >>
+<< /Dests 80 0 R >>
 endobj
 82 0 obj
-<< /Dests 81 0 R >>
+<< /Type /Catalog /Pages 55 0 R /Names 81 0 R /MarkInfo 57 0 R/PageMode /UseOutlines/OpenAction <</S/GoTo /D [21 0 R /Fit] /SD [22 0 R/Fit]>>/Lang (en)/PageLabels <</Nums[0<</S/D>>]>>/StructTreeRoot 5 0 R >>
 endobj
 83 0 obj
-<< /Type /Catalog /Pages 56 0 R /Names 82 0 R /MarkInfo 58 0 R/PageMode /UseOutlines/OpenAction <</S/GoTo /D [21 0 R /Fit] /SD [22 0 R/Fit]>>/Lang (en)/PageLabels <</Nums[0<</S/D>>]>>/StructTreeRoot 5 0 R >>
-endobj
-84 0 obj
 << /Producer (LuaTeX)/Creator <FEFF004C006100540065005800200077006900740068002000680079007000650072007200650066> /CreationDate (D:20160520090000Z) /ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 85
+0 84
 0000000002 65535 f 
 0000002612 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000010 00000 f 
-0000006933 00000 n 
+0000006817 00000 n 
 0000002695 00000 n 
-0000003134 00000 n 
-0000005086 00000 n 
-0000003713 00000 n 
+0000003118 00000 n 
+0000005070 00000 n 
+0000003697 00000 n 
 0000000012 00000 f 
-0000003781 00000 n 
+0000003765 00000 n 
 0000000014 00000 f 
-0000003851 00000 n 
+0000003835 00000 n 
 0000000020 00000 f 
-0000004614 00000 n 
-0000003932 00000 n 
-0000004892 00000 n 
-0000004721 00000 n 
-0000004999 00000 n 
+0000004598 00000 n 
+0000003916 00000 n 
+0000004876 00000 n 
+0000004705 00000 n 
+0000004983 00000 n 
 0000000000 00000 f 
 0000001210 00000 n 
-0000005147 00000 n 
-0000005245 00000 n 
-0000005345 00000 n 
-0000005570 00000 n 
-0000005693 00000 n 
+0000005131 00000 n 
+0000005229 00000 n 
+0000005329 00000 n 
+0000005554 00000 n 
+0000005677 00000 n 
 0000001401 00000 n 
 0000000020 00000 n 
-0000005825 00000 n 
-0000005948 00000 n 
+0000005809 00000 n 
+0000005932 00000 n 
 0000001618 00000 n 
 0000000074 00000 n 
-0000006080 00000 n 
-0000006218 00000 n 
-0000006322 00000 n 
-0000006422 00000 n 
-0000006550 00000 n 
-0000006678 00000 n 
-0000006801 00000 n 
+0000006064 00000 n 
+0000006202 00000 n 
+0000006302 00000 n 
+0000006430 00000 n 
+0000006562 00000 n 
+0000006685 00000 n 
 0000001837 00000 n 
 0000000128 00000 n 
 0000002513 00000 n 
@@ -496,45 +492,45 @@ xref
 0000002116 00000 n 
 0000002168 00000 n 
 0000002230 00000 n 
-0000015571 00000 n 
-0000013068 00000 n 
+0000015455 00000 n 
+0000012952 00000 n 
 0000002283 00000 n 
 0000002345 00000 n 
 0000002398 00000 n 
 0000002460 00000 n 
-0000011067 00000 n 
-0000009063 00000 n 
-0000015925 00000 n 
+0000010951 00000 n 
+0000008947 00000 n 
+0000015809 00000 n 
 0000001360 00000 n 
 0000002659 00000 n 
 0000002814 00000 n 
-0000003097 00000 n 
-0000007053 00000 n 
-0000008068 00000 n 
-0000007106 00000 n 
-0000008288 00000 n 
-0000009216 00000 n 
-0000009415 00000 n 
-0000010099 00000 n 
-0000009446 00000 n 
-0000010320 00000 n 
-0000011220 00000 n 
-0000011419 00000 n 
-0000012100 00000 n 
-0000011450 00000 n 
-0000012321 00000 n 
-0000013221 00000 n 
-0000013420 00000 n 
-0000014542 00000 n 
-0000013496 00000 n 
-0000014763 00000 n 
-0000015725 00000 n 
-0000015987 00000 n 
-0000016130 00000 n 
-0000016166 00000 n 
-0000016390 00000 n 
+0000003081 00000 n 
+0000006937 00000 n 
+0000007952 00000 n 
+0000006990 00000 n 
+0000008172 00000 n 
+0000009100 00000 n 
+0000009299 00000 n 
+0000009983 00000 n 
+0000009330 00000 n 
+0000010204 00000 n 
+0000011104 00000 n 
+0000011303 00000 n 
+0000011984 00000 n 
+0000011334 00000 n 
+0000012205 00000 n 
+0000013105 00000 n 
+0000013304 00000 n 
+0000014426 00000 n 
+0000013380 00000 n 
+0000014647 00000 n 
+0000015609 00000 n 
+0000015871 00000 n 
+0000016014 00000 n 
+0000016050 00000 n 
+0000016274 00000 n 
 trailer
-<< /Size 85 /Root 83 0 R /Info 84 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 84 /Root 82 0 R /Info 83 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-16601
+16485
 %%EOF

--- a/required/latex-lab/testfiles-OR-luatex/test11-series.tpf
+++ b/required/latex-lab/testfiles-OR-luatex/test11-series.tpf
@@ -1,6 +1,6 @@
 %PDF-1.5
 %Ã’¡‘≈ÿ–ƒ∆
-26 0 obj
+24 0 obj
 << /Length 854 >>        
 stream
 /opacity1 gs
@@ -66,27 +66,27 @@ EMC
 EMC
 endstream
 endobj
-25 0 obj
-<< /Type /Page /Contents 26 0 R /Resources 24 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 31 0 R >>
+23 0 obj
+<< /Type /Page /Contents 24 0 R /Resources 22 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 29 0 R >>
 endobj
-24 0 obj
-<< /ExtGState 1 0 R /Font << /F15 27 0 R /F27 28 0 R /F37 29 0 R /F29 30 0 R >> /ProcSet [ /PDF /Text ] >>
+22 0 obj
+<< /ExtGState 1 0 R /Font << /F15 25 0 R /F27 26 0 R /F37 27 0 R /F29 28 0 R >> /ProcSet [ /PDF /Text ] >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-32 0 obj
+30 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 11 0 R 12 0 R 13 0 R 18 0 R 17 0 R 23 0 R 22 0 R] 
+<< /Nums [0 [ 11 0 R 12 0 R 13 0 R 17 0 R 16 0 R 21 0 R 20 0 R] 
 ] >>
 endobj
-33 0 obj
-<< /Limits [(ID.002) (ID.016)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 15 0 R (ID.009) 16 0 R (ID.010) 17 0 R (ID.011) 18 0 R (ID.012) 19 0 R (ID.013) 20 0 R (ID.014) 21 0 R (ID.015) 22 0 R (ID.016) 23 0 R ] >>
+31 0 obj
+<< /Limits [(ID.002) (ID.014)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 15 0 R (ID.009) 16 0 R (ID.010) 17 0 R (ID.011) 18 0 R (ID.012) 19 0 R (ID.013) 20 0 R (ID.014) 21 0 R ] >>
 endobj
-34 0 obj
-<< /Kids [33 0 R] >>
+32 0 obj
+<< /Kids [31 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
@@ -98,62 +98,56 @@ endobj
 <<  /Type /StructElem /S /text-unit /P 9 0 R /K 11 0 R /ID (ID.003) >>
 endobj
 11 0 obj
-<<  /Type /StructElem /S /text /P 10 0 R /K [<</Type /MCR /Pg 25 0 R /MCID 0>>  12 0 R  13 0 R  14 0 R  19 0 R ] /ID (ID.004) >>
+<<  /Type /StructElem /S /text /P 10 0 R /K [<</Type /MCR /Pg 23 0 R /MCID 0>>  12 0 R  13 0 R  14 0 R  18 0 R ] /ID (ID.004) >>
 endobj
 12 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 19 0 R ] /K <</Type /MCR /Pg 25 0 R /MCID 1>>  /ID (ID.005) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 18 0 R ] /K <</Type /MCR /Pg 23 0 R /MCID 1>>  /ID (ID.005) >>
 endobj
 13 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 14 0 R ] /K <</Type /MCR /Pg 25 0 R /MCID 2>>  /ID (ID.006) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 14 0 R ] /K <</Type /MCR /Pg 23 0 R /MCID 2>>  /ID (ID.006) >>
 endobj
 14 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 13 0 R ] /K [15 0 R 16 0 R] /ID (ID.007) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 13 0 R ] /K [17 0 R 15 0 R] /ID (ID.007) >>
 endobj
 15 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 14 0 R /K 18 0 R /ID (ID.008) >>
+<<  /Type /StructElem /S /text-unit /P 14 0 R /K 16 0 R /ID (ID.008) >>
 endobj
 16 0 obj
-<<  /Type /StructElem /S /text-unit /P 14 0 R /K 17 0 R /ID (ID.009) >>
+<<  /Type /StructElem /S /text /P 15 0 R /K [  <</Type /MCR /Pg 23 0 R /MCID 4>>  ] /ID (ID.009) >>
 endobj
 17 0 obj
-<<  /Type /StructElem /S /text /P 16 0 R /K [  <</Type /MCR /Pg 25 0 R /MCID 4>>  ] /ID (ID.010) >>
+<<  /Type /StructElem /S /footnotelabel /P 14 0 R /K <</Type /MCR /Pg 23 0 R /MCID 3>>  /ID (ID.010) >>
 endobj
 18 0 obj
-<<  /Type /StructElem /S /NonStruct /P 15 0 R /K <</Type /MCR /Pg 25 0 R /MCID 3>>  /ID (ID.011) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 12 0 R ] /K [21 0 R 19 0 R] /ID (ID.011) >>
 endobj
 19 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 12 0 R ] /K [20 0 R 21 0 R] /ID (ID.012) >>
+<<  /Type /StructElem /S /text-unit /P 18 0 R /K 20 0 R /ID (ID.012) >>
 endobj
 20 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 19 0 R /K 23 0 R /ID (ID.013) >>
+<<  /Type /StructElem /S /text /P 19 0 R /K [  <</Type /MCR /Pg 23 0 R /MCID 6>>  ] /ID (ID.013) >>
 endobj
 21 0 obj
-<<  /Type /StructElem /S /text-unit /P 19 0 R /K 22 0 R /ID (ID.014) >>
-endobj
-22 0 obj
-<<  /Type /StructElem /S /text /P 21 0 R /K [  <</Type /MCR /Pg 25 0 R /MCID 6>>  ] /ID (ID.015) >>
-endobj
-23 0 obj
-<<  /Type /StructElem /S /NonStruct /P 20 0 R /K <</Type /MCR /Pg 25 0 R /MCID 5>>  /ID (ID.016) >>
+<<  /Type /StructElem /S /footnotelabel /P 18 0 R /K <</Type /MCR /Pg 23 0 R /MCID 5>>  /ID (ID.014) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 34 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
+<<  /Type /StructTreeRoot /IDTree 32 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
 endobj
-35 0 obj
+33 0 obj
 [ 50 [ 472 ] 82 [ 531 ] 105 [ 413 ] 107 [ 531 ] 116 [ 561 ] ]
 endobj
-37 0 obj
+35 0 obj
 << /Length 15 >>         
 [BINARY STREAM]
 endobj
-38 0 obj
+36 0 obj
 << /Subtype /CIDFontType0C /Length 1079 >>       
 [BINARY STREAM]
 endobj
-36 0 obj
-<< /Type /FontDescriptor /FontName /IVUQBN+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 38 0 R /CIDSet 37 0 R >>
+34 0 obj
+<< /Type /FontDescriptor /FontName /IVUQBN+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 36 0 R /CIDSet 35 0 R >>
 endobj
-39 0 obj
+37 0 obj
 << /Length 743 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -193,27 +187,27 @@ end
 %%EOF
 endstream
 endobj
-30 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /IVUQBN+LMRoman8-Regular /DescendantFonts [ 40 0 R ] /ToUnicode 39 0 R >>
+28 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /IVUQBN+LMRoman8-Regular /DescendantFonts [ 38 0 R ] /ToUnicode 37 0 R >>
 endobj
-40 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /IVUQBN+LMRoman8-Regular /FontDescriptor 36 0 R /W 35 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+38 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /IVUQBN+LMRoman8-Regular /FontDescriptor 34 0 R /W 33 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-41 0 obj
+39 0 obj
 [ 82 [ 611 ] ]
 endobj
-43 0 obj
+41 0 obj
 << /Length 11 >>         
 [BINARY STREAM]
 endobj
-44 0 obj
+42 0 obj
 << /Subtype /CIDFontType0C /Length 569 >>        
 [BINARY STREAM]
 endobj
-42 0 obj
-<< /Type /FontDescriptor /FontName /JHITRX+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 44 0 R /CIDSet 43 0 R >>
+40 0 obj
+<< /Type /FontDescriptor /FontName /JHITRX+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 42 0 R /CIDSet 41 0 R >>
 endobj
-45 0 obj
+43 0 obj
 << /Length 687 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -249,27 +243,27 @@ end
 %%EOF
 endstream
 endobj
-29 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JHITRX+LMRoman6-Regular /DescendantFonts [ 46 0 R ] /ToUnicode 45 0 R >>
+27 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JHITRX+LMRoman6-Regular /DescendantFonts [ 44 0 R ] /ToUnicode 43 0 R >>
 endobj
-46 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JHITRX+LMRoman6-Regular /FontDescriptor 42 0 R /W 41 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+44 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JHITRX+LMRoman6-Regular /FontDescriptor 40 0 R /W 39 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-47 0 obj
+45 0 obj
 [ 82 [ 569 ] ]
 endobj
-49 0 obj
+47 0 obj
 << /Length 11 >>         
 [BINARY STREAM]
 endobj
-50 0 obj
+48 0 obj
 << /Subtype /CIDFontType0C /Length 566 >>        
 [BINARY STREAM]
 endobj
-48 0 obj
-<< /Type /FontDescriptor /FontName /JEFPUV+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 50 0 R /CIDSet 49 0 R >>
+46 0 obj
+<< /Type /FontDescriptor /FontName /JEFPUV+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 48 0 R /CIDSet 47 0 R >>
 endobj
-51 0 obj
+49 0 obj
 << /Length 687 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -305,27 +299,27 @@ end
 %%EOF
 endstream
 endobj
-28 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JEFPUV+LMRoman7-Regular /DescendantFonts [ 52 0 R ] /ToUnicode 51 0 R >>
+26 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JEFPUV+LMRoman7-Regular /DescendantFonts [ 50 0 R ] /ToUnicode 49 0 R >>
 endobj
-52 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JEFPUV+LMRoman7-Regular /FontDescriptor 48 0 R /W 47 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+50 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JEFPUV+LMRoman7-Regular /FontDescriptor 46 0 R /W 45 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-53 0 obj
+51 0 obj
 [ 28 [ 500 ] 82 [ 500 ] ]
 endobj
-55 0 obj
+53 0 obj
 << /Length 11 >>         
 [BINARY STREAM]
 endobj
-56 0 obj
+54 0 obj
 << /Subtype /CIDFontType0C /Length 721 >>        
 [BINARY STREAM]
 endobj
-54 0 obj
-<< /Type /FontDescriptor /FontName /KKHHMF+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 56 0 R /CIDSet 55 0 R >>
+52 0 obj
+<< /Type /FontDescriptor /FontName /KKHHMF+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 54 0 R /CIDSet 53 0 R >>
 endobj
-57 0 obj
+55 0 obj
 << /Length 706 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -362,86 +356,84 @@ end
 %%EOF
 endstream
 endobj
-27 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /KKHHMF+LMRoman10-Regular /DescendantFonts [ 58 0 R ] /ToUnicode 57 0 R >>
+25 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /KKHHMF+LMRoman10-Regular /DescendantFonts [ 56 0 R ] /ToUnicode 55 0 R >>
+endobj
+56 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /KKHHMF+LMRoman10-Regular /FontDescriptor 52 0 R /W 51 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+endobj
+29 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 23 0 R ] >>
+endobj
+57 0 obj
+<< /Type /Catalog /Pages 29 0 R /MarkInfo 30 0 R/Lang (en)/StructTreeRoot 5 0 R >>
 endobj
 58 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /KKHHMF+LMRoman10-Regular /FontDescriptor 54 0 R /W 53 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-31 0 obj
-<< /Type /Pages  /Count 1 /Kids [ 25 0 R ] >>
-endobj
-59 0 obj
-<< /Type /Catalog /Pages 31 0 R /MarkInfo 32 0 R/Lang (en)/StructTreeRoot 5 0 R >>
-endobj
-60 0 obj
 << /Producer (LuaTeX)/Creator (TeX) /CreationDate (D:20160520090000Z) /ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 61
+0 59
 0000000002 65535 f 
 0000001192 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000003909 00000 n 
+0000003701 00000 n 
 0000001275 00000 n 
-0000001695 00000 n 
+0000001663 00000 n 
 0000000000 00000 f 
-0000002274 00000 n 
-0000002359 00000 n 
-0000002446 00000 n 
-0000002591 00000 n 
-0000002726 00000 n 
-0000002861 00000 n 
-0000002973 00000 n 
-0000003065 00000 n 
-0000003153 00000 n 
-0000003269 00000 n 
-0000003385 00000 n 
-0000003497 00000 n 
-0000003589 00000 n 
-0000003677 00000 n 
-0000003793 00000 n 
+0000002242 00000 n 
+0000002327 00000 n 
+0000002414 00000 n 
+0000002559 00000 n 
+0000002694 00000 n 
+0000002829 00000 n 
+0000002941 00000 n 
+0000003029 00000 n 
+0000003145 00000 n 
+0000003265 00000 n 
+0000003377 00000 n 
+0000003465 00000 n 
+0000003581 00000 n 
 0000001069 00000 n 
 0000000934 00000 n 
 0000000020 00000 n 
-0000012813 00000 n 
-0000010541 00000 n 
-0000008454 00000 n 
-0000006364 00000 n 
-0000013167 00000 n 
+0000012605 00000 n 
+0000010333 00000 n 
+0000008246 00000 n 
+0000006156 00000 n 
+0000012959 00000 n 
 0000001239 00000 n 
 0000001360 00000 n 
-0000001658 00000 n 
-0000004010 00000 n 
-0000005326 00000 n 
-0000004088 00000 n 
-0000004163 00000 n 
-0000005561 00000 n 
-0000006517 00000 n 
-0000006716 00000 n 
-0000007471 00000 n 
-0000006747 00000 n 
-0000006818 00000 n 
-0000007707 00000 n 
-0000008607 00000 n 
-0000008806 00000 n 
-0000009558 00000 n 
-0000008837 00000 n 
-0000008908 00000 n 
-0000009794 00000 n 
-0000010694 00000 n 
-0000010893 00000 n 
-0000011811 00000 n 
-0000010935 00000 n 
-0000011006 00000 n 
-0000012047 00000 n 
-0000012967 00000 n 
-0000013229 00000 n 
-0000013328 00000 n 
+0000001626 00000 n 
+0000003802 00000 n 
+0000005118 00000 n 
+0000003880 00000 n 
+0000003955 00000 n 
+0000005353 00000 n 
+0000006309 00000 n 
+0000006508 00000 n 
+0000007263 00000 n 
+0000006539 00000 n 
+0000006610 00000 n 
+0000007499 00000 n 
+0000008399 00000 n 
+0000008598 00000 n 
+0000009350 00000 n 
+0000008629 00000 n 
+0000008700 00000 n 
+0000009586 00000 n 
+0000010486 00000 n 
+0000010685 00000 n 
+0000011603 00000 n 
+0000010727 00000 n 
+0000010798 00000 n 
+0000011839 00000 n 
+0000012759 00000 n 
+0000013021 00000 n 
+0000013120 00000 n 
 trailer
-<< /Size 61 /Root 59 0 R /Info 60 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 59 /Root 57 0 R /Info 58 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-13462
+13254
 %%EOF

--- a/required/latex-lab/testfiles-OR-luatex/test2.tpf
+++ b/required/latex-lab/testfiles-OR-luatex/test2.tpf
@@ -1,6 +1,6 @@
 %PDF-1.5
 %Ã’¡‘≈ÿ–ƒ∆
-21 0 obj
+20 0 obj
 << /Length 1261 >>       
 stream
 /opacity1 gs
@@ -92,27 +92,27 @@ EMC
 EMC
 endstream
 endobj
-20 0 obj
-<< /Type /Page /Contents 21 0 R /Resources 19 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 27 0 R >>
-endobj
 19 0 obj
-<< /ExtGState 1 0 R /Font << /F18 22 0 R /F15 23 0 R /F29 24 0 R /F39 25 0 R /F31 26 0 R >> /ProcSet [ /PDF /Text ] >>
+<< /Type /Page /Contents 20 0 R /Resources 18 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 26 0 R >>
+endobj
+18 0 obj
+<< /ExtGState 1 0 R /Font << /F18 21 0 R /F15 22 0 R /F29 23 0 R /F39 24 0 R /F31 25 0 R >> /ProcSet [ /PDF /Text ] >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-28 0 obj
+27 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 11 0 R 12 0 R 11 0 R 13 0 R 18 0 R 17 0 R] 
+<< /Nums [0 [ 11 0 R 12 0 R 11 0 R 13 0 R 17 0 R 16 0 R] 
 ] >>
 endobj
-29 0 obj
-<< /Limits [(ID.002) (ID.011)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 15 0 R (ID.009) 16 0 R (ID.010) 17 0 R (ID.011) 18 0 R ] >>
+28 0 obj
+<< /Limits [(ID.002) (ID.010)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 15 0 R (ID.009) 16 0 R (ID.010) 17 0 R ] >>
 endobj
-30 0 obj
-<< /Kids [29 0 R] >>
+29 0 obj
+<< /Kids [28 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
@@ -124,47 +124,44 @@ endobj
 <<  /Type /StructElem /S /text-unit /P 9 0 R /K 11 0 R /ID (ID.003) >>
 endobj
 11 0 obj
-<<  /Type /StructElem /S /text /P 10 0 R /K [<</Type /MCR /Pg 20 0 R /MCID 0>>  12 0 R <</Type /MCR /Pg 20 0 R /MCID 2>>  13 0 R  14 0 R ] /ID (ID.004) >>
+<<  /Type /StructElem /S /text /P 10 0 R /K [<</Type /MCR /Pg 19 0 R /MCID 0>>  12 0 R <</Type /MCR /Pg 19 0 R /MCID 2>>  13 0 R  14 0 R ] /ID (ID.004) >>
 endobj
 12 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 14 0 R ] /K <</Type /MCR /Pg 20 0 R /MCID 1>>  /ID (ID.005) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 14 0 R ] /K <</Type /MCR /Pg 19 0 R /MCID 1>>  /ID (ID.005) >>
 endobj
 13 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 14 0 R ] /K <</Type /MCR /Pg 20 0 R /MCID 3>>  /ID (ID.006) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 14 0 R ] /K <</Type /MCR /Pg 19 0 R /MCID 3>>  /ID (ID.006) >>
 endobj
 14 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 12 0 R 13 0 R ] /K [15 0 R 16 0 R] /ID (ID.007) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 12 0 R 13 0 R ] /K [17 0 R 15 0 R] /ID (ID.007) >>
 endobj
 15 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 14 0 R /K 18 0 R /ID (ID.008) >>
+<<  /Type /StructElem /S /text-unit /P 14 0 R /K 16 0 R /ID (ID.008) >>
 endobj
 16 0 obj
-<<  /Type /StructElem /S /text-unit /P 14 0 R /K 17 0 R /ID (ID.009) >>
+<<  /Type /StructElem /S /text /P 15 0 R /K [  <</Type /MCR /Pg 19 0 R /MCID 5>>  ] /ID (ID.009) >>
 endobj
 17 0 obj
-<<  /Type /StructElem /S /text /P 16 0 R /K [  <</Type /MCR /Pg 20 0 R /MCID 5>>  ] /ID (ID.010) >>
-endobj
-18 0 obj
-<<  /Type /StructElem /S /NonStruct /P 15 0 R /K <</Type /MCR /Pg 20 0 R /MCID 4>>  /ID (ID.011) >>
+<<  /Type /StructElem /S /footnotelabel /P 14 0 R /K <</Type /MCR /Pg 19 0 R /MCID 4>>  /ID (ID.010) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 30 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
+<<  /Type /StructTreeRoot /IDTree 29 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
 endobj
-31 0 obj
+30 0 obj
 [ 28 [ 531 ] 35 [ 590 ] 43 [ 472 ] ]
 endobj
-33 0 obj
+32 0 obj
 << /Length 6 >>          
 [BINARY STREAM]
 endobj
-34 0 obj
+33 0 obj
 << /Subtype /CIDFontType0C /Length 878 >>        
 [BINARY STREAM]
 endobj
-32 0 obj
-<< /Type /FontDescriptor /FontName /NMCSWH+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 34 0 R /CIDSet 33 0 R >>
+31 0 obj
+<< /Type /FontDescriptor /FontName /NMCSWH+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 33 0 R /CIDSet 32 0 R >>
 endobj
-35 0 obj
+34 0 obj
 << /Length 715 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -202,27 +199,27 @@ end
 %%EOF
 endstream
 endobj
-26 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NMCSWH+LMRoman8-Regular /DescendantFonts [ 36 0 R ] /ToUnicode 35 0 R >>
+25 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NMCSWH+LMRoman8-Regular /DescendantFonts [ 35 0 R ] /ToUnicode 34 0 R >>
+endobj
+35 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NMCSWH+LMRoman8-Regular /FontDescriptor 31 0 R /W 30 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 36 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NMCSWH+LMRoman8-Regular /FontDescriptor 32 0 R /W 31 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-37 0 obj
 [ 82 [ 611 ] ]
 endobj
-39 0 obj
+38 0 obj
 << /Length 11 >>         
 [BINARY STREAM]
 endobj
-40 0 obj
+39 0 obj
 << /Subtype /CIDFontType0C /Length 569 >>        
 [BINARY STREAM]
 endobj
-38 0 obj
-<< /Type /FontDescriptor /FontName /JHITRX+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 40 0 R /CIDSet 39 0 R >>
+37 0 obj
+<< /Type /FontDescriptor /FontName /JHITRX+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 39 0 R /CIDSet 38 0 R >>
 endobj
-41 0 obj
+40 0 obj
 << /Length 687 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -258,27 +255,27 @@ end
 %%EOF
 endstream
 endobj
-25 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JHITRX+LMRoman6-Regular /DescendantFonts [ 42 0 R ] /ToUnicode 41 0 R >>
+24 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JHITRX+LMRoman6-Regular /DescendantFonts [ 41 0 R ] /ToUnicode 40 0 R >>
+endobj
+41 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JHITRX+LMRoman6-Regular /FontDescriptor 37 0 R /W 36 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 42 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JHITRX+LMRoman6-Regular /FontDescriptor 38 0 R /W 37 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-43 0 obj
 [ 82 [ 569 ] ]
 endobj
-45 0 obj
+44 0 obj
 << /Length 11 >>         
 [BINARY STREAM]
 endobj
-46 0 obj
+45 0 obj
 << /Subtype /CIDFontType0C /Length 566 >>        
 [BINARY STREAM]
 endobj
-44 0 obj
-<< /Type /FontDescriptor /FontName /JEFPUV+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 46 0 R /CIDSet 45 0 R >>
+43 0 obj
+<< /Type /FontDescriptor /FontName /JEFPUV+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 45 0 R /CIDSet 44 0 R >>
 endobj
-47 0 obj
+46 0 obj
 << /Length 687 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -314,27 +311,27 @@ end
 %%EOF
 endstream
 endobj
-24 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JEFPUV+LMRoman7-Regular /DescendantFonts [ 48 0 R ] /ToUnicode 47 0 R >>
+23 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JEFPUV+LMRoman7-Regular /DescendantFonts [ 47 0 R ] /ToUnicode 46 0 R >>
+endobj
+47 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JEFPUV+LMRoman7-Regular /FontDescriptor 43 0 R /W 42 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 48 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JEFPUV+LMRoman7-Regular /FontDescriptor 44 0 R /W 43 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-49 0 obj
 [ 28 [ 500 ] 35 [ 556 ] 43 [ 444 ] 82 [ 500 ] 103 [ 333 ] ]
 endobj
-51 0 obj
+50 0 obj
 << /Length 13 >>         
 [BINARY STREAM]
 endobj
-52 0 obj
+51 0 obj
 << /Subtype /CIDFontType0C /Length 962 >>        
 [BINARY STREAM]
 endobj
-50 0 obj
-<< /Type /FontDescriptor /FontName /MKEZUM+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 52 0 R /CIDSet 51 0 R >>
+49 0 obj
+<< /Type /FontDescriptor /FontName /MKEZUM+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 51 0 R /CIDSet 50 0 R >>
 endobj
-53 0 obj
+52 0 obj
 << /Length 748 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -374,27 +371,27 @@ end
 %%EOF
 endstream
 endobj
-23 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /MKEZUM+LMRoman10-Regular /DescendantFonts [ 54 0 R ] /ToUnicode 53 0 R >>
+22 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /MKEZUM+LMRoman10-Regular /DescendantFonts [ 53 0 R ] /ToUnicode 52 0 R >>
+endobj
+53 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /MKEZUM+LMRoman10-Regular /FontDescriptor 49 0 R /W 48 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 54 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /MKEZUM+LMRoman10-Regular /FontDescriptor 50 0 R /W 49 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-55 0 obj
 [ 82 [ 681 ] 103 [ 472 ] 107 [ 681 ] ]
 endobj
-57 0 obj
+56 0 obj
 << /Length 14 >>         
 [BINARY STREAM]
 endobj
-58 0 obj
+57 0 obj
 << /Subtype /CIDFontType0C /Length 706 >>        
 [BINARY STREAM]
 endobj
-56 0 obj
-<< /Type /FontDescriptor /FontName /CMQYBH+LMRoman5-Regular /Flags 4 /FontBBox [ -566 -303 1772 1126 ] /Ascent 1126 /CapHeight 683 /Descent -303 /ItalicAngle 0 /StemV 134 /XHeight 431 /FontFile3 58 0 R /CIDSet 57 0 R >>
+55 0 obj
+<< /Type /FontDescriptor /FontName /CMQYBH+LMRoman5-Regular /Flags 4 /FontBBox [ -566 -303 1772 1126 ] /Ascent 1126 /CapHeight 683 /Descent -303 /ItalicAngle 0 /StemV 134 /XHeight 431 /FontFile3 57 0 R /CIDSet 56 0 R >>
 endobj
-59 0 obj
+58 0 obj
 << /Length 715 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -432,88 +429,87 @@ end
 %%EOF
 endstream
 endobj
-22 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /CMQYBH+LMRoman5-Regular /DescendantFonts [ 60 0 R ] /ToUnicode 59 0 R >>
+21 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /CMQYBH+LMRoman5-Regular /DescendantFonts [ 59 0 R ] /ToUnicode 58 0 R >>
+endobj
+59 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /CMQYBH+LMRoman5-Regular /FontDescriptor 55 0 R /W 54 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+endobj
+26 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 19 0 R ] >>
 endobj
 60 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /CMQYBH+LMRoman5-Regular /FontDescriptor 56 0 R /W 55 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-27 0 obj
-<< /Type /Pages  /Count 1 /Kids [ 20 0 R ] >>
+<< /Type /Catalog /Pages 26 0 R /MarkInfo 27 0 R/Lang (en)/StructTreeRoot 5 0 R >>
 endobj
 61 0 obj
-<< /Type /Catalog /Pages 27 0 R /MarkInfo 28 0 R/Lang (en)/StructTreeRoot 5 0 R >>
-endobj
-62 0 obj
 << /Producer (LuaTeX)/Creator (TeX) /CreationDate (D:20160520090000Z) /ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 63
+0 62
 0000000002 65535 f 
 0000001611 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000003750 00000 n 
+0000003646 00000 n 
 0000001694 00000 n 
-0000002027 00000 n 
+0000002011 00000 n 
 0000000000 00000 f 
-0000002606 00000 n 
-0000002691 00000 n 
-0000002778 00000 n 
-0000002949 00000 n 
-0000003084 00000 n 
-0000003219 00000 n 
-0000003338 00000 n 
-0000003430 00000 n 
-0000003518 00000 n 
-0000003634 00000 n 
+0000002590 00000 n 
+0000002675 00000 n 
+0000002762 00000 n 
+0000002933 00000 n 
+0000003068 00000 n 
+0000003203 00000 n 
+0000003322 00000 n 
+0000003410 00000 n 
+0000003526 00000 n 
 0000001476 00000 n 
 0000001341 00000 n 
 0000000020 00000 n 
-0000014994 00000 n 
-0000012710 00000 n 
-0000010119 00000 n 
-0000008032 00000 n 
-0000005942 00000 n 
-0000015346 00000 n 
+0000014890 00000 n 
+0000012606 00000 n 
+0000010015 00000 n 
+0000007928 00000 n 
+0000005838 00000 n 
+0000015242 00000 n 
 0000001658 00000 n 
 0000001772 00000 n 
-0000001990 00000 n 
-0000003851 00000 n 
-0000004932 00000 n 
-0000003904 00000 n 
-0000003970 00000 n 
-0000005167 00000 n 
-0000006095 00000 n 
-0000006294 00000 n 
-0000007049 00000 n 
-0000006325 00000 n 
-0000006396 00000 n 
-0000007285 00000 n 
-0000008185 00000 n 
-0000008384 00000 n 
-0000009136 00000 n 
-0000008415 00000 n 
-0000008486 00000 n 
-0000009372 00000 n 
-0000010272 00000 n 
-0000010471 00000 n 
-0000011666 00000 n 
-0000010547 00000 n 
-0000010620 00000 n 
-0000011902 00000 n 
-0000012864 00000 n 
-0000013064 00000 n 
-0000013983 00000 n 
-0000013119 00000 n 
-0000013193 00000 n 
-0000014219 00000 n 
-0000015147 00000 n 
-0000015408 00000 n 
-0000015507 00000 n 
+0000001974 00000 n 
+0000003747 00000 n 
+0000004828 00000 n 
+0000003800 00000 n 
+0000003866 00000 n 
+0000005063 00000 n 
+0000005991 00000 n 
+0000006190 00000 n 
+0000006945 00000 n 
+0000006221 00000 n 
+0000006292 00000 n 
+0000007181 00000 n 
+0000008081 00000 n 
+0000008280 00000 n 
+0000009032 00000 n 
+0000008311 00000 n 
+0000008382 00000 n 
+0000009268 00000 n 
+0000010168 00000 n 
+0000010367 00000 n 
+0000011562 00000 n 
+0000010443 00000 n 
+0000010516 00000 n 
+0000011798 00000 n 
+0000012760 00000 n 
+0000012960 00000 n 
+0000013879 00000 n 
+0000013015 00000 n 
+0000013089 00000 n 
+0000014115 00000 n 
+0000015043 00000 n 
+0000015304 00000 n 
+0000015403 00000 n 
 trailer
-<< /Size 63 /Root 61 0 R /Info 62 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 62 /Root 60 0 R /Info 61 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-15641
+15537
 %%EOF

--- a/required/latex-lab/testfiles-OR-luatex/test3.tpf
+++ b/required/latex-lab/testfiles-OR-luatex/test3.tpf
@@ -1,6 +1,6 @@
 %PDF-1.5
 %Ã’¡‘≈ÿ–ƒ∆
-21 0 obj
+20 0 obj
 << /Length 1261 >>       
 stream
 /opacity1 gs
@@ -92,27 +92,27 @@ EMC
 EMC
 endstream
 endobj
-20 0 obj
-<< /Type /Page /Contents 21 0 R /Resources 19 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 27 0 R >>
-endobj
 19 0 obj
-<< /ExtGState 1 0 R /Font << /F18 22 0 R /F15 23 0 R /F29 24 0 R /F39 25 0 R /F31 26 0 R >> /ProcSet [ /PDF /Text ] >>
+<< /Type /Page /Contents 20 0 R /Resources 18 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 26 0 R >>
+endobj
+18 0 obj
+<< /ExtGState 1 0 R /Font << /F18 21 0 R /F15 22 0 R /F29 23 0 R /F39 24 0 R /F31 25 0 R >> /ProcSet [ /PDF /Text ] >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-28 0 obj
+27 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 11 0 R 12 0 R 11 0 R 13 0 R 18 0 R 17 0 R] 
+<< /Nums [0 [ 11 0 R 12 0 R 11 0 R 13 0 R 17 0 R 16 0 R] 
 ] >>
 endobj
-29 0 obj
-<< /Limits [(ID.002) (ID.011)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 15 0 R (ID.009) 16 0 R (ID.010) 17 0 R (ID.011) 18 0 R ] >>
+28 0 obj
+<< /Limits [(ID.002) (ID.010)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 15 0 R (ID.009) 16 0 R (ID.010) 17 0 R ] >>
 endobj
-30 0 obj
-<< /Kids [29 0 R] >>
+29 0 obj
+<< /Kids [28 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
@@ -124,47 +124,44 @@ endobj
 <<  /Type /StructElem /S /text-unit /P 9 0 R /K 11 0 R /ID (ID.003) >>
 endobj
 11 0 obj
-<<  /Type /StructElem /S /text /P 10 0 R /K [<</Type /MCR /Pg 20 0 R /MCID 0>>  12 0 R <</Type /MCR /Pg 20 0 R /MCID 2>>  13 0 R  14 0 R ] /ID (ID.004) >>
+<<  /Type /StructElem /S /text /P 10 0 R /K [<</Type /MCR /Pg 19 0 R /MCID 0>>  12 0 R <</Type /MCR /Pg 19 0 R /MCID 2>>  13 0 R  14 0 R ] /ID (ID.004) >>
 endobj
 12 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 14 0 R ] /K <</Type /MCR /Pg 20 0 R /MCID 1>>  /ID (ID.005) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 14 0 R ] /K <</Type /MCR /Pg 19 0 R /MCID 1>>  /ID (ID.005) >>
 endobj
 13 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 14 0 R ] /K <</Type /MCR /Pg 20 0 R /MCID 3>>  /ID (ID.006) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 14 0 R ] /K <</Type /MCR /Pg 19 0 R /MCID 3>>  /ID (ID.006) >>
 endobj
 14 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 12 0 R 13 0 R ] /K [15 0 R 16 0 R] /ID (ID.007) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 12 0 R 13 0 R ] /K [17 0 R 15 0 R] /ID (ID.007) >>
 endobj
 15 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 14 0 R /K 18 0 R /ID (ID.008) >>
+<<  /Type /StructElem /S /text-unit /P 14 0 R /K 16 0 R /ID (ID.008) >>
 endobj
 16 0 obj
-<<  /Type /StructElem /S /text-unit /P 14 0 R /K 17 0 R /ID (ID.009) >>
+<<  /Type /StructElem /S /text /P 15 0 R /K [  <</Type /MCR /Pg 19 0 R /MCID 5>>  ] /ID (ID.009) >>
 endobj
 17 0 obj
-<<  /Type /StructElem /S /text /P 16 0 R /K [  <</Type /MCR /Pg 20 0 R /MCID 5>>  ] /ID (ID.010) >>
-endobj
-18 0 obj
-<<  /Type /StructElem /S /NonStruct /P 15 0 R /K <</Type /MCR /Pg 20 0 R /MCID 4>>  /ID (ID.011) >>
+<<  /Type /StructElem /S /footnotelabel /P 14 0 R /K <</Type /MCR /Pg 19 0 R /MCID 4>>  /ID (ID.010) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 30 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
+<<  /Type /StructTreeRoot /IDTree 29 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
 endobj
-31 0 obj
+30 0 obj
 [ 28 [ 531 ] 35 [ 590 ] 43 [ 472 ] ]
 endobj
-33 0 obj
+32 0 obj
 << /Length 6 >>          
 [BINARY STREAM]
 endobj
-34 0 obj
+33 0 obj
 << /Subtype /CIDFontType0C /Length 878 >>        
 [BINARY STREAM]
 endobj
-32 0 obj
-<< /Type /FontDescriptor /FontName /NMCSWH+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 34 0 R /CIDSet 33 0 R >>
+31 0 obj
+<< /Type /FontDescriptor /FontName /NMCSWH+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 33 0 R /CIDSet 32 0 R >>
 endobj
-35 0 obj
+34 0 obj
 << /Length 715 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -202,27 +199,27 @@ end
 %%EOF
 endstream
 endobj
-26 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NMCSWH+LMRoman8-Regular /DescendantFonts [ 36 0 R ] /ToUnicode 35 0 R >>
+25 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NMCSWH+LMRoman8-Regular /DescendantFonts [ 35 0 R ] /ToUnicode 34 0 R >>
+endobj
+35 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NMCSWH+LMRoman8-Regular /FontDescriptor 31 0 R /W 30 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 36 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NMCSWH+LMRoman8-Regular /FontDescriptor 32 0 R /W 31 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-37 0 obj
 [ 82 [ 611 ] ]
 endobj
-39 0 obj
+38 0 obj
 << /Length 11 >>         
 [BINARY STREAM]
 endobj
-40 0 obj
+39 0 obj
 << /Subtype /CIDFontType0C /Length 569 >>        
 [BINARY STREAM]
 endobj
-38 0 obj
-<< /Type /FontDescriptor /FontName /JHITRX+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 40 0 R /CIDSet 39 0 R >>
+37 0 obj
+<< /Type /FontDescriptor /FontName /JHITRX+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 39 0 R /CIDSet 38 0 R >>
 endobj
-41 0 obj
+40 0 obj
 << /Length 687 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -258,27 +255,27 @@ end
 %%EOF
 endstream
 endobj
-25 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JHITRX+LMRoman6-Regular /DescendantFonts [ 42 0 R ] /ToUnicode 41 0 R >>
+24 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JHITRX+LMRoman6-Regular /DescendantFonts [ 41 0 R ] /ToUnicode 40 0 R >>
+endobj
+41 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JHITRX+LMRoman6-Regular /FontDescriptor 37 0 R /W 36 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 42 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JHITRX+LMRoman6-Regular /FontDescriptor 38 0 R /W 37 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-43 0 obj
 [ 82 [ 569 ] ]
 endobj
-45 0 obj
+44 0 obj
 << /Length 11 >>         
 [BINARY STREAM]
 endobj
-46 0 obj
+45 0 obj
 << /Subtype /CIDFontType0C /Length 566 >>        
 [BINARY STREAM]
 endobj
-44 0 obj
-<< /Type /FontDescriptor /FontName /JEFPUV+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 46 0 R /CIDSet 45 0 R >>
+43 0 obj
+<< /Type /FontDescriptor /FontName /JEFPUV+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 45 0 R /CIDSet 44 0 R >>
 endobj
-47 0 obj
+46 0 obj
 << /Length 687 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -314,27 +311,27 @@ end
 %%EOF
 endstream
 endobj
-24 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JEFPUV+LMRoman7-Regular /DescendantFonts [ 48 0 R ] /ToUnicode 47 0 R >>
+23 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JEFPUV+LMRoman7-Regular /DescendantFonts [ 47 0 R ] /ToUnicode 46 0 R >>
+endobj
+47 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JEFPUV+LMRoman7-Regular /FontDescriptor 43 0 R /W 42 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 48 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JEFPUV+LMRoman7-Regular /FontDescriptor 44 0 R /W 43 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-49 0 obj
 [ 28 [ 500 ] 35 [ 556 ] 43 [ 444 ] 82 [ 500 ] 103 [ 333 ] ]
 endobj
-51 0 obj
+50 0 obj
 << /Length 13 >>         
 [BINARY STREAM]
 endobj
-52 0 obj
+51 0 obj
 << /Subtype /CIDFontType0C /Length 962 >>        
 [BINARY STREAM]
 endobj
-50 0 obj
-<< /Type /FontDescriptor /FontName /MKEZUM+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 52 0 R /CIDSet 51 0 R >>
+49 0 obj
+<< /Type /FontDescriptor /FontName /MKEZUM+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 51 0 R /CIDSet 50 0 R >>
 endobj
-53 0 obj
+52 0 obj
 << /Length 748 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -374,27 +371,27 @@ end
 %%EOF
 endstream
 endobj
-23 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /MKEZUM+LMRoman10-Regular /DescendantFonts [ 54 0 R ] /ToUnicode 53 0 R >>
+22 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /MKEZUM+LMRoman10-Regular /DescendantFonts [ 53 0 R ] /ToUnicode 52 0 R >>
+endobj
+53 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /MKEZUM+LMRoman10-Regular /FontDescriptor 49 0 R /W 48 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 54 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /MKEZUM+LMRoman10-Regular /FontDescriptor 50 0 R /W 49 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-55 0 obj
 [ 82 [ 681 ] 103 [ 472 ] 107 [ 681 ] ]
 endobj
-57 0 obj
+56 0 obj
 << /Length 14 >>         
 [BINARY STREAM]
 endobj
-58 0 obj
+57 0 obj
 << /Subtype /CIDFontType0C /Length 706 >>        
 [BINARY STREAM]
 endobj
-56 0 obj
-<< /Type /FontDescriptor /FontName /CMQYBH+LMRoman5-Regular /Flags 4 /FontBBox [ -566 -303 1772 1126 ] /Ascent 1126 /CapHeight 683 /Descent -303 /ItalicAngle 0 /StemV 134 /XHeight 431 /FontFile3 58 0 R /CIDSet 57 0 R >>
+55 0 obj
+<< /Type /FontDescriptor /FontName /CMQYBH+LMRoman5-Regular /Flags 4 /FontBBox [ -566 -303 1772 1126 ] /Ascent 1126 /CapHeight 683 /Descent -303 /ItalicAngle 0 /StemV 134 /XHeight 431 /FontFile3 57 0 R /CIDSet 56 0 R >>
 endobj
-59 0 obj
+58 0 obj
 << /Length 715 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -432,88 +429,87 @@ end
 %%EOF
 endstream
 endobj
-22 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /CMQYBH+LMRoman5-Regular /DescendantFonts [ 60 0 R ] /ToUnicode 59 0 R >>
+21 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /CMQYBH+LMRoman5-Regular /DescendantFonts [ 59 0 R ] /ToUnicode 58 0 R >>
+endobj
+59 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /CMQYBH+LMRoman5-Regular /FontDescriptor 55 0 R /W 54 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+endobj
+26 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 19 0 R ] >>
 endobj
 60 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /CMQYBH+LMRoman5-Regular /FontDescriptor 56 0 R /W 55 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-27 0 obj
-<< /Type /Pages  /Count 1 /Kids [ 20 0 R ] >>
+<< /Type /Catalog /Pages 26 0 R /MarkInfo 27 0 R/Lang (en)/StructTreeRoot 5 0 R >>
 endobj
 61 0 obj
-<< /Type /Catalog /Pages 27 0 R /MarkInfo 28 0 R/Lang (en)/StructTreeRoot 5 0 R >>
-endobj
-62 0 obj
 << /Producer (LuaTeX)/Creator (TeX) /CreationDate (D:20160520090000Z) /ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 63
+0 62
 0000000002 65535 f 
 0000001611 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000003750 00000 n 
+0000003646 00000 n 
 0000001694 00000 n 
-0000002027 00000 n 
+0000002011 00000 n 
 0000000000 00000 f 
-0000002606 00000 n 
-0000002691 00000 n 
-0000002778 00000 n 
-0000002949 00000 n 
-0000003084 00000 n 
-0000003219 00000 n 
-0000003338 00000 n 
-0000003430 00000 n 
-0000003518 00000 n 
-0000003634 00000 n 
+0000002590 00000 n 
+0000002675 00000 n 
+0000002762 00000 n 
+0000002933 00000 n 
+0000003068 00000 n 
+0000003203 00000 n 
+0000003322 00000 n 
+0000003410 00000 n 
+0000003526 00000 n 
 0000001476 00000 n 
 0000001341 00000 n 
 0000000020 00000 n 
-0000014994 00000 n 
-0000012710 00000 n 
-0000010119 00000 n 
-0000008032 00000 n 
-0000005942 00000 n 
-0000015346 00000 n 
+0000014890 00000 n 
+0000012606 00000 n 
+0000010015 00000 n 
+0000007928 00000 n 
+0000005838 00000 n 
+0000015242 00000 n 
 0000001658 00000 n 
 0000001772 00000 n 
-0000001990 00000 n 
-0000003851 00000 n 
-0000004932 00000 n 
-0000003904 00000 n 
-0000003970 00000 n 
-0000005167 00000 n 
-0000006095 00000 n 
-0000006294 00000 n 
-0000007049 00000 n 
-0000006325 00000 n 
-0000006396 00000 n 
-0000007285 00000 n 
-0000008185 00000 n 
-0000008384 00000 n 
-0000009136 00000 n 
-0000008415 00000 n 
-0000008486 00000 n 
-0000009372 00000 n 
-0000010272 00000 n 
-0000010471 00000 n 
-0000011666 00000 n 
-0000010547 00000 n 
-0000010620 00000 n 
-0000011902 00000 n 
-0000012864 00000 n 
-0000013064 00000 n 
-0000013983 00000 n 
-0000013119 00000 n 
-0000013193 00000 n 
-0000014219 00000 n 
-0000015147 00000 n 
-0000015408 00000 n 
-0000015507 00000 n 
+0000001974 00000 n 
+0000003747 00000 n 
+0000004828 00000 n 
+0000003800 00000 n 
+0000003866 00000 n 
+0000005063 00000 n 
+0000005991 00000 n 
+0000006190 00000 n 
+0000006945 00000 n 
+0000006221 00000 n 
+0000006292 00000 n 
+0000007181 00000 n 
+0000008081 00000 n 
+0000008280 00000 n 
+0000009032 00000 n 
+0000008311 00000 n 
+0000008382 00000 n 
+0000009268 00000 n 
+0000010168 00000 n 
+0000010367 00000 n 
+0000011562 00000 n 
+0000010443 00000 n 
+0000010516 00000 n 
+0000011798 00000 n 
+0000012760 00000 n 
+0000012960 00000 n 
+0000013879 00000 n 
+0000013015 00000 n 
+0000013089 00000 n 
+0000014115 00000 n 
+0000015043 00000 n 
+0000015304 00000 n 
+0000015403 00000 n 
 trailer
-<< /Size 63 /Root 61 0 R /Info 62 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 62 /Root 60 0 R /Info 61 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-15641
+15537
 %%EOF

--- a/required/latex-lab/testfiles-OR-luatex/test4.tpf
+++ b/required/latex-lab/testfiles-OR-luatex/test4.tpf
@@ -1,6 +1,6 @@
 %PDF-2.0
 %Ã’¡‘≈ÿ–ƒ∆
-33 0 obj
+32 0 obj
 << /Length 1261 >>       
 stream
 /opacity1 gs
@@ -92,27 +92,27 @@ EMC
 EMC
 endstream
 endobj
-32 0 obj
-<< /Type /Page /Contents 33 0 R /Resources 31 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 39 0 R >>
-endobj
 31 0 obj
-<< /ExtGState 1 0 R /Font << /F18 34 0 R /F15 35 0 R /F29 36 0 R /F39 37 0 R /F31 38 0 R >> >>
+<< /Type /Page /Contents 32 0 R /Resources 30 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 38 0 R >>
+endobj
+30 0 obj
+<< /ExtGState 1 0 R /Font << /F18 33 0 R /F15 34 0 R /F29 35 0 R /F39 36 0 R /F31 37 0 R >> >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-40 0 obj
+39 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 23 0 R 24 0 R 23 0 R 25 0 R 30 0 R 29 0 R] 
+<< /Nums [0 [ 23 0 R 24 0 R 23 0 R 25 0 R 29 0 R 28 0 R] 
 ] >>
 endobj
-41 0 obj
-<< /Limits [(ID.002) (ID.011)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 27 0 R (ID.009) 28 0 R (ID.010) 29 0 R (ID.011) 30 0 R ] >>
+40 0 obj
+<< /Limits [(ID.002) (ID.010)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 27 0 R (ID.009) 28 0 R (ID.010) 29 0 R ] >>
 endobj
-42 0 obj
-<< /Kids [41 0 R] >>
+41 0 obj
+<< /Kids [40 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
@@ -151,43 +151,40 @@ endobj
 <<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 21 0 R /K 23 0 R /ID (ID.003) >>
 endobj
 23 0 obj
-<<  /Type /StructElem /S /text /NS 15 0 R  /P 22 0 R /K [<</Type /MCR /Pg 32 0 R /MCID 0>>  24 0 R <</Type /MCR /Pg 32 0 R /MCID 2>>  25 0 R  26 0 R ] /ID (ID.004) >>
+<<  /Type /StructElem /S /text /NS 15 0 R  /P 22 0 R /K [<</Type /MCR /Pg 31 0 R /MCID 0>>  24 0 R <</Type /MCR /Pg 31 0 R /MCID 2>>  25 0 R  26 0 R ] /ID (ID.004) >>
 endobj
 24 0 obj
-<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 32 0 R /MCID 1>>  /ID (ID.005) >>
+<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 31 0 R /MCID 1>>  /ID (ID.005) >>
 endobj
 25 0 obj
-<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 32 0 R /MCID 3>>  /ID (ID.006) >>
+<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 31 0 R /MCID 3>>  /ID (ID.006) >>
 endobj
 26 0 obj
-<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 23 0 R /Ref [ 24 0 R 25 0 R ] /K [27 0 R 28 0 R] /ID (ID.007) >>
+<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 23 0 R /Ref [ 24 0 R 25 0 R ] /K [29 0 R 27 0 R] /ID (ID.007) >>
 endobj
 27 0 obj
-<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 26 0 R /K 30 0 R /ID (ID.008) >>
+<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 26 0 R /K 28 0 R /ID (ID.008) >>
 endobj
 28 0 obj
-<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 26 0 R /K 29 0 R /ID (ID.009) >>
+<<  /Type /StructElem /S /text /NS 15 0 R  /P 27 0 R /K [  <</Type /MCR /Pg 31 0 R /MCID 5>>  ] /ID (ID.009) >>
 endobj
 29 0 obj
-<<  /Type /StructElem /S /text /NS 15 0 R  /P 28 0 R /K [  <</Type /MCR /Pg 32 0 R /MCID 5>>  ] /ID (ID.010) >>
-endobj
-30 0 obj
-<<  /Type /StructElem /S /NonStruct /NS 11 0 R  /P 27 0 R /K <</Type /MCR /Pg 32 0 R /MCID 4>>  /ID (ID.011) >>
+<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 26 0 R /K <</Type /MCR /Pg 31 0 R /MCID 4>>  /ID (ID.010) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 42 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
+<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 41 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
 endobj
-43 0 obj
+42 0 obj
 [ 28 [ 531 ] 35 [ 590 ] 43 [ 472 ] ]
 endobj
-45 0 obj
+44 0 obj
 << /Subtype /CIDFontType0C /Length 878 >>        
 [BINARY STREAM]
 endobj
-44 0 obj
-<< /Type /FontDescriptor /FontName /NMCSWH+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 45 0 R >>
+43 0 obj
+<< /Type /FontDescriptor /FontName /NMCSWH+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 44 0 R >>
 endobj
-46 0 obj
+45 0 obj
 << /Length 715 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -225,23 +222,23 @@ end
 %%EOF
 endstream
 endobj
-38 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NMCSWH+LMRoman8-Regular /DescendantFonts [ 47 0 R ] /ToUnicode 46 0 R >>
+37 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NMCSWH+LMRoman8-Regular /DescendantFonts [ 46 0 R ] /ToUnicode 45 0 R >>
+endobj
+46 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NMCSWH+LMRoman8-Regular /FontDescriptor 43 0 R /W 42 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 47 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NMCSWH+LMRoman8-Regular /FontDescriptor 44 0 R /W 43 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-48 0 obj
 [ 82 [ 611 ] ]
 endobj
-50 0 obj
+49 0 obj
 << /Subtype /CIDFontType0C /Length 569 >>        
 [BINARY STREAM]
 endobj
-49 0 obj
-<< /Type /FontDescriptor /FontName /JHITRX+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 50 0 R >>
+48 0 obj
+<< /Type /FontDescriptor /FontName /JHITRX+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 49 0 R >>
 endobj
-51 0 obj
+50 0 obj
 << /Length 687 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -277,23 +274,23 @@ end
 %%EOF
 endstream
 endobj
-37 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JHITRX+LMRoman6-Regular /DescendantFonts [ 52 0 R ] /ToUnicode 51 0 R >>
+36 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JHITRX+LMRoman6-Regular /DescendantFonts [ 51 0 R ] /ToUnicode 50 0 R >>
+endobj
+51 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JHITRX+LMRoman6-Regular /FontDescriptor 48 0 R /W 47 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 52 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JHITRX+LMRoman6-Regular /FontDescriptor 49 0 R /W 48 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-53 0 obj
 [ 82 [ 569 ] ]
 endobj
-55 0 obj
+54 0 obj
 << /Subtype /CIDFontType0C /Length 566 >>        
 [BINARY STREAM]
 endobj
-54 0 obj
-<< /Type /FontDescriptor /FontName /JEFPUV+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 55 0 R >>
+53 0 obj
+<< /Type /FontDescriptor /FontName /JEFPUV+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 54 0 R >>
 endobj
-56 0 obj
+55 0 obj
 << /Length 687 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -329,23 +326,23 @@ end
 %%EOF
 endstream
 endobj
-36 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JEFPUV+LMRoman7-Regular /DescendantFonts [ 57 0 R ] /ToUnicode 56 0 R >>
+35 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JEFPUV+LMRoman7-Regular /DescendantFonts [ 56 0 R ] /ToUnicode 55 0 R >>
+endobj
+56 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JEFPUV+LMRoman7-Regular /FontDescriptor 53 0 R /W 52 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 57 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JEFPUV+LMRoman7-Regular /FontDescriptor 54 0 R /W 53 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-58 0 obj
 [ 28 [ 500 ] 35 [ 556 ] 43 [ 444 ] 82 [ 500 ] 103 [ 333 ] ]
 endobj
-60 0 obj
+59 0 obj
 << /Subtype /CIDFontType0C /Length 962 >>        
 [BINARY STREAM]
 endobj
-59 0 obj
-<< /Type /FontDescriptor /FontName /MKEZUM+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 60 0 R >>
+58 0 obj
+<< /Type /FontDescriptor /FontName /MKEZUM+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 59 0 R >>
 endobj
-61 0 obj
+60 0 obj
 << /Length 748 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -385,23 +382,23 @@ end
 %%EOF
 endstream
 endobj
-35 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /MKEZUM+LMRoman10-Regular /DescendantFonts [ 62 0 R ] /ToUnicode 61 0 R >>
+34 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /MKEZUM+LMRoman10-Regular /DescendantFonts [ 61 0 R ] /ToUnicode 60 0 R >>
+endobj
+61 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /MKEZUM+LMRoman10-Regular /FontDescriptor 58 0 R /W 57 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 62 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /MKEZUM+LMRoman10-Regular /FontDescriptor 59 0 R /W 58 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-63 0 obj
 [ 82 [ 681 ] 103 [ 472 ] 107 [ 681 ] ]
 endobj
-65 0 obj
+64 0 obj
 << /Subtype /CIDFontType0C /Length 706 >>        
 [BINARY STREAM]
 endobj
-64 0 obj
-<< /Type /FontDescriptor /FontName /CMQYBH+LMRoman5-Regular /Flags 4 /FontBBox [ -566 -303 1772 1126 ] /Ascent 1126 /CapHeight 683 /Descent -303 /ItalicAngle 0 /StemV 134 /XHeight 431 /FontFile3 65 0 R >>
+63 0 obj
+<< /Type /FontDescriptor /FontName /CMQYBH+LMRoman5-Regular /Flags 4 /FontBBox [ -566 -303 1772 1126 ] /Ascent 1126 /CapHeight 683 /Descent -303 /ItalicAngle 0 /StemV 134 /XHeight 431 /FontFile3 64 0 R >>
 endobj
-66 0 obj
+65 0 obj
 << /Length 715 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -439,95 +436,94 @@ end
 %%EOF
 endstream
 endobj
-34 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /CMQYBH+LMRoman5-Regular /DescendantFonts [ 67 0 R ] /ToUnicode 66 0 R >>
+33 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /CMQYBH+LMRoman5-Regular /DescendantFonts [ 66 0 R ] /ToUnicode 65 0 R >>
+endobj
+66 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /CMQYBH+LMRoman5-Regular /FontDescriptor 63 0 R /W 62 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+endobj
+38 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 31 0 R ] >>
 endobj
 67 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /CMQYBH+LMRoman5-Regular /FontDescriptor 64 0 R /W 63 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-39 0 obj
-<< /Type /Pages  /Count 1 /Kids [ 32 0 R ] >>
+<< /Type /Catalog /Pages 38 0 R /MarkInfo 39 0 R/Lang (en)/StructTreeRoot 5 0 R >>
 endobj
 68 0 obj
-<< /Type /Catalog /Pages 39 0 R /MarkInfo 40 0 R/Lang (en)/StructTreeRoot 5 0 R >>
-endobj
-69 0 obj
 << /Producer (LuaTeX)/Creator (TeX) /CreationDate (D:20160520090000Z) /ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 70
+0 69
 0000000002 65535 f 
 0000001587 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000010 00000 f 
-0000005283 00000 n 
+0000005167 00000 n 
 0000001670 00000 n 
-0000002004 00000 n 
-0000003956 00000 n 
-0000002583 00000 n 
+0000001988 00000 n 
+0000003940 00000 n 
+0000002567 00000 n 
 0000000012 00000 f 
-0000002651 00000 n 
+0000002635 00000 n 
 0000000014 00000 f 
-0000002721 00000 n 
+0000002705 00000 n 
 0000000020 00000 f 
-0000003484 00000 n 
-0000002802 00000 n 
-0000003762 00000 n 
-0000003591 00000 n 
-0000003869 00000 n 
+0000003468 00000 n 
+0000002786 00000 n 
+0000003746 00000 n 
+0000003575 00000 n 
+0000003853 00000 n 
 0000000000 00000 f 
-0000004017 00000 n 
-0000004115 00000 n 
-0000004215 00000 n 
-0000004398 00000 n 
-0000004545 00000 n 
-0000004692 00000 n 
-0000004823 00000 n 
-0000004927 00000 n 
-0000005027 00000 n 
-0000005155 00000 n 
+0000004001 00000 n 
+0000004099 00000 n 
+0000004199 00000 n 
+0000004382 00000 n 
+0000004529 00000 n 
+0000004676 00000 n 
+0000004807 00000 n 
+0000004907 00000 n 
+0000005035 00000 n 
 0000001476 00000 n 
 0000001341 00000 n 
 0000000020 00000 n 
-0000016116 00000 n 
-0000013921 00000 n 
-0000011418 00000 n 
-0000009417 00000 n 
-0000007413 00000 n 
-0000016468 00000 n 
+0000016000 00000 n 
+0000013805 00000 n 
+0000011302 00000 n 
+0000009301 00000 n 
+0000007297 00000 n 
+0000016352 00000 n 
 0000001634 00000 n 
 0000001748 00000 n 
-0000001967 00000 n 
-0000005403 00000 n 
-0000006418 00000 n 
-0000005456 00000 n 
-0000006638 00000 n 
-0000007566 00000 n 
-0000007765 00000 n 
-0000008449 00000 n 
-0000007796 00000 n 
-0000008670 00000 n 
-0000009570 00000 n 
-0000009769 00000 n 
-0000010450 00000 n 
-0000009800 00000 n 
-0000010671 00000 n 
-0000011571 00000 n 
-0000011770 00000 n 
-0000012892 00000 n 
-0000011846 00000 n 
-0000013113 00000 n 
-0000014075 00000 n 
-0000014275 00000 n 
-0000015120 00000 n 
-0000014330 00000 n 
-0000015341 00000 n 
-0000016269 00000 n 
-0000016530 00000 n 
-0000016629 00000 n 
+0000001951 00000 n 
+0000005287 00000 n 
+0000006302 00000 n 
+0000005340 00000 n 
+0000006522 00000 n 
+0000007450 00000 n 
+0000007649 00000 n 
+0000008333 00000 n 
+0000007680 00000 n 
+0000008554 00000 n 
+0000009454 00000 n 
+0000009653 00000 n 
+0000010334 00000 n 
+0000009684 00000 n 
+0000010555 00000 n 
+0000011455 00000 n 
+0000011654 00000 n 
+0000012776 00000 n 
+0000011730 00000 n 
+0000012997 00000 n 
+0000013959 00000 n 
+0000014159 00000 n 
+0000015004 00000 n 
+0000014214 00000 n 
+0000015225 00000 n 
+0000016153 00000 n 
+0000016414 00000 n 
+0000016513 00000 n 
 trailer
-<< /Size 70 /Root 68 0 R /Info 69 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 69 /Root 67 0 R /Info 68 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-16763
+16647
 %%EOF

--- a/required/latex-lab/testfiles-OR-luatex/test5.tpf
+++ b/required/latex-lab/testfiles-OR-luatex/test5.tpf
@@ -1,6 +1,6 @@
 %PDF-2.0
 %Ã’¡‘≈ÿ–ƒ∆
-37 0 obj
+36 0 obj
 << /Length 12695 >>      
 stream
 /opacity1 gs
@@ -157,27 +157,27 @@ EMC
 EMC
 endstream
 endobj
-36 0 obj
-<< /Type /Page /Contents 37 0 R /Resources 35 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 43 0 R >>
-endobj
 35 0 obj
-<< /ExtGState 1 0 R /Font << /F18 38 0 R /F15 39 0 R /F29 40 0 R /F39 41 0 R /F31 42 0 R >> >>
+<< /Type /Page /Contents 36 0 R /Resources 34 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 42 0 R >>
+endobj
+34 0 obj
+<< /ExtGState 1 0 R /Font << /F18 37 0 R /F15 38 0 R /F29 39 0 R /F39 40 0 R /F31 41 0 R >> >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-44 0 obj
+43 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 23 0 R 24 0 R 23 0 R 25 0 R 30 0 R 29 0 R 32 0 R 34 0 R] 
+<< /Nums [0 [ 23 0 R 24 0 R 23 0 R 25 0 R 29 0 R 28 0 R 31 0 R 33 0 R] 
 ] >>
 endobj
-45 0 obj
-<< /Limits [(ID.002) (ID.015)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 27 0 R (ID.009) 28 0 R (ID.010) 29 0 R (ID.011) 30 0 R (ID.012) 31 0 R (ID.013) 32 0 R (ID.014) 33 0 R (ID.015) 34 0 R ] >>
+44 0 obj
+<< /Limits [(ID.002) (ID.014)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 27 0 R (ID.009) 28 0 R (ID.010) 29 0 R (ID.011) 30 0 R (ID.012) 31 0 R (ID.013) 32 0 R (ID.014) 33 0 R ] >>
 endobj
-46 0 obj
-<< /Kids [45 0 R] >>
+45 0 obj
+<< /Kids [44 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
@@ -216,55 +216,52 @@ endobj
 <<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 21 0 R /K 23 0 R /ID (ID.003) >>
 endobj
 23 0 obj
-<<  /Type /StructElem /S /text /NS 15 0 R  /P 22 0 R /K [<</Type /MCR /Pg 36 0 R /MCID 0>>  24 0 R <</Type /MCR /Pg 36 0 R /MCID 2>>  25 0 R  26 0 R ] /ID (ID.004) >>
+<<  /Type /StructElem /S /text /NS 15 0 R  /P 22 0 R /K [<</Type /MCR /Pg 35 0 R /MCID 0>>  24 0 R <</Type /MCR /Pg 35 0 R /MCID 2>>  25 0 R  26 0 R ] /ID (ID.004) >>
 endobj
 24 0 obj
-<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 36 0 R /MCID 1>>  /ID (ID.005) >>
+<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 35 0 R /MCID 1>>  /ID (ID.005) >>
 endobj
 25 0 obj
-<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 36 0 R /MCID 3>>  /ID (ID.006) >>
+<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 35 0 R /MCID 3>>  /ID (ID.006) >>
 endobj
 26 0 obj
-<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 23 0 R /Ref [ 24 0 R 25 0 R ] /K [27 0 R 28 0 R 31 0 R 33 0 R] /ID (ID.007) >>
+<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 23 0 R /Ref [ 24 0 R 25 0 R ] /K [29 0 R 27 0 R 30 0 R 32 0 R] /ID (ID.007) >>
 endobj
 27 0 obj
-<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 26 0 R /K 30 0 R /ID (ID.008) >>
+<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 26 0 R /K 28 0 R /ID (ID.008) >>
 endobj
 28 0 obj
-<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 26 0 R /K 29 0 R /ID (ID.009) >>
+<<  /Type /StructElem /S /text /NS 15 0 R  /P 27 0 R /K [  <</Type /MCR /Pg 35 0 R /MCID 5>> ] /ID (ID.009) >>
 endobj
 29 0 obj
-<<  /Type /StructElem /S /text /NS 15 0 R  /P 28 0 R /K [  <</Type /MCR /Pg 36 0 R /MCID 5>> ] /ID (ID.010) >>
+<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 26 0 R /K <</Type /MCR /Pg 35 0 R /MCID 4>>  /ID (ID.010) >>
 endobj
 30 0 obj
-<<  /Type /StructElem /S /NonStruct /NS 11 0 R  /P 27 0 R /K <</Type /MCR /Pg 36 0 R /MCID 4>>  /ID (ID.011) >>
+<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 26 0 R /K 31 0 R /ID (ID.011) >>
 endobj
 31 0 obj
-<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 26 0 R /K 32 0 R /ID (ID.012) >>
+<<  /Type /StructElem /S /text /NS 15 0 R  /P 30 0 R /K <</Type /MCR /Pg 35 0 R /MCID 6>>  /ID (ID.012) >>
 endobj
 32 0 obj
-<<  /Type /StructElem /S /text /NS 15 0 R  /P 31 0 R /K <</Type /MCR /Pg 36 0 R /MCID 6>>  /ID (ID.013) >>
+<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 26 0 R /K 33 0 R /ID (ID.013) >>
 endobj
 33 0 obj
-<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 26 0 R /K 34 0 R /ID (ID.014) >>
-endobj
-34 0 obj
-<<  /Type /StructElem /S /text /NS 15 0 R  /P 33 0 R /K [<</Type /MCR /Pg 36 0 R /MCID 7>>  ] /ID (ID.015) >>
+<<  /Type /StructElem /S /text /NS 15 0 R  /P 32 0 R /K [<</Type /MCR /Pg 35 0 R /MCID 7>>  ] /ID (ID.014) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 46 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
+<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 45 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
 endobj
-47 0 obj
+46 0 obj
 [ 27 [ 796 531 ] 35 [ 590 ] 42 [ 767 472 ] 45 [ 295 811 590 ] 50 [ 472 ] 55 [ 325 ] 59 [ 531 ] 63 [ 590 ] 65 [ 383 295 ] 68 [ 325 ] 71 [ 664 295 ] 74 [ 973 885 796 590 ] 81 [ 531 ] 83 [ 723 590 ] 88 [ 295 ] 91 [ 561 ] 96 [ 414 590 419 ] 103 [ 354 ] 105 [ 413 ] 108 [ 796 590 ] 111 [ 796 561 ] 114 [ 767 ] 118 [ 561 ] 542 [ 354 ] ]
 endobj
-49 0 obj
+48 0 obj
 << /Subtype /CIDFontType0C /Length 4935 >>       
 [BINARY STREAM]
 endobj
-48 0 obj
-<< /Type /FontDescriptor /FontName /GORIJG+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 49 0 R >>
+47 0 obj
+<< /Type /FontDescriptor /FontName /GORIJG+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 48 0 R >>
 endobj
-50 0 obj
+49 0 obj
 << /Length 1206 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -337,23 +334,23 @@ end
 %%EOF
 endstream
 endobj
-42 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /GORIJG+LMRoman8-Regular /DescendantFonts [ 51 0 R ] /ToUnicode 50 0 R >>
+41 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /GORIJG+LMRoman8-Regular /DescendantFonts [ 50 0 R ] /ToUnicode 49 0 R >>
+endobj
+50 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /GORIJG+LMRoman8-Regular /FontDescriptor 47 0 R /W 46 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 51 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /GORIJG+LMRoman8-Regular /FontDescriptor 48 0 R /W 47 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-52 0 obj
 [ 82 [ 611 ] ]
 endobj
-54 0 obj
+53 0 obj
 << /Subtype /CIDFontType0C /Length 569 >>        
 [BINARY STREAM]
 endobj
-53 0 obj
-<< /Type /FontDescriptor /FontName /JHITRX+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 54 0 R >>
+52 0 obj
+<< /Type /FontDescriptor /FontName /JHITRX+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 53 0 R >>
 endobj
-55 0 obj
+54 0 obj
 << /Length 687 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -389,23 +386,23 @@ end
 %%EOF
 endstream
 endobj
-41 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JHITRX+LMRoman6-Regular /DescendantFonts [ 56 0 R ] /ToUnicode 55 0 R >>
+40 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JHITRX+LMRoman6-Regular /DescendantFonts [ 55 0 R ] /ToUnicode 54 0 R >>
+endobj
+55 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JHITRX+LMRoman6-Regular /FontDescriptor 52 0 R /W 51 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 56 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JHITRX+LMRoman6-Regular /FontDescriptor 53 0 R /W 52 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-57 0 obj
 [ 82 [ 569 ] ]
 endobj
-59 0 obj
+58 0 obj
 << /Subtype /CIDFontType0C /Length 566 >>        
 [BINARY STREAM]
 endobj
-58 0 obj
-<< /Type /FontDescriptor /FontName /JEFPUV+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 59 0 R >>
+57 0 obj
+<< /Type /FontDescriptor /FontName /JEFPUV+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 58 0 R >>
 endobj
-60 0 obj
+59 0 obj
 << /Length 687 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -441,23 +438,23 @@ end
 %%EOF
 endstream
 endobj
-40 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JEFPUV+LMRoman7-Regular /DescendantFonts [ 61 0 R ] /ToUnicode 60 0 R >>
+39 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JEFPUV+LMRoman7-Regular /DescendantFonts [ 60 0 R ] /ToUnicode 59 0 R >>
+endobj
+60 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JEFPUV+LMRoman7-Regular /FontDescriptor 57 0 R /W 56 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 61 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JEFPUV+LMRoman7-Regular /FontDescriptor 58 0 R /W 57 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-62 0 obj
 [ 28 [ 500 ] 35 [ 556 ] 43 [ 444 ] 82 [ 500 ] 103 [ 333 ] ]
 endobj
-64 0 obj
+63 0 obj
 << /Subtype /CIDFontType0C /Length 962 >>        
 [BINARY STREAM]
 endobj
-63 0 obj
-<< /Type /FontDescriptor /FontName /MKEZUM+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 64 0 R >>
+62 0 obj
+<< /Type /FontDescriptor /FontName /MKEZUM+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 63 0 R >>
 endobj
-65 0 obj
+64 0 obj
 << /Length 748 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -497,23 +494,23 @@ end
 %%EOF
 endstream
 endobj
-39 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /MKEZUM+LMRoman10-Regular /DescendantFonts [ 66 0 R ] /ToUnicode 65 0 R >>
+38 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /MKEZUM+LMRoman10-Regular /DescendantFonts [ 65 0 R ] /ToUnicode 64 0 R >>
+endobj
+65 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /MKEZUM+LMRoman10-Regular /FontDescriptor 62 0 R /W 61 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 66 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /MKEZUM+LMRoman10-Regular /FontDescriptor 63 0 R /W 62 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-67 0 obj
 [ 57 [ 681 ] 82 [ 681 ] 103 [ 472 ] 106 [ 681 681 ] ]
 endobj
-69 0 obj
+68 0 obj
 << /Subtype /CIDFontType0C /Length 954 >>        
 [BINARY STREAM]
 endobj
-68 0 obj
-<< /Type /FontDescriptor /FontName /VAIGVA+LMRoman5-Regular /Flags 4 /FontBBox [ -566 -303 1772 1126 ] /Ascent 1126 /CapHeight 683 /Descent -303 /ItalicAngle 0 /StemV 134 /XHeight 431 /FontFile3 69 0 R >>
+67 0 obj
+<< /Type /FontDescriptor /FontName /VAIGVA+LMRoman5-Regular /Flags 4 /FontBBox [ -566 -303 1772 1126 ] /Ascent 1126 /CapHeight 683 /Descent -303 /ItalicAngle 0 /StemV 134 /XHeight 431 /FontFile3 68 0 R >>
 endobj
-70 0 obj
+69 0 obj
 << /Length 743 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -553,99 +550,98 @@ end
 %%EOF
 endstream
 endobj
-38 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /VAIGVA+LMRoman5-Regular /DescendantFonts [ 71 0 R ] /ToUnicode 70 0 R >>
+37 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /VAIGVA+LMRoman5-Regular /DescendantFonts [ 70 0 R ] /ToUnicode 69 0 R >>
+endobj
+70 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /VAIGVA+LMRoman5-Regular /FontDescriptor 67 0 R /W 66 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+endobj
+42 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 35 0 R ] >>
 endobj
 71 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /VAIGVA+LMRoman5-Regular /FontDescriptor 68 0 R /W 67 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-43 0 obj
-<< /Type /Pages  /Count 1 /Kids [ 36 0 R ] >>
+<< /Type /Catalog /Pages 42 0 R /MarkInfo 43 0 R/Lang (en)/StructTreeRoot 5 0 R >>
 endobj
 72 0 obj
-<< /Type /Catalog /Pages 43 0 R /MarkInfo 44 0 R/Lang (en)/StructTreeRoot 5 0 R >>
-endobj
-73 0 obj
 << /Producer (LuaTeX)/Creator (TeX) /CreationDate (D:20160520090000Z) /ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 74
+0 73
 0000000002 65535 f 
 0000013021 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000010 00000 f 
-0000017257 00000 n 
+0000017141 00000 n 
 0000013104 00000 n 
-0000013516 00000 n 
-0000015468 00000 n 
-0000014095 00000 n 
+0000013500 00000 n 
+0000015452 00000 n 
+0000014079 00000 n 
 0000000012 00000 f 
-0000014163 00000 n 
+0000014147 00000 n 
 0000000014 00000 f 
-0000014233 00000 n 
+0000014217 00000 n 
 0000000020 00000 f 
-0000014996 00000 n 
-0000014314 00000 n 
-0000015274 00000 n 
-0000015103 00000 n 
-0000015381 00000 n 
+0000014980 00000 n 
+0000014298 00000 n 
+0000015258 00000 n 
+0000015087 00000 n 
+0000015365 00000 n 
 0000000000 00000 f 
-0000015529 00000 n 
-0000015627 00000 n 
-0000015727 00000 n 
-0000015910 00000 n 
-0000016057 00000 n 
-0000016204 00000 n 
-0000016349 00000 n 
-0000016453 00000 n 
-0000016553 00000 n 
-0000016680 00000 n 
-0000016808 00000 n 
-0000016908 00000 n 
-0000017031 00000 n 
-0000017131 00000 n 
+0000015513 00000 n 
+0000015611 00000 n 
+0000015711 00000 n 
+0000015894 00000 n 
+0000016041 00000 n 
+0000016188 00000 n 
+0000016333 00000 n 
+0000016433 00000 n 
+0000016560 00000 n 
+0000016692 00000 n 
+0000016792 00000 n 
+0000016915 00000 n 
+0000017015 00000 n 
 0000012910 00000 n 
 0000012775 00000 n 
 0000000020 00000 n 
-0000033223 00000 n 
-0000030737 00000 n 
-0000028234 00000 n 
-0000026233 00000 n 
-0000024229 00000 n 
-0000033575 00000 n 
+0000033107 00000 n 
+0000030621 00000 n 
+0000028118 00000 n 
+0000026117 00000 n 
+0000024113 00000 n 
+0000033459 00000 n 
 0000013068 00000 n 
 0000013196 00000 n 
-0000013479 00000 n 
-0000017377 00000 n 
-0000022743 00000 n 
-0000017724 00000 n 
-0000022963 00000 n 
-0000024382 00000 n 
-0000024581 00000 n 
-0000025265 00000 n 
-0000024612 00000 n 
-0000025486 00000 n 
-0000026386 00000 n 
-0000026585 00000 n 
-0000027266 00000 n 
-0000026616 00000 n 
-0000027487 00000 n 
-0000028387 00000 n 
-0000028586 00000 n 
-0000029708 00000 n 
-0000028662 00000 n 
-0000029929 00000 n 
-0000030891 00000 n 
-0000031091 00000 n 
-0000032199 00000 n 
-0000031161 00000 n 
-0000032420 00000 n 
-0000033376 00000 n 
-0000033637 00000 n 
-0000033736 00000 n 
+0000013463 00000 n 
+0000017261 00000 n 
+0000022627 00000 n 
+0000017608 00000 n 
+0000022847 00000 n 
+0000024266 00000 n 
+0000024465 00000 n 
+0000025149 00000 n 
+0000024496 00000 n 
+0000025370 00000 n 
+0000026270 00000 n 
+0000026469 00000 n 
+0000027150 00000 n 
+0000026500 00000 n 
+0000027371 00000 n 
+0000028271 00000 n 
+0000028470 00000 n 
+0000029592 00000 n 
+0000028546 00000 n 
+0000029813 00000 n 
+0000030775 00000 n 
+0000030975 00000 n 
+0000032083 00000 n 
+0000031045 00000 n 
+0000032304 00000 n 
+0000033260 00000 n 
+0000033521 00000 n 
+0000033620 00000 n 
 trailer
-<< /Size 74 /Root 72 0 R /Info 73 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 73 /Root 71 0 R /Info 72 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-33870
+33754
 %%EOF

--- a/required/latex-lab/testfiles-OR-luatex/test6.tpf
+++ b/required/latex-lab/testfiles-OR-luatex/test6.tpf
@@ -1,6 +1,6 @@
 %PDF-2.0
 %Ã’¡‘≈ÿ–ƒ∆
-35 0 obj
+33 0 obj
 << /Length 1565 >>       
 stream
 /opacity1 gs
@@ -110,27 +110,27 @@ EMC
 EMC
 endstream
 endobj
-34 0 obj
-<< /Type /Page /Contents 35 0 R /Resources 33 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 41 0 R >>
+32 0 obj
+<< /Type /Page /Contents 33 0 R /Resources 31 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 39 0 R >>
 endobj
-33 0 obj
-<< /ExtGState 1 0 R /Font << /F20 36 0 R /F15 37 0 R /F31 38 0 R /F39 39 0 R /F18 40 0 R >> >>
+31 0 obj
+<< /ExtGState 1 0 R /Font << /F20 34 0 R /F15 35 0 R /F31 36 0 R /F39 37 0 R /F18 38 0 R >> >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-42 0 obj
+40 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 23 0 R 24 0 R 23 0 R 25 0 R 23 0 R 29 0 R 28 0 R 26 0 R 26 0 R 32 0 R 30 0 R] 
+<< /Nums [0 [ 23 0 R 24 0 R 23 0 R 25 0 R 23 0 R 28 0 R 27 0 R 26 0 R 26 0 R 30 0 R 29 0 R] 
 ] >>
 endobj
-43 0 obj
-<< /Limits [(ID.002) (ID.013)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 27 0 R (ID.009) 28 0 R (ID.010) 29 0 R (ID.011) 30 0 R (ID.012) 31 0 R (ID.013) 32 0 R ] >>
+41 0 obj
+<< /Limits [(ID.002) (ID.011)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 27 0 R (ID.009) 28 0 R (ID.010) 29 0 R (ID.011) 30 0 R ] >>
 endobj
-44 0 obj
-<< /Kids [43 0 R] >>
+42 0 obj
+<< /Kids [41 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
@@ -169,49 +169,43 @@ endobj
 <<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 21 0 R /K 23 0 R /ID (ID.003) >>
 endobj
 23 0 obj
-<<  /Type /StructElem /S /text /NS 15 0 R  /P 22 0 R /K [<</Type /MCR /Pg 34 0 R /MCID 0>>  24 0 R <</Type /MCR /Pg 34 0 R /MCID 2>>  25 0 R  26 0 R <</Type /MCR /Pg 34 0 R /MCID 4>>  29 0 R  30 0 R ] /ID (ID.004) >>
+<<  /Type /StructElem /S /text /NS 15 0 R  /P 22 0 R /K [<</Type /MCR /Pg 32 0 R /MCID 0>>  24 0 R <</Type /MCR /Pg 32 0 R /MCID 2>>  25 0 R  26 0 R <</Type /MCR /Pg 32 0 R /MCID 4>>  28 0 R  29 0 R ] /ID (ID.004) >>
 endobj
 24 0 obj
-<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 34 0 R /MCID 1>>  /ID (ID.005) >>
+<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 32 0 R /MCID 1>>  /ID (ID.005) >>
 endobj
 25 0 obj
-<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 34 0 R /MCID 3>>  /ID (ID.006) >>
+<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 32 0 R /MCID 3>>  /ID (ID.006) >>
 endobj
 26 0 obj
-<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 23 0 R /Ref [ 24 0 R 25 0 R ] /K [27 0 R <</Type /MCR /Pg 34 0 R /MCID 7>> <</Type /MCR /Pg 34 0 R /MCID 8>> ] /ID (ID.007) >>
+<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 23 0 R /Ref [ 24 0 R 25 0 R ] /K [27 0 R <</Type /MCR /Pg 32 0 R /MCID 7>> <</Type /MCR /Pg 32 0 R /MCID 8>> ] /ID (ID.007) >>
 endobj
 27 0 obj
-<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 26 0 R /K 28 0 R /ID (ID.008) >>
+<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 26 0 R /K <</Type /MCR /Pg 32 0 R /MCID 6>>  /ID (ID.008) >>
 endobj
 28 0 obj
-<<  /Type /StructElem /S /NonStruct /NS 11 0 R  /P 27 0 R /K <</Type /MCR /Pg 34 0 R /MCID 6>>  /ID (ID.009) >>
+<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 29 0 R ] /K <</Type /MCR /Pg 32 0 R /MCID 5>>  /ID (ID.009) >>
 endobj
 29 0 obj
-<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 30 0 R ] /K <</Type /MCR /Pg 34 0 R /MCID 5>>  /ID (ID.010) >>
+<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 23 0 R /Ref [ 28 0 R ] /K [30 0 R <</Type /MCR /Pg 32 0 R /MCID 10>> ] /ID (ID.010) >>
 endobj
 30 0 obj
-<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 23 0 R /Ref [ 29 0 R ] /K [31 0 R <</Type /MCR /Pg 34 0 R /MCID 10>> ] /ID (ID.011) >>
-endobj
-31 0 obj
-<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 30 0 R /K 32 0 R /ID (ID.012) >>
-endobj
-32 0 obj
-<<  /Type /StructElem /S /NonStruct /NS 11 0 R  /P 31 0 R /K <</Type /MCR /Pg 34 0 R /MCID 9>>  /ID (ID.013) >>
+<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 29 0 R /K <</Type /MCR /Pg 32 0 R /MCID 9>>  /ID (ID.011) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 44 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
+<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 42 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
 endobj
-45 0 obj
+43 0 obj
 [ 28 [ 531 ] 35 [ 590 ] 43 [ 472 ] 103 [ 354 ] 116 [ 561 ] ]
 endobj
-47 0 obj
+45 0 obj
 << /Subtype /CIDFontType0C /Length 1066 >>       
 [BINARY STREAM]
 endobj
-46 0 obj
-<< /Type /FontDescriptor /FontName /LWEGST+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 47 0 R >>
+44 0 obj
+<< /Type /FontDescriptor /FontName /LWEGST+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 45 0 R >>
 endobj
-48 0 obj
+46 0 obj
 << /Length 743 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -251,23 +245,23 @@ end
 %%EOF
 endstream
 endobj
-40 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /LWEGST+LMRoman8-Regular /DescendantFonts [ 49 0 R ] /ToUnicode 48 0 R >>
+38 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /LWEGST+LMRoman8-Regular /DescendantFonts [ 47 0 R ] /ToUnicode 46 0 R >>
 endobj
-49 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /LWEGST+LMRoman8-Regular /FontDescriptor 46 0 R /W 45 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+47 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /LWEGST+LMRoman8-Regular /FontDescriptor 44 0 R /W 43 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-50 0 obj
+48 0 obj
 [ 82 [ 611 ] 107 [ 611 ] ]
 endobj
-52 0 obj
+50 0 obj
 << /Subtype /CIDFontType0C /Length 686 >>        
 [BINARY STREAM]
 endobj
-51 0 obj
-<< /Type /FontDescriptor /FontName /HBHNFB+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 52 0 R >>
+49 0 obj
+<< /Type /FontDescriptor /FontName /HBHNFB+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 50 0 R >>
 endobj
-53 0 obj
+51 0 obj
 << /Length 701 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -304,23 +298,23 @@ end
 %%EOF
 endstream
 endobj
-39 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /HBHNFB+LMRoman6-Regular /DescendantFonts [ 54 0 R ] /ToUnicode 53 0 R >>
+37 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /HBHNFB+LMRoman6-Regular /DescendantFonts [ 52 0 R ] /ToUnicode 51 0 R >>
 endobj
-54 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /HBHNFB+LMRoman6-Regular /FontDescriptor 51 0 R /W 50 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+52 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /HBHNFB+LMRoman6-Regular /FontDescriptor 49 0 R /W 48 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-55 0 obj
+53 0 obj
 [ 82 [ 569 ] 107 [ 569 ] ]
 endobj
-57 0 obj
+55 0 obj
 << /Subtype /CIDFontType0C /Length 678 >>        
 [BINARY STREAM]
 endobj
-56 0 obj
-<< /Type /FontDescriptor /FontName /KPSRQI+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 57 0 R >>
+54 0 obj
+<< /Type /FontDescriptor /FontName /KPSRQI+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 55 0 R >>
 endobj
-58 0 obj
+56 0 obj
 << /Length 701 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -357,23 +351,23 @@ end
 %%EOF
 endstream
 endobj
-38 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /KPSRQI+LMRoman7-Regular /DescendantFonts [ 59 0 R ] /ToUnicode 58 0 R >>
+36 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /KPSRQI+LMRoman7-Regular /DescendantFonts [ 57 0 R ] /ToUnicode 56 0 R >>
 endobj
-59 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /KPSRQI+LMRoman7-Regular /FontDescriptor 56 0 R /W 55 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+57 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /KPSRQI+LMRoman7-Regular /FontDescriptor 54 0 R /W 53 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-60 0 obj
+58 0 obj
 [ 28 [ 500 ] 35 [ 556 ] 43 [ 444 ] 47 [ 556 ] 82 [ 500 ] 103 [ 333 ] ]
 endobj
-62 0 obj
+60 0 obj
 << /Subtype /CIDFontType0C /Length 1101 >>       
 [BINARY STREAM]
 endobj
-61 0 obj
-<< /Type /FontDescriptor /FontName /NMMYUK+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 62 0 R >>
+59 0 obj
+<< /Type /FontDescriptor /FontName /NMMYUK+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 60 0 R >>
 endobj
-63 0 obj
+61 0 obj
 << /Length 762 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -414,23 +408,23 @@ end
 %%EOF
 endstream
 endobj
-37 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NMMYUK+LMRoman10-Regular /DescendantFonts [ 64 0 R ] /ToUnicode 63 0 R >>
+35 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NMMYUK+LMRoman10-Regular /DescendantFonts [ 62 0 R ] /ToUnicode 61 0 R >>
 endobj
-64 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NMMYUK+LMRoman10-Regular /FontDescriptor 61 0 R /W 60 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+62 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NMMYUK+LMRoman10-Regular /FontDescriptor 59 0 R /W 58 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-65 0 obj
+63 0 obj
 [ 82 [ 681 ] 103 [ 472 ] ]
 endobj
-67 0 obj
+65 0 obj
 << /Subtype /CIDFontType0C /Length 578 >>        
 [BINARY STREAM]
 endobj
-66 0 obj
-<< /Type /FontDescriptor /FontName /NPWRKI+LMRoman5-Regular /Flags 4 /FontBBox [ -566 -303 1772 1126 ] /Ascent 1126 /CapHeight 683 /Descent -303 /ItalicAngle 0 /StemV 134 /XHeight 431 /FontFile3 67 0 R >>
+64 0 obj
+<< /Type /FontDescriptor /FontName /NPWRKI+LMRoman5-Regular /Flags 4 /FontBBox [ -566 -303 1772 1126 ] /Ascent 1126 /CapHeight 683 /Descent -303 /ItalicAngle 0 /StemV 134 /XHeight 431 /FontFile3 65 0 R >>
 endobj
-68 0 obj
+66 0 obj
 << /Length 701 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -467,97 +461,95 @@ end
 %%EOF
 endstream
 endobj
-36 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NPWRKI+LMRoman5-Regular /DescendantFonts [ 69 0 R ] /ToUnicode 68 0 R >>
+34 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NPWRKI+LMRoman5-Regular /DescendantFonts [ 67 0 R ] /ToUnicode 66 0 R >>
+endobj
+67 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NPWRKI+LMRoman5-Regular /FontDescriptor 64 0 R /W 63 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+endobj
+39 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 32 0 R ] >>
+endobj
+68 0 obj
+<< /Type /Catalog /Pages 39 0 R /MarkInfo 40 0 R/Lang (en)/StructTreeRoot 5 0 R >>
 endobj
 69 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NPWRKI+LMRoman5-Regular /FontDescriptor 66 0 R /W 65 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-41 0 obj
-<< /Type /Pages  /Count 1 /Kids [ 34 0 R ] >>
-endobj
-70 0 obj
-<< /Type /Catalog /Pages 41 0 R /MarkInfo 42 0 R/Lang (en)/StructTreeRoot 5 0 R >>
-endobj
-71 0 obj
 << /Producer (LuaTeX)/Creator (TeX) /CreationDate (D:20160520090000Z) /ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 72
+0 70
 0000000002 65535 f 
 0000001891 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000010 00000 f 
-0000006070 00000 n 
-0000001974 00000 n 
-0000002375 00000 n 
-0000004327 00000 n 
-0000002954 00000 n 
-0000000012 00000 f 
-0000003022 00000 n 
-0000000014 00000 f 
-0000003092 00000 n 
-0000000020 00000 f 
-0000003855 00000 n 
-0000003173 00000 n 
-0000004133 00000 n 
-0000003962 00000 n 
-0000004240 00000 n 
-0000000000 00000 f 
-0000004388 00000 n 
-0000004486 00000 n 
-0000004586 00000 n 
-0000004819 00000 n 
-0000004966 00000 n 
-0000005113 00000 n 
-0000005306 00000 n 
-0000005410 00000 n 
-0000005538 00000 n 
-0000005685 00000 n 
 0000005838 00000 n 
-0000005942 00000 n 
+0000001974 00000 n 
+0000002343 00000 n 
+0000004295 00000 n 
+0000002922 00000 n 
+0000000012 00000 f 
+0000002990 00000 n 
+0000000014 00000 f 
+0000003060 00000 n 
+0000000020 00000 f 
+0000003823 00000 n 
+0000003141 00000 n 
+0000004101 00000 n 
+0000003930 00000 n 
+0000004208 00000 n 
+0000000000 00000 f 
+0000004356 00000 n 
+0000004454 00000 n 
+0000004554 00000 n 
+0000004787 00000 n 
+0000004934 00000 n 
+0000005081 00000 n 
+0000005274 00000 n 
+0000005406 00000 n 
+0000005553 00000 n 
+0000005706 00000 n 
 0000001780 00000 n 
 0000001645 00000 n 
 0000000020 00000 n 
-0000017434 00000 n 
-0000015393 00000 n 
-0000012726 00000 n 
-0000010587 00000 n 
-0000008440 00000 n 
-0000017786 00000 n 
+0000017202 00000 n 
+0000015161 00000 n 
+0000012494 00000 n 
+0000010355 00000 n 
+0000008208 00000 n 
+0000017554 00000 n 
 0000001938 00000 n 
 0000002087 00000 n 
-0000002338 00000 n 
-0000006190 00000 n 
-0000007417 00000 n 
-0000006267 00000 n 
-0000007637 00000 n 
-0000008593 00000 n 
-0000008792 00000 n 
-0000009605 00000 n 
-0000008835 00000 n 
-0000009826 00000 n 
-0000010740 00000 n 
-0000010939 00000 n 
-0000011744 00000 n 
-0000010982 00000 n 
-0000011965 00000 n 
-0000012879 00000 n 
-0000013078 00000 n 
-0000014350 00000 n 
-0000013165 00000 n 
-0000014571 00000 n 
-0000015547 00000 n 
-0000015747 00000 n 
-0000016452 00000 n 
-0000015790 00000 n 
-0000016673 00000 n 
-0000017587 00000 n 
-0000017848 00000 n 
-0000017947 00000 n 
+0000002306 00000 n 
+0000005958 00000 n 
+0000007185 00000 n 
+0000006035 00000 n 
+0000007405 00000 n 
+0000008361 00000 n 
+0000008560 00000 n 
+0000009373 00000 n 
+0000008603 00000 n 
+0000009594 00000 n 
+0000010508 00000 n 
+0000010707 00000 n 
+0000011512 00000 n 
+0000010750 00000 n 
+0000011733 00000 n 
+0000012647 00000 n 
+0000012846 00000 n 
+0000014118 00000 n 
+0000012933 00000 n 
+0000014339 00000 n 
+0000015315 00000 n 
+0000015515 00000 n 
+0000016220 00000 n 
+0000015558 00000 n 
+0000016441 00000 n 
+0000017355 00000 n 
+0000017616 00000 n 
+0000017715 00000 n 
 trailer
-<< /Size 72 /Root 70 0 R /Info 71 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 70 /Root 68 0 R /Info 69 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-18081
+17849
 %%EOF

--- a/required/latex-lab/testfiles-OR-luatex/test7.tpf
+++ b/required/latex-lab/testfiles-OR-luatex/test7.tpf
@@ -1,6 +1,6 @@
 %PDF-2.0
 %Ã’¡‘≈ÿ–ƒ∆
-39 0 obj
+37 0 obj
 << /Length 1796 >>       
 stream
 /opacity1 gs
@@ -128,27 +128,27 @@ EMC
 EMC
 endstream
 endobj
-38 0 obj
-<< /Type /Page /Contents 39 0 R /Resources 37 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 45 0 R >>
+36 0 obj
+<< /Type /Page /Contents 37 0 R /Resources 35 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 43 0 R >>
 endobj
-37 0 obj
-<< /ExtGState 1 0 R /Font << /F18 40 0 R /F15 41 0 R /F29 42 0 R /F39 43 0 R /F31 44 0 R >> >>
+35 0 obj
+<< /ExtGState 1 0 R /Font << /F18 38 0 R /F15 39 0 R /F29 40 0 R /F39 41 0 R /F31 42 0 R >> >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-46 0 obj
+44 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 23 0 R 24 0 R 23 0 R 25 0 R 23 0 R 31 0 R 30 0 R 29 0 R 36 0 R 35 0 R] 
+<< /Nums [0 [ 23 0 R 24 0 R 23 0 R 25 0 R 23 0 R 30 0 R 29 0 R 28 0 R 34 0 R 33 0 R] 
 ] >>
 endobj
-47 0 obj
-<< /Limits [(ID.002) (ID.017)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 27 0 R (ID.009) 28 0 R (ID.010) 29 0 R (ID.011) 30 0 R (ID.012) 31 0 R (ID.013) 32 0 R (ID.014) 33 0 R (ID.015) 34 0 R (ID.016) 35 0 R (ID.017) 36 0 R ] >>
+45 0 obj
+<< /Limits [(ID.002) (ID.015)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 27 0 R (ID.009) 28 0 R (ID.010) 29 0 R (ID.011) 30 0 R (ID.012) 31 0 R (ID.013) 32 0 R (ID.014) 33 0 R (ID.015) 34 0 R ] >>
 endobj
-48 0 obj
-<< /Kids [47 0 R] >>
+46 0 obj
+<< /Kids [45 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
@@ -187,61 +187,55 @@ endobj
 <<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 21 0 R /K 23 0 R /ID (ID.003) >>
 endobj
 23 0 obj
-<<  /Type /StructElem /S /text /NS 15 0 R  /P 22 0 R /K [<</Type /MCR /Pg 38 0 R /MCID 0>>  24 0 R <</Type /MCR /Pg 38 0 R /MCID 2>>  25 0 R  26 0 R <</Type /MCR /Pg 38 0 R /MCID 4>>  31 0 R  32 0 R ] /ID (ID.004) >>
+<<  /Type /StructElem /S /text /NS 15 0 R  /P 22 0 R /K [<</Type /MCR /Pg 36 0 R /MCID 0>>  24 0 R <</Type /MCR /Pg 36 0 R /MCID 2>>  25 0 R  26 0 R <</Type /MCR /Pg 36 0 R /MCID 4>>  30 0 R  31 0 R ] /ID (ID.004) >>
 endobj
 24 0 obj
-<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 38 0 R /MCID 1>>  /ID (ID.005) >>
+<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 36 0 R /MCID 1>>  /ID (ID.005) >>
 endobj
 25 0 obj
-<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 38 0 R /MCID 3>>  /ID (ID.006) >>
+<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 36 0 R /MCID 3>>  /ID (ID.006) >>
 endobj
 26 0 obj
-<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 23 0 R /Ref [ 24 0 R 25 0 R ] /K [27 0 R 28 0 R] /ID (ID.007) >>
+<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 23 0 R /Ref [ 24 0 R 25 0 R ] /K [29 0 R 27 0 R] /ID (ID.007) >>
 endobj
 27 0 obj
-<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 26 0 R /K 30 0 R /ID (ID.008) >>
+<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 26 0 R /K 28 0 R /ID (ID.008) >>
 endobj
 28 0 obj
-<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 26 0 R /K 29 0 R /ID (ID.009) >>
+<<  /Type /StructElem /S /text /NS 15 0 R  /P 27 0 R /K [  <</Type /MCR /Pg 36 0 R /MCID 7>>  ] /ID (ID.009) >>
 endobj
 29 0 obj
-<<  /Type /StructElem /S /text /NS 15 0 R  /P 28 0 R /K [  <</Type /MCR /Pg 38 0 R /MCID 7>>  ] /ID (ID.010) >>
+<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 26 0 R /K <</Type /MCR /Pg 36 0 R /MCID 6>>  /ID (ID.010) >>
 endobj
 30 0 obj
-<<  /Type /StructElem /S /NonStruct /NS 11 0 R  /P 27 0 R /K <</Type /MCR /Pg 38 0 R /MCID 6>>  /ID (ID.011) >>
+<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 31 0 R ] /K <</Type /MCR /Pg 36 0 R /MCID 5>>  /ID (ID.011) >>
 endobj
 31 0 obj
-<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 32 0 R ] /K <</Type /MCR /Pg 38 0 R /MCID 5>>  /ID (ID.012) >>
+<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 23 0 R /Ref [ 30 0 R ] /K [34 0 R 32 0 R] /ID (ID.012) >>
 endobj
 32 0 obj
-<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 23 0 R /Ref [ 31 0 R ] /K [33 0 R 34 0 R] /ID (ID.013) >>
+<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 31 0 R /K 33 0 R /ID (ID.013) >>
 endobj
 33 0 obj
-<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 32 0 R /K 36 0 R /ID (ID.014) >>
+<<  /Type /StructElem /S /text /NS 15 0 R  /P 32 0 R /K [  <</Type /MCR /Pg 36 0 R /MCID 9>>  ] /ID (ID.014) >>
 endobj
 34 0 obj
-<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 32 0 R /K 35 0 R /ID (ID.015) >>
-endobj
-35 0 obj
-<<  /Type /StructElem /S /text /NS 15 0 R  /P 34 0 R /K [  <</Type /MCR /Pg 38 0 R /MCID 9>>  ] /ID (ID.016) >>
-endobj
-36 0 obj
-<<  /Type /StructElem /S /NonStruct /NS 11 0 R  /P 33 0 R /K <</Type /MCR /Pg 38 0 R /MCID 8>>  /ID (ID.017) >>
+<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 31 0 R /K <</Type /MCR /Pg 36 0 R /MCID 8>>  /ID (ID.015) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 48 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
+<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 46 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
 endobj
-49 0 obj
+47 0 obj
 [ 28 [ 531 ] 35 [ 590 ] 43 [ 472 ] 116 [ 561 ] ]
 endobj
-51 0 obj
+49 0 obj
 << /Subtype /CIDFontType0C /Length 1059 >>       
 [BINARY STREAM]
 endobj
-50 0 obj
-<< /Type /FontDescriptor /FontName /NKBJZF+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 51 0 R >>
+48 0 obj
+<< /Type /FontDescriptor /FontName /NKBJZF+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 49 0 R >>
 endobj
-52 0 obj
+50 0 obj
 << /Length 729 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -280,23 +274,23 @@ end
 %%EOF
 endstream
 endobj
-44 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NKBJZF+LMRoman8-Regular /DescendantFonts [ 53 0 R ] /ToUnicode 52 0 R >>
+42 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NKBJZF+LMRoman8-Regular /DescendantFonts [ 51 0 R ] /ToUnicode 50 0 R >>
 endobj
-53 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NKBJZF+LMRoman8-Regular /FontDescriptor 50 0 R /W 49 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+51 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NKBJZF+LMRoman8-Regular /FontDescriptor 48 0 R /W 47 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-54 0 obj
+52 0 obj
 [ 82 [ 611 ] 107 [ 611 ] ]
 endobj
-56 0 obj
+54 0 obj
 << /Subtype /CIDFontType0C /Length 686 >>        
 [BINARY STREAM]
 endobj
-55 0 obj
-<< /Type /FontDescriptor /FontName /HBHNFB+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 56 0 R >>
+53 0 obj
+<< /Type /FontDescriptor /FontName /HBHNFB+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 54 0 R >>
 endobj
-57 0 obj
+55 0 obj
 << /Length 701 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -333,23 +327,23 @@ end
 %%EOF
 endstream
 endobj
-43 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /HBHNFB+LMRoman6-Regular /DescendantFonts [ 58 0 R ] /ToUnicode 57 0 R >>
+41 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /HBHNFB+LMRoman6-Regular /DescendantFonts [ 56 0 R ] /ToUnicode 55 0 R >>
 endobj
-58 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /HBHNFB+LMRoman6-Regular /FontDescriptor 55 0 R /W 54 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+56 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /HBHNFB+LMRoman6-Regular /FontDescriptor 53 0 R /W 52 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-59 0 obj
+57 0 obj
 [ 82 [ 569 ] 107 [ 569 ] ]
 endobj
-61 0 obj
+59 0 obj
 << /Subtype /CIDFontType0C /Length 678 >>        
 [BINARY STREAM]
 endobj
-60 0 obj
-<< /Type /FontDescriptor /FontName /KPSRQI+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 61 0 R >>
+58 0 obj
+<< /Type /FontDescriptor /FontName /KPSRQI+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 59 0 R >>
 endobj
-62 0 obj
+60 0 obj
 << /Length 701 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -386,23 +380,23 @@ end
 %%EOF
 endstream
 endobj
-42 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /KPSRQI+LMRoman7-Regular /DescendantFonts [ 63 0 R ] /ToUnicode 62 0 R >>
+40 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /KPSRQI+LMRoman7-Regular /DescendantFonts [ 61 0 R ] /ToUnicode 60 0 R >>
 endobj
-63 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /KPSRQI+LMRoman7-Regular /FontDescriptor 60 0 R /W 59 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+61 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /KPSRQI+LMRoman7-Regular /FontDescriptor 58 0 R /W 57 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-64 0 obj
+62 0 obj
 [ 28 [ 500 ] 35 [ 556 ] 43 [ 444 ] 47 [ 556 ] 82 [ 500 ] 103 [ 333 ] ]
 endobj
-66 0 obj
+64 0 obj
 << /Subtype /CIDFontType0C /Length 1101 >>       
 [BINARY STREAM]
 endobj
-65 0 obj
-<< /Type /FontDescriptor /FontName /NMMYUK+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 66 0 R >>
+63 0 obj
+<< /Type /FontDescriptor /FontName /NMMYUK+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 64 0 R >>
 endobj
-67 0 obj
+65 0 obj
 << /Length 762 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -443,23 +437,23 @@ end
 %%EOF
 endstream
 endobj
-41 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NMMYUK+LMRoman10-Regular /DescendantFonts [ 68 0 R ] /ToUnicode 67 0 R >>
+39 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NMMYUK+LMRoman10-Regular /DescendantFonts [ 66 0 R ] /ToUnicode 65 0 R >>
 endobj
-68 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NMMYUK+LMRoman10-Regular /FontDescriptor 65 0 R /W 64 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+66 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NMMYUK+LMRoman10-Regular /FontDescriptor 63 0 R /W 62 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-69 0 obj
+67 0 obj
 [ 82 [ 681 ] 103 [ 472 ] 106 [ 681 681 ] ]
 endobj
-71 0 obj
+69 0 obj
 << /Subtype /CIDFontType0C /Length 867 >>        
 [BINARY STREAM]
 endobj
-70 0 obj
-<< /Type /FontDescriptor /FontName /ZFIHJZ+LMRoman5-Regular /Flags 4 /FontBBox [ -566 -303 1772 1126 ] /Ascent 1126 /CapHeight 683 /Descent -303 /ItalicAngle 0 /StemV 134 /XHeight 431 /FontFile3 71 0 R >>
+68 0 obj
+<< /Type /FontDescriptor /FontName /ZFIHJZ+LMRoman5-Regular /Flags 4 /FontBBox [ -566 -303 1772 1126 ] /Ascent 1126 /CapHeight 683 /Descent -303 /ItalicAngle 0 /StemV 134 /XHeight 431 /FontFile3 69 0 R >>
 endobj
-72 0 obj
+70 0 obj
 << /Length 729 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -498,101 +492,99 @@ end
 %%EOF
 endstream
 endobj
-40 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /ZFIHJZ+LMRoman5-Regular /DescendantFonts [ 73 0 R ] /ToUnicode 72 0 R >>
+38 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /ZFIHJZ+LMRoman5-Regular /DescendantFonts [ 71 0 R ] /ToUnicode 70 0 R >>
+endobj
+71 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /ZFIHJZ+LMRoman5-Regular /FontDescriptor 68 0 R /W 67 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+endobj
+43 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 36 0 R ] >>
+endobj
+72 0 obj
+<< /Type /Catalog /Pages 43 0 R /MarkInfo 44 0 R/Lang (en)/StructTreeRoot 5 0 R >>
 endobj
 73 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /ZFIHJZ+LMRoman5-Regular /FontDescriptor 70 0 R /W 69 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-45 0 obj
-<< /Type /Pages  /Count 1 /Kids [ 38 0 R ] >>
-endobj
-74 0 obj
-<< /Type /Catalog /Pages 45 0 R /MarkInfo 46 0 R/Lang (en)/StructTreeRoot 5 0 R >>
-endobj
-75 0 obj
 << /Producer (LuaTeX)/Creator (TeX) /CreationDate (D:20160520090000Z) /ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 76
+0 74
 0000000002 65535 f 
 0000002122 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000010 00000 f 
-0000006723 00000 n 
+0000006491 00000 n 
 0000002205 00000 n 
-0000002663 00000 n 
-0000004615 00000 n 
-0000003242 00000 n 
+0000002631 00000 n 
+0000004583 00000 n 
+0000003210 00000 n 
 0000000012 00000 f 
-0000003310 00000 n 
+0000003278 00000 n 
 0000000014 00000 f 
-0000003380 00000 n 
+0000003348 00000 n 
 0000000020 00000 f 
-0000004143 00000 n 
-0000003461 00000 n 
-0000004421 00000 n 
-0000004250 00000 n 
-0000004528 00000 n 
+0000004111 00000 n 
+0000003429 00000 n 
+0000004389 00000 n 
+0000004218 00000 n 
+0000004496 00000 n 
 0000000000 00000 f 
-0000004676 00000 n 
-0000004774 00000 n 
-0000004874 00000 n 
-0000005107 00000 n 
-0000005254 00000 n 
-0000005401 00000 n 
-0000005532 00000 n 
-0000005636 00000 n 
-0000005736 00000 n 
-0000005864 00000 n 
-0000005992 00000 n 
-0000006139 00000 n 
-0000006263 00000 n 
-0000006367 00000 n 
-0000006467 00000 n 
-0000006595 00000 n 
+0000004644 00000 n 
+0000004742 00000 n 
+0000004842 00000 n 
+0000005075 00000 n 
+0000005222 00000 n 
+0000005369 00000 n 
+0000005500 00000 n 
+0000005600 00000 n 
+0000005728 00000 n 
+0000005860 00000 n 
+0000006007 00000 n 
+0000006131 00000 n 
+0000006231 00000 n 
+0000006359 00000 n 
 0000002011 00000 n 
 0000001876 00000 n 
 0000000020 00000 n 
-0000018387 00000 n 
-0000016013 00000 n 
-0000013346 00000 n 
-0000011207 00000 n 
-0000009060 00000 n 
-0000018739 00000 n 
+0000018155 00000 n 
+0000015781 00000 n 
+0000013114 00000 n 
+0000010975 00000 n 
+0000008828 00000 n 
+0000018507 00000 n 
 0000002169 00000 n 
 0000002311 00000 n 
-0000002626 00000 n 
-0000006843 00000 n 
-0000008051 00000 n 
-0000006908 00000 n 
-0000008271 00000 n 
-0000009213 00000 n 
-0000009412 00000 n 
-0000010225 00000 n 
-0000009455 00000 n 
-0000010446 00000 n 
-0000011360 00000 n 
-0000011559 00000 n 
-0000012364 00000 n 
-0000011602 00000 n 
-0000012585 00000 n 
-0000013499 00000 n 
-0000013698 00000 n 
-0000014970 00000 n 
-0000013785 00000 n 
-0000015191 00000 n 
-0000016167 00000 n 
-0000016367 00000 n 
-0000017377 00000 n 
-0000016426 00000 n 
-0000017598 00000 n 
-0000018540 00000 n 
-0000018801 00000 n 
-0000018900 00000 n 
+0000002594 00000 n 
+0000006611 00000 n 
+0000007819 00000 n 
+0000006676 00000 n 
+0000008039 00000 n 
+0000008981 00000 n 
+0000009180 00000 n 
+0000009993 00000 n 
+0000009223 00000 n 
+0000010214 00000 n 
+0000011128 00000 n 
+0000011327 00000 n 
+0000012132 00000 n 
+0000011370 00000 n 
+0000012353 00000 n 
+0000013267 00000 n 
+0000013466 00000 n 
+0000014738 00000 n 
+0000013553 00000 n 
+0000014959 00000 n 
+0000015935 00000 n 
+0000016135 00000 n 
+0000017145 00000 n 
+0000016194 00000 n 
+0000017366 00000 n 
+0000018308 00000 n 
+0000018569 00000 n 
+0000018668 00000 n 
 trailer
-<< /Size 76 /Root 74 0 R /Info 75 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 74 /Root 72 0 R /Info 73 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-19034
+18802
 %%EOF

--- a/required/latex-lab/testfiles-OR-luatex/test8.tpf
+++ b/required/latex-lab/testfiles-OR-luatex/test8.tpf
@@ -1,6 +1,6 @@
 %PDF-2.0
 %Ã’¡‘≈ÿ–ƒ∆
-34 0 obj
+33 0 obj
 << /Length 965 >>        
 stream
 /opacity1 gs
@@ -72,27 +72,27 @@ EMC
 EMC
 endstream
 endobj
-33 0 obj
-<< /Type /Page /Contents 34 0 R /Resources 32 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 39 0 R >>
-endobj
 32 0 obj
-<< /ExtGState 1 0 R /Font << /F15 35 0 R /F27 36 0 R /F37 37 0 R /F29 38 0 R >> >>
+<< /Type /Page /Contents 33 0 R /Resources 31 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 38 0 R >>
+endobj
+31 0 obj
+<< /ExtGState 1 0 R /Font << /F15 34 0 R /F27 35 0 R /F37 36 0 R /F29 37 0 R >> >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-40 0 obj
+39 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 23 0 R 24 0 R 23 0 R 25 0 R 23 0 R 31 0 R 30 0 R 29 0 R] 
+<< /Nums [0 [ 23 0 R 24 0 R 23 0 R 25 0 R 23 0 R 30 0 R 29 0 R 28 0 R] 
 ] >>
 endobj
-41 0 obj
-<< /Limits [(ID.002) (ID.012)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 27 0 R (ID.009) 28 0 R (ID.010) 29 0 R (ID.011) 30 0 R (ID.012) 31 0 R ] >>
+40 0 obj
+<< /Limits [(ID.002) (ID.011)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 27 0 R (ID.009) 28 0 R (ID.010) 29 0 R (ID.011) 30 0 R ] >>
 endobj
-42 0 obj
-<< /Kids [41 0 R] >>
+41 0 obj
+<< /Kids [40 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
@@ -131,46 +131,43 @@ endobj
 <<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 21 0 R /K 23 0 R /ID (ID.003) >>
 endobj
 23 0 obj
-<<  /Type /StructElem /S /text /NS 15 0 R  /P 22 0 R /K [<</Type /MCR /Pg 33 0 R /MCID 0>>  24 0 R <</Type /MCR /Pg 33 0 R /MCID 2>>  25 0 R  26 0 R <</Type /MCR /Pg 33 0 R /MCID 4>>  31 0 R ] /ID (ID.004) >>
+<<  /Type /StructElem /S /text /NS 15 0 R  /P 22 0 R /K [<</Type /MCR /Pg 32 0 R /MCID 0>>  24 0 R <</Type /MCR /Pg 32 0 R /MCID 2>>  25 0 R  26 0 R <</Type /MCR /Pg 32 0 R /MCID 4>>  30 0 R ] /ID (ID.004) >>
 endobj
 24 0 obj
-<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 33 0 R /MCID 1>>  /ID (ID.005) >>
+<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 32 0 R /MCID 1>>  /ID (ID.005) >>
 endobj
 25 0 obj
-<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 33 0 R /MCID 3>>  /ID (ID.006) >>
+<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 32 0 R /MCID 3>>  /ID (ID.006) >>
 endobj
 26 0 obj
-<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 23 0 R /Ref [ 25 0 R 24 0 R 31 0 R ] /K [27 0 R 28 0 R] /ID (ID.007) >>
+<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 23 0 R /Ref [ 25 0 R 24 0 R 30 0 R ] /K [29 0 R 27 0 R] /ID (ID.007) >>
 endobj
 27 0 obj
-<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 26 0 R /K 30 0 R /ID (ID.008) >>
+<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 26 0 R /K 28 0 R /ID (ID.008) >>
 endobj
 28 0 obj
-<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 26 0 R /K 29 0 R /ID (ID.009) >>
+<<  /Type /StructElem /S /text /NS 15 0 R  /P 27 0 R /K [  <</Type /MCR /Pg 32 0 R /MCID 7>>  ] /ID (ID.009) >>
 endobj
 29 0 obj
-<<  /Type /StructElem /S /text /NS 15 0 R  /P 28 0 R /K [  <</Type /MCR /Pg 33 0 R /MCID 7>>  ] /ID (ID.010) >>
+<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 26 0 R /K <</Type /MCR /Pg 32 0 R /MCID 6>>  /ID (ID.010) >>
 endobj
 30 0 obj
-<<  /Type /StructElem /S /NonStruct /NS 11 0 R  /P 27 0 R /K <</Type /MCR /Pg 33 0 R /MCID 6>>  /ID (ID.011) >>
-endobj
-31 0 obj
-<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 33 0 R /MCID 5>>  /ID (ID.012) >>
+<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 23 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 32 0 R /MCID 5>>  /ID (ID.011) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 42 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
+<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 41 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
 endobj
-43 0 obj
+42 0 obj
 [ 28 [ 531 ] 35 [ 590 ] 43 [ 472 ] ]
 endobj
-45 0 obj
+44 0 obj
 << /Subtype /CIDFontType0C /Length 878 >>        
 [BINARY STREAM]
 endobj
-44 0 obj
-<< /Type /FontDescriptor /FontName /NMCSWH+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 45 0 R >>
+43 0 obj
+<< /Type /FontDescriptor /FontName /NMCSWH+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 44 0 R >>
 endobj
-46 0 obj
+45 0 obj
 << /Length 715 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -208,23 +205,23 @@ end
 %%EOF
 endstream
 endobj
-38 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NMCSWH+LMRoman8-Regular /DescendantFonts [ 47 0 R ] /ToUnicode 46 0 R >>
+37 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NMCSWH+LMRoman8-Regular /DescendantFonts [ 46 0 R ] /ToUnicode 45 0 R >>
+endobj
+46 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NMCSWH+LMRoman8-Regular /FontDescriptor 43 0 R /W 42 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 47 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NMCSWH+LMRoman8-Regular /FontDescriptor 44 0 R /W 43 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-48 0 obj
 [ 82 [ 611 ] ]
 endobj
-50 0 obj
+49 0 obj
 << /Subtype /CIDFontType0C /Length 569 >>        
 [BINARY STREAM]
 endobj
-49 0 obj
-<< /Type /FontDescriptor /FontName /JHITRX+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 50 0 R >>
+48 0 obj
+<< /Type /FontDescriptor /FontName /JHITRX+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 49 0 R >>
 endobj
-51 0 obj
+50 0 obj
 << /Length 687 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -260,23 +257,23 @@ end
 %%EOF
 endstream
 endobj
-37 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JHITRX+LMRoman6-Regular /DescendantFonts [ 52 0 R ] /ToUnicode 51 0 R >>
+36 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JHITRX+LMRoman6-Regular /DescendantFonts [ 51 0 R ] /ToUnicode 50 0 R >>
+endobj
+51 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JHITRX+LMRoman6-Regular /FontDescriptor 48 0 R /W 47 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 52 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JHITRX+LMRoman6-Regular /FontDescriptor 49 0 R /W 48 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-53 0 obj
 [ 82 [ 569 ] ]
 endobj
-55 0 obj
+54 0 obj
 << /Subtype /CIDFontType0C /Length 566 >>        
 [BINARY STREAM]
 endobj
-54 0 obj
-<< /Type /FontDescriptor /FontName /JEFPUV+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 55 0 R >>
+53 0 obj
+<< /Type /FontDescriptor /FontName /JEFPUV+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 54 0 R >>
 endobj
-56 0 obj
+55 0 obj
 << /Length 687 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -312,23 +309,23 @@ end
 %%EOF
 endstream
 endobj
-36 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JEFPUV+LMRoman7-Regular /DescendantFonts [ 57 0 R ] /ToUnicode 56 0 R >>
+35 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JEFPUV+LMRoman7-Regular /DescendantFonts [ 56 0 R ] /ToUnicode 55 0 R >>
+endobj
+56 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JEFPUV+LMRoman7-Regular /FontDescriptor 53 0 R /W 52 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 57 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JEFPUV+LMRoman7-Regular /FontDescriptor 54 0 R /W 53 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-58 0 obj
 [ 28 [ 500 ] 35 [ 556 ] 43 [ 444 ] 82 [ 500 ] 103 [ 333 ] ]
 endobj
-60 0 obj
+59 0 obj
 << /Subtype /CIDFontType0C /Length 962 >>        
 [BINARY STREAM]
 endobj
-59 0 obj
-<< /Type /FontDescriptor /FontName /MKEZUM+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 60 0 R >>
+58 0 obj
+<< /Type /FontDescriptor /FontName /MKEZUM+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 59 0 R >>
 endobj
-61 0 obj
+60 0 obj
 << /Length 748 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -368,90 +365,89 @@ end
 %%EOF
 endstream
 endobj
-35 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /MKEZUM+LMRoman10-Regular /DescendantFonts [ 62 0 R ] /ToUnicode 61 0 R >>
+34 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /MKEZUM+LMRoman10-Regular /DescendantFonts [ 61 0 R ] /ToUnicode 60 0 R >>
+endobj
+61 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /MKEZUM+LMRoman10-Regular /FontDescriptor 58 0 R /W 57 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+endobj
+38 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 32 0 R ] >>
 endobj
 62 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /MKEZUM+LMRoman10-Regular /FontDescriptor 59 0 R /W 58 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-39 0 obj
-<< /Type /Pages  /Count 1 /Kids [ 33 0 R ] >>
+<< /Type /Catalog /Pages 38 0 R /MarkInfo 39 0 R/Lang (en)/StructTreeRoot 5 0 R >>
 endobj
 63 0 obj
-<< /Type /Catalog /Pages 39 0 R /MarkInfo 40 0 R/Lang (en)/StructTreeRoot 5 0 R >>
-endobj
-64 0 obj
 << /Producer (LuaTeX)/Creator (TeX) /CreationDate (D:20160520090000Z) /ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 65
+0 64
 0000000002 65535 f 
 0000001279 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000010 00000 f 
-0000005201 00000 n 
+0000005085 00000 n 
 0000001362 00000 n 
-0000001726 00000 n 
-0000003678 00000 n 
-0000002305 00000 n 
+0000001710 00000 n 
+0000003662 00000 n 
+0000002289 00000 n 
 0000000012 00000 f 
-0000002373 00000 n 
+0000002357 00000 n 
 0000000014 00000 f 
-0000002443 00000 n 
+0000002427 00000 n 
 0000000020 00000 f 
-0000003206 00000 n 
-0000002524 00000 n 
-0000003484 00000 n 
-0000003313 00000 n 
-0000003591 00000 n 
+0000003190 00000 n 
+0000002508 00000 n 
+0000003468 00000 n 
+0000003297 00000 n 
+0000003575 00000 n 
 0000000000 00000 f 
-0000003739 00000 n 
-0000003837 00000 n 
-0000003937 00000 n 
-0000004162 00000 n 
-0000004309 00000 n 
-0000004456 00000 n 
-0000004594 00000 n 
-0000004698 00000 n 
-0000004798 00000 n 
-0000004926 00000 n 
-0000005054 00000 n 
+0000003723 00000 n 
+0000003821 00000 n 
+0000003921 00000 n 
+0000004146 00000 n 
+0000004293 00000 n 
+0000004440 00000 n 
+0000004578 00000 n 
+0000004678 00000 n 
+0000004806 00000 n 
+0000004938 00000 n 
 0000001180 00000 n 
 0000001045 00000 n 
 0000000020 00000 n 
-0000013839 00000 n 
-0000011336 00000 n 
-0000009335 00000 n 
-0000007331 00000 n 
-0000014193 00000 n 
+0000013723 00000 n 
+0000011220 00000 n 
+0000009219 00000 n 
+0000007215 00000 n 
+0000014077 00000 n 
 0000001326 00000 n 
 0000001454 00000 n 
-0000001689 00000 n 
-0000005321 00000 n 
-0000006336 00000 n 
-0000005374 00000 n 
-0000006556 00000 n 
-0000007484 00000 n 
-0000007683 00000 n 
-0000008367 00000 n 
-0000007714 00000 n 
-0000008588 00000 n 
-0000009488 00000 n 
-0000009687 00000 n 
-0000010368 00000 n 
-0000009718 00000 n 
-0000010589 00000 n 
-0000011489 00000 n 
-0000011688 00000 n 
-0000012810 00000 n 
-0000011764 00000 n 
-0000013031 00000 n 
-0000013993 00000 n 
-0000014255 00000 n 
-0000014354 00000 n 
+0000001673 00000 n 
+0000005205 00000 n 
+0000006220 00000 n 
+0000005258 00000 n 
+0000006440 00000 n 
+0000007368 00000 n 
+0000007567 00000 n 
+0000008251 00000 n 
+0000007598 00000 n 
+0000008472 00000 n 
+0000009372 00000 n 
+0000009571 00000 n 
+0000010252 00000 n 
+0000009602 00000 n 
+0000010473 00000 n 
+0000011373 00000 n 
+0000011572 00000 n 
+0000012694 00000 n 
+0000011648 00000 n 
+0000012915 00000 n 
+0000013877 00000 n 
+0000014139 00000 n 
+0000014238 00000 n 
 trailer
-<< /Size 65 /Root 63 0 R /Info 64 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 64 /Root 62 0 R /Info 63 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-14488
+14372
 %%EOF

--- a/required/latex-lab/testfiles-OR-luatex/test9.tpf
+++ b/required/latex-lab/testfiles-OR-luatex/test9.tpf
@@ -3,7 +3,7 @@
 28 0 obj
 << /Type/OBJR/Obj 27 0 R/Pg 21 0 R >>
 endobj
-35 0 obj
+34 0 obj
 << /Length 596 >>        
 stream
 /opacity1 gs
@@ -52,57 +52,57 @@ EMC
 endstream
 endobj
 21 0 obj
-<< /Type /Page /Contents 35 0 R /Resources 34 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 48 0 R /Annots 49 0 R >>
+<< /Type /Page /Contents 34 0 R /Resources 33 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 47 0 R /Annots 48 0 R >>
 endobj
-49 0 obj
+48 0 obj
 [ 27 0 R ]
 endobj
 27 0 obj
-<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 1  /Rect [ 167.641 656.13 174.1 666.478 ]/A  << /S /GoTo /D (footnote*.5) /SD 43 0 R >> >>
+<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 1  /Rect [ 167.641 656.13 174.1 666.478 ]/A  << /S /GoTo /D (footnote*.5) /SD 42 0 R >> >>
 endobj
-36 0 obj
+35 0 obj
 << /D [ 21 0 R /XYZ 132.768 705.06 null ] >>
 endobj
-37 0 obj
+36 0 obj
 [ 22 0 R /XYZ 132.768 705.06 null ]
 endobj
-38 0 obj
+37 0 obj
 << /D [ 21 0 R /XYZ 133.768 667.198 null ] >>
 endobj
-39 0 obj
+38 0 obj
 [ 22 0 R /XYZ 133.768 667.198 null ]
 endobj
-42 0 obj
+41 0 obj
 << /D [ 21 0 R /XYZ 133.768 650.946 null ] >>
+endobj
+42 0 obj
+[ 31 0 R /XYZ 133.768 650.946 null ]
 endobj
 43 0 obj
-[ 32 0 R /XYZ 133.768 650.946 null ]
-endobj
-44 0 obj
 << /D [ 21 0 R /XYZ 133.768 650.946 null ] >>
 endobj
-45 0 obj
-[ 32 0 R /XYZ 133.768 650.946 null ]
+44 0 obj
+[ 31 0 R /XYZ 133.768 650.946 null ]
 endobj
-34 0 obj
-<< /ExtGState 1 0 R /Font << /F15 40 0 R /F27 41 0 R /F37 46 0 R /F29 47 0 R >> >>
+33 0 obj
+<< /ExtGState 1 0 R /Font << /F15 39 0 R /F27 40 0 R /F37 45 0 R /F29 46 0 R >> >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-50 0 obj
+49 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 24 0 R 26 0 R 33 0 R 32 0 R] 
+<< /Nums [0 [ 24 0 R 26 0 R 32 0 R 31 0 R] 
 1 26 0 R
 ] >>
 endobj
-51 0 obj
-<< /Limits [(ID.002) (ID.011)]/Names [(ID.002) 22 0 R (ID.003) 23 0 R (ID.004) 24 0 R (ID.005) 25 0 R (ID.006) 26 0 R (ID.007) 29 0 R (ID.008) 30 0 R (ID.009) 31 0 R (ID.010) 32 0 R (ID.011) 33 0 R ] >>
+50 0 obj
+<< /Limits [(ID.002) (ID.010)]/Names [(ID.002) 22 0 R (ID.003) 23 0 R (ID.004) 24 0 R (ID.005) 25 0 R (ID.006) 26 0 R (ID.007) 29 0 R (ID.008) 30 0 R (ID.009) 31 0 R (ID.010) 32 0 R ] >>
 endobj
-52 0 obj
-<< /Kids [51 0 R] >>
+51 0 obj
+<< /Kids [50 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
@@ -150,34 +150,31 @@ endobj
 <<  /Type /StructElem /S /Link /NS 11 0 R  /P 25 0 R /K [<</Type /MCR /Pg 21 0 R /MCID 1>>  28 0 R] /ID (ID.006) >>
 endobj
 29 0 obj
-<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 24 0 R /Ref [ 25 0 R ] /K [30 0 R 31 0 R] /ID (ID.007) >>
+<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 24 0 R /Ref [ 25 0 R ] /K [32 0 R 30 0 R] /ID (ID.007) >>
 endobj
 30 0 obj
-<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 29 0 R /K 33 0 R /ID (ID.008) >>
+<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 29 0 R /K 31 0 R /ID (ID.008) >>
 endobj
 31 0 obj
-<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 29 0 R /K 32 0 R /ID (ID.009) >>
+<<  /Type /StructElem /S /text /NS 15 0 R  /P 30 0 R /K [  <</Type /MCR /Pg 21 0 R /MCID 3>>  ] /ID (ID.009) >>
 endobj
 32 0 obj
-<<  /Type /StructElem /S /text /NS 15 0 R  /P 31 0 R /K [  <</Type /MCR /Pg 21 0 R /MCID 3>>  ] /ID (ID.010) >>
-endobj
-33 0 obj
-<<  /Type /StructElem /S /NonStruct /NS 11 0 R  /P 30 0 R /K <</Type /MCR /Pg 21 0 R /MCID 2>>  /ID (ID.011) >>
+<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 29 0 R /K <</Type /MCR /Pg 21 0 R /MCID 2>>  /ID (ID.010) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 52 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 22 0 R >>
+<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 51 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 22 0 R >>
 endobj
-53 0 obj
+52 0 obj
 [ 28 [ 531 ] 35 [ 590 ] 43 [ 472 ] ]
 endobj
-55 0 obj
+54 0 obj
 << /Subtype /CIDFontType0C /Length 878 >>        
 [BINARY STREAM]
 endobj
-54 0 obj
-<< /Type /FontDescriptor /FontName /NMCSWH+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 55 0 R >>
+53 0 obj
+<< /Type /FontDescriptor /FontName /NMCSWH+LMRoman8-Regular /Flags 4 /FontBBox [ -456 -292 1497 1125 ] /Ascent 1125 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 98 /XHeight 431 /FontFile3 54 0 R >>
 endobj
-56 0 obj
+55 0 obj
 << /Length 715 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -215,23 +212,23 @@ end
 %%EOF
 endstream
 endobj
-47 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NMCSWH+LMRoman8-Regular /DescendantFonts [ 57 0 R ] /ToUnicode 56 0 R >>
+46 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NMCSWH+LMRoman8-Regular /DescendantFonts [ 56 0 R ] /ToUnicode 55 0 R >>
+endobj
+56 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NMCSWH+LMRoman8-Regular /FontDescriptor 53 0 R /W 52 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 57 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NMCSWH+LMRoman8-Regular /FontDescriptor 54 0 R /W 53 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-58 0 obj
 [ 82 [ 611 ] ]
 endobj
-60 0 obj
+59 0 obj
 << /Subtype /CIDFontType0C /Length 569 >>        
 [BINARY STREAM]
 endobj
-59 0 obj
-<< /Type /FontDescriptor /FontName /JHITRX+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 60 0 R >>
+58 0 obj
+<< /Type /FontDescriptor /FontName /JHITRX+LMRoman6-Regular /Flags 4 /FontBBox [ -515 -298 1647 1125 ] /Ascent 1125 /CapHeight 683 /Descent -298 /ItalicAngle 0 /StemV 117 /XHeight 431 /FontFile3 59 0 R >>
 endobj
-61 0 obj
+60 0 obj
 << /Length 687 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -267,23 +264,23 @@ end
 %%EOF
 endstream
 endobj
-46 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JHITRX+LMRoman6-Regular /DescendantFonts [ 62 0 R ] /ToUnicode 61 0 R >>
+45 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JHITRX+LMRoman6-Regular /DescendantFonts [ 61 0 R ] /ToUnicode 60 0 R >>
+endobj
+61 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JHITRX+LMRoman6-Regular /FontDescriptor 58 0 R /W 57 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 62 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JHITRX+LMRoman6-Regular /FontDescriptor 59 0 R /W 58 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-63 0 obj
 [ 82 [ 569 ] ]
 endobj
-65 0 obj
+64 0 obj
 << /Subtype /CIDFontType0C /Length 566 >>        
 [BINARY STREAM]
 endobj
-64 0 obj
-<< /Type /FontDescriptor /FontName /JEFPUV+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 65 0 R >>
+63 0 obj
+<< /Type /FontDescriptor /FontName /JEFPUV+LMRoman7-Regular /Flags 4 /FontBBox [ -483 -292 1562 1124 ] /Ascent 1124 /CapHeight 683 /Descent -292 /ItalicAngle 0 /StemV 108 /XHeight 431 /FontFile3 64 0 R >>
 endobj
-66 0 obj
+65 0 obj
 << /Length 687 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -319,23 +316,23 @@ end
 %%EOF
 endstream
 endobj
-41 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JEFPUV+LMRoman7-Regular /DescendantFonts [ 67 0 R ] /ToUnicode 66 0 R >>
+40 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /JEFPUV+LMRoman7-Regular /DescendantFonts [ 66 0 R ] /ToUnicode 65 0 R >>
+endobj
+66 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JEFPUV+LMRoman7-Regular /FontDescriptor 63 0 R /W 62 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 67 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /JEFPUV+LMRoman7-Regular /FontDescriptor 64 0 R /W 63 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-68 0 obj
 [ 28 [ 500 ] 82 [ 500 ] ]
 endobj
-70 0 obj
+69 0 obj
 << /Subtype /CIDFontType0C /Length 721 >>        
 [BINARY STREAM]
 endobj
-69 0 obj
-<< /Type /FontDescriptor /FontName /KKHHMF+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 70 0 R >>
+68 0 obj
+<< /Type /FontDescriptor /FontName /KKHHMF+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 69 0 R >>
 endobj
-71 0 obj
+70 0 obj
 << /Length 706 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -372,108 +369,107 @@ end
 %%EOF
 endstream
 endobj
-40 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /KKHHMF+LMRoman10-Regular /DescendantFonts [ 72 0 R ] /ToUnicode 71 0 R >>
+39 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /KKHHMF+LMRoman10-Regular /DescendantFonts [ 71 0 R ] /ToUnicode 70 0 R >>
 endobj
-72 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /KKHHMF+LMRoman10-Regular /FontDescriptor 69 0 R /W 68 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+71 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /KKHHMF+LMRoman10-Regular /FontDescriptor 68 0 R /W 67 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
-48 0 obj
+47 0 obj
 << /Type /Pages  /Count 1 /Kids [ 21 0 R ] >>
 endobj
+72 0 obj
+<< /Names [ (Doc-Start) 37 0 R (footnote*.5) 41 0 R (footnote*.7) 43 0 R (page.1) 35 0 R ] /Limits [ (Doc-Start) (page.1) ] >>
+endobj
 73 0 obj
-<< /Names [ (Doc-Start) 38 0 R (footnote*.5) 42 0 R (footnote*.7) 44 0 R (page.1) 36 0 R ] /Limits [ (Doc-Start) (page.1) ] >>
+<< /Dests 72 0 R >>
 endobj
 74 0 obj
-<< /Dests 73 0 R >>
+<< /Type /Catalog /Pages 47 0 R /Names 73 0 R /MarkInfo 49 0 R/PageMode /UseOutlines/OpenAction <</S/GoTo /D [21 0 R /Fit] /SD [22 0 R/Fit]>>/Lang (en)/PageLabels <</Nums[0<</S/D>>]>>/StructTreeRoot 5 0 R >>
 endobj
 75 0 obj
-<< /Type /Catalog /Pages 48 0 R /Names 74 0 R /MarkInfo 50 0 R/PageMode /UseOutlines/OpenAction <</S/GoTo /D [21 0 R /Fit] /SD [22 0 R/Fit]>>/Lang (en)/PageLabels <</Nums[0<</S/D>>]>>/StructTreeRoot 5 0 R >>
-endobj
-76 0 obj
 << /Producer (LuaTeX)/Creator <FEFF004C006100540065005800200077006900740068002000680079007000650072007200650066> /CreationDate (D:20160520090000Z) /ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 77
+0 76
 0000000002 65535 f 
 0000001681 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000010 00000 f 
-0000005284 00000 n 
+0000005168 00000 n 
 0000001764 00000 n 
-0000002093 00000 n 
-0000004045 00000 n 
-0000002672 00000 n 
+0000002077 00000 n 
+0000004029 00000 n 
+0000002656 00000 n 
 0000000012 00000 f 
-0000002740 00000 n 
+0000002724 00000 n 
 0000000014 00000 f 
-0000002810 00000 n 
+0000002794 00000 n 
 0000000020 00000 f 
-0000003573 00000 n 
-0000002891 00000 n 
-0000003851 00000 n 
-0000003680 00000 n 
-0000003958 00000 n 
+0000003557 00000 n 
+0000002875 00000 n 
+0000003835 00000 n 
+0000003664 00000 n 
+0000003942 00000 n 
 0000000000 00000 f 
 0000000730 00000 n 
-0000004106 00000 n 
-0000004204 00000 n 
-0000004304 00000 n 
-0000004445 00000 n 
-0000004568 00000 n 
+0000004090 00000 n 
+0000004188 00000 n 
+0000004288 00000 n 
+0000004429 00000 n 
+0000004552 00000 n 
 0000000907 00000 n 
 0000000020 00000 n 
-0000004700 00000 n 
-0000004824 00000 n 
-0000004928 00000 n 
-0000005028 00000 n 
-0000005156 00000 n 
+0000004684 00000 n 
+0000004808 00000 n 
+0000004908 00000 n 
+0000005036 00000 n 
 0000001582 00000 n 
 0000000074 00000 n 
 0000001124 00000 n 
 0000001185 00000 n 
 0000001237 00000 n 
 0000001299 00000 n 
-0000013605 00000 n 
-0000011419 00000 n 
+0000013489 00000 n 
+0000011303 00000 n 
 0000001352 00000 n 
 0000001414 00000 n 
 0000001467 00000 n 
 0000001529 00000 n 
-0000009418 00000 n 
-0000007414 00000 n 
-0000013959 00000 n 
+0000009302 00000 n 
+0000007298 00000 n 
+0000013843 00000 n 
 0000000880 00000 n 
 0000001728 00000 n 
 0000001837 00000 n 
-0000002056 00000 n 
-0000005404 00000 n 
-0000006419 00000 n 
-0000005457 00000 n 
-0000006639 00000 n 
-0000007567 00000 n 
-0000007766 00000 n 
-0000008450 00000 n 
-0000007797 00000 n 
-0000008671 00000 n 
-0000009571 00000 n 
-0000009770 00000 n 
-0000010451 00000 n 
-0000009801 00000 n 
-0000010672 00000 n 
-0000011572 00000 n 
-0000011771 00000 n 
-0000012618 00000 n 
-0000011813 00000 n 
-0000012839 00000 n 
-0000013759 00000 n 
-0000014021 00000 n 
-0000014164 00000 n 
-0000014200 00000 n 
-0000014424 00000 n 
+0000002040 00000 n 
+0000005288 00000 n 
+0000006303 00000 n 
+0000005341 00000 n 
+0000006523 00000 n 
+0000007451 00000 n 
+0000007650 00000 n 
+0000008334 00000 n 
+0000007681 00000 n 
+0000008555 00000 n 
+0000009455 00000 n 
+0000009654 00000 n 
+0000010335 00000 n 
+0000009685 00000 n 
+0000010556 00000 n 
+0000011456 00000 n 
+0000011655 00000 n 
+0000012502 00000 n 
+0000011697 00000 n 
+0000012723 00000 n 
+0000013643 00000 n 
+0000013905 00000 n 
+0000014048 00000 n 
+0000014084 00000 n 
+0000014308 00000 n 
 trailer
-<< /Size 77 /Root 75 0 R /Info 76 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 76 /Root 74 0 R /Info 75 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-14635
+14519
 %%EOF

--- a/required/latex-lab/testfiles-OR/check-declarations.tlg
+++ b/required/latex-lab/testfiles-OR/check-declarations.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -63,7 +63,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext

--- a/required/latex-lab/testfiles-OR/footmisc-002.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-002.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -63,7 +63,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext

--- a/required/latex-lab/testfiles-OR/footmisc-003.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-003.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -63,7 +63,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
@@ -222,7 +222,7 @@ Completed box being shipped out [1]
 .....\pdfliteral page{EMC}
 .....\write1{\new@label@record{mcid-14}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{14}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Link <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 3 } action goto name{footnote*.14}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 3 } action goto name{footnote*.13}
 .....\hbox(8.16115+0.0)x4.48514
 ......\mathon
 ......\hbox(4.53223+0.0)x4.48514, shifted -3.62892
@@ -243,30 +243,30 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,12,13,text,,,}
-....\marks4{b+,12,13,text,,,}
-....\marks4{e-,12,13,}
-....\marks4{e+,12,13,}
-....\marks4{b-,13,14,Lbl,,,}
-....\marks4{b+,13,14,Lbl,,,}
-....\marks4{e-,13,14,}
-....\marks4{e+,13,14,}
-....\marks4{b-,14,15,Link,,,}
-....\marks4{b+,14,15,Link,,,}
-....\marks4{e-,14,15,}
-....\marks4{e+,14,15,}
-....\marks4{b-,15,14,Lbl,,,}
-....\marks4{b+,15,14,Lbl,,,}
-....\marks4{e-,15,14,}
-....\marks4{e+,15,14,}
-....\marks4{b-,16,13,text,,,}
-....\marks4{b+,16,13,text,,,}
-....\marks4{e-,16,13,}
-....\marks4{e+,16,13,}
-....\marks4{b-,22,13,text,,,}
-....\marks4{b+,22,13,text,,,}
-....\marks4{e-,22,13,}
-....\marks4{e+,22,13,}
+....\marks4{b-,12,12,text,,,}
+....\marks4{b+,12,12,text,,,}
+....\marks4{e-,12,12,}
+....\marks4{e+,12,12,}
+....\marks4{b-,13,13,Lbl,,,}
+....\marks4{b+,13,13,Lbl,,,}
+....\marks4{e-,13,13,}
+....\marks4{e+,13,13,}
+....\marks4{b-,14,14,Link,,,}
+....\marks4{b+,14,14,Link,,,}
+....\marks4{e-,14,14,}
+....\marks4{e+,14,14,}
+....\marks4{b-,15,13,Lbl,,,}
+....\marks4{b+,15,13,Lbl,,,}
+....\marks4{e-,15,13,}
+....\marks4{e+,15,13,}
+....\marks4{b-,16,12,text,,,}
+....\marks4{b+,16,12,text,,,}
+....\marks4{e-,16,12,}
+....\marks4{e+,16,12,}
+....\marks4{b-,22,12,text,,,}
+....\marks4{b+,22,12,text,,,}
+....\marks4{e-,22,12,}
+....\marks4{e+,22,12,}
 ....\glue 0.0 plus 1.0fil
 ....\kern 0.0
 ....\hbox(0.0+0.0)x0.0
@@ -283,13 +283,13 @@ Completed box being shipped out [1]
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
 .......\pdfdest name{footnote*.5} xyz
-.......\pdfdest struct20 name{footnote*.5} xyz
+.......\pdfdest struct19 name{footnote*.5} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
 .......\pdfdest name{footnote*.7} xyz
-.......\pdfdest struct20 name{footnote*.7} xyz
+.......\pdfdest struct19 name{footnote*.7} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-7}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{7}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -318,26 +318,26 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,6,10,text,,,}
-....\marks4{b+,6,10,text,,,}
-....\marks4{e-,6,10,}
-....\marks4{e+,6,10,}
-....\marks4{b-,7,11,Lbl,,,}
-....\marks4{b+,7,11,Lbl,,,}
-....\marks4{e-,7,11,}
-....\marks4{e+,7,11,}
-....\marks4{b-,8,10,text,,,}
-....\marks4{b+,8,10,text,,,}
-....\marks4{e-,8,10,}
-....\marks4{e+,8,10,}
-....\marks4{b-,9,10,text,,,}
-....\marks4{b+,9,10,text,,,}
-....\marks4{e-,9,10,}
-....\marks4{e+,9,10,}
-....\marks4{b-,10,10,text,,,}
-....\marks4{b+,10,10,text,,,}
-....\marks4{e-,10,10,}
-....\marks4{e+,10,10,}
+....\marks4{b-,6,9,text,,,}
+....\marks4{b+,6,9,text,,,}
+....\marks4{e-,6,9,}
+....\marks4{e+,6,9,}
+....\marks4{b-,7,10,Lbl,,,}
+....\marks4{b+,7,10,Lbl,,,}
+....\marks4{e-,7,10,}
+....\marks4{e+,7,10,}
+....\marks4{b-,8,9,text,,,}
+....\marks4{b+,8,9,text,,,}
+....\marks4{e-,8,9,}
+....\marks4{e+,8,9,}
+....\marks4{b-,9,9,text,,,}
+....\marks4{b+,9,9,text,,,}
+....\marks4{e-,9,9,}
+....\marks4{e+,9,9,}
+....\marks4{b-,10,9,text,,,}
+....\marks4{b+,10,9,text,,,}
+....\marks4{e-,10,9,}
+....\marks4{e+,10,9,}
 ....\hbox(6.6724+2.85002)x345.0, glue set 320.98918fil
 .....\write1{\new@label@record{mcid-17}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{17}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -345,14 +345,14 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.14} xyz
-.......\pdfdest struct31 name{footnote*.14} xyz
+.......\pdfdest name{footnote*.13} xyz
+.......\pdfdest struct29 name{footnote*.13} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.16} xyz
-.......\pdfdest struct31 name{footnote*.16} xyz
+.......\pdfdest name{footnote*.15} xyz
+.......\pdfdest struct29 name{footnote*.15} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-18}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{18}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -381,26 +381,26 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,17,19,text,,,}
-....\marks4{b+,17,19,text,,,}
-....\marks4{e-,17,19,}
-....\marks4{e+,17,19,}
-....\marks4{b-,18,20,Lbl,,,}
-....\marks4{b+,18,20,Lbl,,,}
-....\marks4{e-,18,20,}
-....\marks4{e+,18,20,}
-....\marks4{b-,19,19,text,,,}
-....\marks4{b+,19,19,text,,,}
-....\marks4{e-,19,19,}
-....\marks4{e+,19,19,}
-....\marks4{b-,20,19,text,,,}
-....\marks4{b+,20,19,text,,,}
-....\marks4{e-,20,19,}
-....\marks4{e+,20,19,}
-....\marks4{b-,21,19,text,,,}
-....\marks4{b+,21,19,text,,,}
-....\marks4{e-,21,19,}
-....\marks4{e+,21,19,}
+....\marks4{b-,17,17,text,,,}
+....\marks4{b+,17,17,text,,,}
+....\marks4{e-,17,17,}
+....\marks4{e+,17,17,}
+....\marks4{b-,18,18,Lbl,,,}
+....\marks4{b+,18,18,Lbl,,,}
+....\marks4{e-,18,18,}
+....\marks4{e+,18,18,}
+....\marks4{b-,19,17,text,,,}
+....\marks4{b+,19,17,text,,,}
+....\marks4{e-,19,17,}
+....\marks4{e+,19,17,}
+....\marks4{b-,20,17,text,,,}
+....\marks4{b+,20,17,text,,,}
+....\marks4{e-,20,17,}
+....\marks4{e+,20,17,}
+....\marks4{b-,21,17,text,,,}
+....\marks4{b+,21,17,text,,,}
+....\marks4{e-,21,17,}
+....\marks4{e+,21,17,}
 ....\kern -2.85002
 ....\hbox(0.0+2.85002)x0.0
 ....\glue -2.85002
@@ -480,7 +480,7 @@ Completed box being shipped out [2]
 .....\pdfliteral page{EMC}
 .....\write1{\new@label@record{mcid-27}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{27}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Link <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 4 } action goto name{footnote*.23}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 4 } action goto name{footnote*.21}
 .....\hbox(8.16115+0.0)x4.48514
 ......\mathon
 ......\hbox(4.53223+0.0)x4.48514, shifted -3.62892
@@ -501,30 +501,30 @@ Completed box being shipped out [2]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,25,22,text,,,}
-....\marks4{b+,25,22,text,,,}
-....\marks4{e-,25,22,}
-....\marks4{e+,25,22,}
-....\marks4{b-,26,23,Lbl,,,}
-....\marks4{b+,26,23,Lbl,,,}
-....\marks4{e-,26,23,}
-....\marks4{e+,26,23,}
-....\marks4{b-,27,24,Link,,,}
-....\marks4{b+,27,24,Link,,,}
-....\marks4{e-,27,24,}
-....\marks4{e+,27,24,}
-....\marks4{b-,28,23,Lbl,,,}
-....\marks4{b+,28,23,Lbl,,,}
-....\marks4{e-,28,23,}
-....\marks4{e+,28,23,}
-....\marks4{b-,29,22,text,,,}
-....\marks4{b+,29,22,text,,,}
-....\marks4{e-,29,22,}
-....\marks4{e+,29,22,}
-....\marks4{b-,35,22,text,,,}
-....\marks4{b+,35,22,text,,,}
-....\marks4{e-,35,22,}
-....\marks4{e+,35,22,}
+....\marks4{b-,25,20,text,,,}
+....\marks4{b+,25,20,text,,,}
+....\marks4{e-,25,20,}
+....\marks4{e+,25,20,}
+....\marks4{b-,26,21,Lbl,,,}
+....\marks4{b+,26,21,Lbl,,,}
+....\marks4{e-,26,21,}
+....\marks4{e+,26,21,}
+....\marks4{b-,27,22,Link,,,}
+....\marks4{b+,27,22,Link,,,}
+....\marks4{e-,27,22,}
+....\marks4{e+,27,22,}
+....\marks4{b-,28,21,Lbl,,,}
+....\marks4{b+,28,21,Lbl,,,}
+....\marks4{e-,28,21,}
+....\marks4{e+,28,21,}
+....\marks4{b-,29,20,text,,,}
+....\marks4{b+,29,20,text,,,}
+....\marks4{e-,29,20,}
+....\marks4{e+,29,20,}
+....\marks4{b-,35,20,text,,,}
+....\marks4{b+,35,20,text,,,}
+....\marks4{e-,35,20,}
+....\marks4{e+,35,20,}
 ....\glue 0.0 plus 1.0fil
 ....\kern 0.0
 ....\hbox(0.0+0.0)x0.0
@@ -540,14 +540,14 @@ Completed box being shipped out [2]
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.23} xyz
-.......\pdfdest struct62 name{footnote*.23} xyz
+.......\pdfdest name{footnote*.21} xyz
+.......\pdfdest struct59 name{footnote*.21} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.25} xyz
-.......\pdfdest struct62 name{footnote*.25} xyz
+.......\pdfdest name{footnote*.23} xyz
+.......\pdfdest struct59 name{footnote*.23} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-31}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{31}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -576,26 +576,26 @@ Completed box being shipped out [2]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,30,28,text,,,}
-....\marks4{b+,30,28,text,,,}
-....\marks4{e-,30,28,}
-....\marks4{e+,30,28,}
-....\marks4{b-,31,29,Lbl,,,}
-....\marks4{b+,31,29,Lbl,,,}
-....\marks4{e-,31,29,}
-....\marks4{e+,31,29,}
-....\marks4{b-,32,28,text,,,}
-....\marks4{b+,32,28,text,,,}
-....\marks4{e-,32,28,}
-....\marks4{e+,32,28,}
-....\marks4{b-,33,28,text,,,}
-....\marks4{b+,33,28,text,,,}
-....\marks4{e-,33,28,}
-....\marks4{e+,33,28,}
-....\marks4{b-,34,28,text,,,}
-....\marks4{b+,34,28,text,,,}
-....\marks4{e-,34,28,}
-....\marks4{e+,34,28,}
+....\marks4{b-,30,25,text,,,}
+....\marks4{b+,30,25,text,,,}
+....\marks4{e-,30,25,}
+....\marks4{e+,30,25,}
+....\marks4{b-,31,26,Lbl,,,}
+....\marks4{b+,31,26,Lbl,,,}
+....\marks4{e-,31,26,}
+....\marks4{e+,31,26,}
+....\marks4{b-,32,25,text,,,}
+....\marks4{b+,32,25,text,,,}
+....\marks4{e-,32,25,}
+....\marks4{e+,32,25,}
+....\marks4{b-,33,25,text,,,}
+....\marks4{b+,33,25,text,,,}
+....\marks4{e-,33,25,}
+....\marks4{e+,33,25,}
+....\marks4{b-,34,25,text,,,}
+....\marks4{b+,34,25,text,,,}
+....\marks4{e-,34,25,}
+....\marks4{e+,34,25,}
 ....\kern -2.85002
 ....\hbox(0.0+2.85002)x0.0
 ....\glue -2.85002

--- a/required/latex-lab/testfiles-OR/footmisc-004.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-004.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -63,7 +63,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
@@ -226,7 +226,7 @@ Completed box being shipped out [1]
 .....\pdfliteral page{EMC}
 .....\write1{\new@label@record{mcid-14}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{14}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Link <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 3 } action goto name{footnote*.14}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 3 } action goto name{footnote*.13}
 .....\hbox(8.16115+0.0)x4.48514
 ......\mathon
 ......\hbox(4.53223+0.0)x4.48514, shifted -3.62892
@@ -247,30 +247,30 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,12,13,text,,,}
-....\marks4{b+,12,13,text,,,}
-....\marks4{e-,12,13,}
-....\marks4{e+,12,13,}
-....\marks4{b-,13,14,Lbl,,,}
-....\marks4{b+,13,14,Lbl,,,}
-....\marks4{e-,13,14,}
-....\marks4{e+,13,14,}
-....\marks4{b-,14,15,Link,,,}
-....\marks4{b+,14,15,Link,,,}
-....\marks4{e-,14,15,}
-....\marks4{e+,14,15,}
-....\marks4{b-,15,14,Lbl,,,}
-....\marks4{b+,15,14,Lbl,,,}
-....\marks4{e-,15,14,}
-....\marks4{e+,15,14,}
-....\marks4{b-,16,13,text,,,}
-....\marks4{b+,16,13,text,,,}
-....\marks4{e-,16,13,}
-....\marks4{e+,16,13,}
-....\marks4{b-,22,13,text,,,}
-....\marks4{b+,22,13,text,,,}
-....\marks4{e-,22,13,}
-....\marks4{e+,22,13,}
+....\marks4{b-,12,12,text,,,}
+....\marks4{b+,12,12,text,,,}
+....\marks4{e-,12,12,}
+....\marks4{e+,12,12,}
+....\marks4{b-,13,13,Lbl,,,}
+....\marks4{b+,13,13,Lbl,,,}
+....\marks4{e-,13,13,}
+....\marks4{e+,13,13,}
+....\marks4{b-,14,14,Link,,,}
+....\marks4{b+,14,14,Link,,,}
+....\marks4{e-,14,14,}
+....\marks4{e+,14,14,}
+....\marks4{b-,15,13,Lbl,,,}
+....\marks4{b+,15,13,Lbl,,,}
+....\marks4{e-,15,13,}
+....\marks4{e+,15,13,}
+....\marks4{b-,16,12,text,,,}
+....\marks4{b+,16,12,text,,,}
+....\marks4{e-,16,12,}
+....\marks4{e+,16,12,}
+....\marks4{b-,22,12,text,,,}
+....\marks4{b+,22,12,text,,,}
+....\marks4{e-,22,12,}
+....\marks4{e+,22,12,}
 ....\glue 0.0 plus 1.0fil
 ....\kern 0.0
 ....\hbox(0.0+0.0)x0.0
@@ -287,13 +287,13 @@ Completed box being shipped out [1]
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
 .......\pdfdest name{footnote*.5} xyz
-.......\pdfdest struct20 name{footnote*.5} xyz
+.......\pdfdest struct19 name{footnote*.5} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
 .......\pdfdest name{footnote*.7} xyz
-.......\pdfdest struct20 name{footnote*.7} xyz
+.......\pdfdest struct19 name{footnote*.7} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-7}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{7}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -322,26 +322,26 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,6,10,text,,,}
-....\marks4{b+,6,10,text,,,}
-....\marks4{e-,6,10,}
-....\marks4{e+,6,10,}
-....\marks4{b-,7,11,Lbl,,,}
-....\marks4{b+,7,11,Lbl,,,}
-....\marks4{e-,7,11,}
-....\marks4{e+,7,11,}
-....\marks4{b-,8,10,text,,,}
-....\marks4{b+,8,10,text,,,}
-....\marks4{e-,8,10,}
-....\marks4{e+,8,10,}
-....\marks4{b-,9,10,text,,,}
-....\marks4{b+,9,10,text,,,}
-....\marks4{e-,9,10,}
-....\marks4{e+,9,10,}
-....\marks4{b-,10,10,text,,,}
-....\marks4{b+,10,10,text,,,}
-....\marks4{e-,10,10,}
-....\marks4{e+,10,10,}
+....\marks4{b-,6,9,text,,,}
+....\marks4{b+,6,9,text,,,}
+....\marks4{e-,6,9,}
+....\marks4{e+,6,9,}
+....\marks4{b-,7,10,Lbl,,,}
+....\marks4{b+,7,10,Lbl,,,}
+....\marks4{e-,7,10,}
+....\marks4{e+,7,10,}
+....\marks4{b-,8,9,text,,,}
+....\marks4{b+,8,9,text,,,}
+....\marks4{e-,8,9,}
+....\marks4{e+,8,9,}
+....\marks4{b-,9,9,text,,,}
+....\marks4{b+,9,9,text,,,}
+....\marks4{e-,9,9,}
+....\marks4{e+,9,9,}
+....\marks4{b-,10,9,text,,,}
+....\marks4{b+,10,9,text,,,}
+....\marks4{e-,10,9,}
+....\marks4{e+,10,9,}
 ....\hbox(6.6724+2.85002)x345.0, glue set 320.98918fil
 .....\write1{\new@label@record{mcid-17}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{17}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -349,14 +349,14 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.14} xyz
-.......\pdfdest struct31 name{footnote*.14} xyz
+.......\pdfdest name{footnote*.13} xyz
+.......\pdfdest struct29 name{footnote*.13} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.16} xyz
-.......\pdfdest struct31 name{footnote*.16} xyz
+.......\pdfdest name{footnote*.15} xyz
+.......\pdfdest struct29 name{footnote*.15} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-18}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{18}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -385,26 +385,26 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,17,19,text,,,}
-....\marks4{b+,17,19,text,,,}
-....\marks4{e-,17,19,}
-....\marks4{e+,17,19,}
-....\marks4{b-,18,20,Lbl,,,}
-....\marks4{b+,18,20,Lbl,,,}
-....\marks4{e-,18,20,}
-....\marks4{e+,18,20,}
-....\marks4{b-,19,19,text,,,}
-....\marks4{b+,19,19,text,,,}
-....\marks4{e-,19,19,}
-....\marks4{e+,19,19,}
-....\marks4{b-,20,19,text,,,}
-....\marks4{b+,20,19,text,,,}
-....\marks4{e-,20,19,}
-....\marks4{e+,20,19,}
-....\marks4{b-,21,19,text,,,}
-....\marks4{b+,21,19,text,,,}
-....\marks4{e-,21,19,}
-....\marks4{e+,21,19,}
+....\marks4{b-,17,17,text,,,}
+....\marks4{b+,17,17,text,,,}
+....\marks4{e-,17,17,}
+....\marks4{e+,17,17,}
+....\marks4{b-,18,18,Lbl,,,}
+....\marks4{b+,18,18,Lbl,,,}
+....\marks4{e-,18,18,}
+....\marks4{e+,18,18,}
+....\marks4{b-,19,17,text,,,}
+....\marks4{b+,19,17,text,,,}
+....\marks4{e-,19,17,}
+....\marks4{e+,19,17,}
+....\marks4{b-,20,17,text,,,}
+....\marks4{b+,20,17,text,,,}
+....\marks4{e-,20,17,}
+....\marks4{e+,20,17,}
+....\marks4{b-,21,17,text,,,}
+....\marks4{b+,21,17,text,,,}
+....\marks4{e-,21,17,}
+....\marks4{e+,21,17,}
 ....\kern -2.85002
 ....\hbox(0.0+2.85002)x0.0
 ....\glue -2.85002
@@ -486,7 +486,7 @@ Completed box being shipped out [2]
 .....\pdfliteral page{EMC}
 .....\write1{\new@label@record{mcid-27}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{27}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Link <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 4 } action goto name{footnote*.23}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 4 } action goto name{footnote*.21}
 .....\hbox(8.16115+0.0)x4.48514
 ......\mathon
 ......\hbox(4.53223+0.0)x4.48514, shifted -3.62892
@@ -507,30 +507,30 @@ Completed box being shipped out [2]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,25,22,text,,,}
-....\marks4{b+,25,22,text,,,}
-....\marks4{e-,25,22,}
-....\marks4{e+,25,22,}
-....\marks4{b-,26,23,Lbl,,,}
-....\marks4{b+,26,23,Lbl,,,}
-....\marks4{e-,26,23,}
-....\marks4{e+,26,23,}
-....\marks4{b-,27,24,Link,,,}
-....\marks4{b+,27,24,Link,,,}
-....\marks4{e-,27,24,}
-....\marks4{e+,27,24,}
-....\marks4{b-,28,23,Lbl,,,}
-....\marks4{b+,28,23,Lbl,,,}
-....\marks4{e-,28,23,}
-....\marks4{e+,28,23,}
-....\marks4{b-,29,22,text,,,}
-....\marks4{b+,29,22,text,,,}
-....\marks4{e-,29,22,}
-....\marks4{e+,29,22,}
-....\marks4{b-,35,22,text,,,}
-....\marks4{b+,35,22,text,,,}
-....\marks4{e-,35,22,}
-....\marks4{e+,35,22,}
+....\marks4{b-,25,20,text,,,}
+....\marks4{b+,25,20,text,,,}
+....\marks4{e-,25,20,}
+....\marks4{e+,25,20,}
+....\marks4{b-,26,21,Lbl,,,}
+....\marks4{b+,26,21,Lbl,,,}
+....\marks4{e-,26,21,}
+....\marks4{e+,26,21,}
+....\marks4{b-,27,22,Link,,,}
+....\marks4{b+,27,22,Link,,,}
+....\marks4{e-,27,22,}
+....\marks4{e+,27,22,}
+....\marks4{b-,28,21,Lbl,,,}
+....\marks4{b+,28,21,Lbl,,,}
+....\marks4{e-,28,21,}
+....\marks4{e+,28,21,}
+....\marks4{b-,29,20,text,,,}
+....\marks4{b+,29,20,text,,,}
+....\marks4{e-,29,20,}
+....\marks4{e+,29,20,}
+....\marks4{b-,35,20,text,,,}
+....\marks4{b+,35,20,text,,,}
+....\marks4{e-,35,20,}
+....\marks4{e+,35,20,}
 ....\glue 0.0 plus 1.0fil
 ....\kern 0.0
 ....\hbox(0.0+0.0)x0.0
@@ -546,14 +546,14 @@ Completed box being shipped out [2]
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.23} xyz
-.......\pdfdest struct62 name{footnote*.23} xyz
+.......\pdfdest name{footnote*.21} xyz
+.......\pdfdest struct59 name{footnote*.21} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.25} xyz
-.......\pdfdest struct62 name{footnote*.25} xyz
+.......\pdfdest name{footnote*.23} xyz
+.......\pdfdest struct59 name{footnote*.23} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-31}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{31}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -582,26 +582,26 @@ Completed box being shipped out [2]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,30,28,text,,,}
-....\marks4{b+,30,28,text,,,}
-....\marks4{e-,30,28,}
-....\marks4{e+,30,28,}
-....\marks4{b-,31,29,Lbl,,,}
-....\marks4{b+,31,29,Lbl,,,}
-....\marks4{e-,31,29,}
-....\marks4{e+,31,29,}
-....\marks4{b-,32,28,text,,,}
-....\marks4{b+,32,28,text,,,}
-....\marks4{e-,32,28,}
-....\marks4{e+,32,28,}
-....\marks4{b-,33,28,text,,,}
-....\marks4{b+,33,28,text,,,}
-....\marks4{e-,33,28,}
-....\marks4{e+,33,28,}
-....\marks4{b-,34,28,text,,,}
-....\marks4{b+,34,28,text,,,}
-....\marks4{e-,34,28,}
-....\marks4{e+,34,28,}
+....\marks4{b-,30,25,text,,,}
+....\marks4{b+,30,25,text,,,}
+....\marks4{e-,30,25,}
+....\marks4{e+,30,25,}
+....\marks4{b-,31,26,Lbl,,,}
+....\marks4{b+,31,26,Lbl,,,}
+....\marks4{e-,31,26,}
+....\marks4{e+,31,26,}
+....\marks4{b-,32,25,text,,,}
+....\marks4{b+,32,25,text,,,}
+....\marks4{e-,32,25,}
+....\marks4{e+,32,25,}
+....\marks4{b-,33,25,text,,,}
+....\marks4{b+,33,25,text,,,}
+....\marks4{e-,33,25,}
+....\marks4{e+,33,25,}
+....\marks4{b-,34,25,text,,,}
+....\marks4{b+,34,25,text,,,}
+....\marks4{e-,34,25,}
+....\marks4{e+,34,25,}
 ....\kern -2.85002
 ....\hbox(0.0+2.85002)x0.0
 ....\glue -2.85002

--- a/required/latex-lab/testfiles-OR/footmisc-005.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-005.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -63,7 +63,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
@@ -201,22 +201,22 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,7,10,text,,,}
-...\marks4{b+,7,10,text,,,}
-...\marks4{e-,7,10,}
-...\marks4{e+,7,10,}
-...\marks4{b-,8,11,Lbl,,,}
-...\marks4{b+,8,11,Lbl,,,}
-...\marks4{e-,8,11,}
-...\marks4{e+,8,11,}
-...\marks4{b-,9,10,text,,,}
-...\marks4{b+,9,10,text,,,}
-...\marks4{e-,9,10,}
-...\marks4{e+,9,10,}
-...\marks4{b-,12,10,text,,,}
-...\marks4{b+,12,10,text,,,}
-...\marks4{e-,12,10,}
-...\marks4{e+,12,10,}
+...\marks4{b-,7,9,text,,,}
+...\marks4{b+,7,9,text,,,}
+...\marks4{e-,7,9,}
+...\marks4{e+,7,9,}
+...\marks4{b-,8,10,Lbl,,,}
+...\marks4{b+,8,10,Lbl,,,}
+...\marks4{e-,8,10,}
+...\marks4{e+,8,10,}
+...\marks4{b-,9,9,text,,,}
+...\marks4{b+,9,9,text,,,}
+...\marks4{e-,9,9,}
+...\marks4{e+,9,9,}
+...\marks4{b-,12,9,text,,,}
+...\marks4{b+,12,9,text,,,}
+...\marks4{e-,12,9,}
+...\marks4{e+,12,9,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.83885
@@ -263,34 +263,34 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,13,16,text,,,}
-...\marks4{b+,13,16,text,,,}
-...\marks4{e-,13,16,}
-...\marks4{e+,13,16,}
-...\marks4{b-,14,17,Lbl,,,}
-...\marks4{b+,14,17,Lbl,,,}
-...\marks4{e-,14,17,}
-...\marks4{e+,14,17,}
-...\marks4{b-,15,16,text,,,}
-...\marks4{b+,15,16,text,,,}
-...\marks4{e-,15,16,}
-...\marks4{e+,15,16,}
-...\marks4{b-,18,16,text,,,}
-...\marks4{b+,18,16,text,,,}
-...\marks4{e-,18,16,}
-...\marks4{e+,18,16,}
-...\marks4{b-,19,21,Lbl,,,}
-...\marks4{b+,19,21,Lbl,,,}
-...\marks4{e-,19,21,}
-...\marks4{e+,19,21,}
-...\marks4{b-,20,16,text,,,}
-...\marks4{b+,20,16,text,,,}
-...\marks4{e-,20,16,}
-...\marks4{e+,20,16,}
-...\marks4{b-,23,16,text,,,}
-...\marks4{b+,23,16,text,,,}
-...\marks4{e-,23,16,}
-...\marks4{e+,23,16,}
+...\marks4{b-,13,14,text,,,}
+...\marks4{b+,13,14,text,,,}
+...\marks4{e-,13,14,}
+...\marks4{e+,13,14,}
+...\marks4{b-,14,15,Lbl,,,}
+...\marks4{b+,14,15,Lbl,,,}
+...\marks4{e-,14,15,}
+...\marks4{e+,14,15,}
+...\marks4{b-,15,14,text,,,}
+...\marks4{b+,15,14,text,,,}
+...\marks4{e-,15,14,}
+...\marks4{e+,15,14,}
+...\marks4{b-,18,14,text,,,}
+...\marks4{b+,18,14,text,,,}
+...\marks4{e-,18,14,}
+...\marks4{e+,18,14,}
+...\marks4{b-,19,18,Lbl,,,}
+...\marks4{b+,19,18,Lbl,,,}
+...\marks4{e-,19,18,}
+...\marks4{e+,19,18,}
+...\marks4{b-,20,14,text,,,}
+...\marks4{b+,20,14,text,,,}
+...\marks4{e-,20,14,}
+...\marks4{e+,20,14,}
+...\marks4{b-,23,14,text,,,}
+...\marks4{b+,23,14,text,,,}
+...\marks4{e-,23,14,}
+...\marks4{e+,23,14,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.83885
@@ -324,22 +324,22 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,24,26,text,,,}
-...\marks4{b+,24,26,text,,,}
-...\marks4{e-,24,26,}
-...\marks4{e+,24,26,}
-...\marks4{b-,25,27,Lbl,,,}
-...\marks4{b+,25,27,Lbl,,,}
-...\marks4{e-,25,27,}
-...\marks4{e+,25,27,}
-...\marks4{b-,26,26,text,,,}
-...\marks4{b+,26,26,text,,,}
-...\marks4{e-,26,26,}
-...\marks4{e+,26,26,}
-...\marks4{b-,29,26,text,,,}
-...\marks4{b+,29,26,text,,,}
-...\marks4{e-,29,26,}
-...\marks4{e+,29,26,}
+...\marks4{b-,24,22,text,,,}
+...\marks4{b+,24,22,text,,,}
+...\marks4{e-,24,22,}
+...\marks4{e+,24,22,}
+...\marks4{b-,25,23,Lbl,,,}
+...\marks4{b+,25,23,Lbl,,,}
+...\marks4{e-,25,23,}
+...\marks4{e+,25,23,}
+...\marks4{b-,26,22,text,,,}
+...\marks4{b+,26,22,text,,,}
+...\marks4{e-,26,22,}
+...\marks4{e+,26,22,}
+...\marks4{b-,29,22,text,,,}
+...\marks4{b+,29,22,text,,,}
+...\marks4{e-,29,22,}
+...\marks4{e+,29,22,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.83885
@@ -391,34 +391,34 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,30,32,text,,,}
-...\marks4{b+,30,32,text,,,}
-...\marks4{e-,30,32,}
-...\marks4{e+,30,32,}
-...\marks4{b-,31,33,Lbl,,,}
-...\marks4{b+,31,33,Lbl,,,}
-...\marks4{e-,31,33,}
-...\marks4{e+,31,33,}
-...\marks4{b-,32,32,text,,,}
-...\marks4{b+,32,32,text,,,}
-...\marks4{e-,32,32,}
-...\marks4{e+,32,32,}
-...\marks4{b-,35,32,text,,,}
-...\marks4{b+,35,32,text,,,}
-...\marks4{e-,35,32,}
-...\marks4{e+,35,32,}
-...\marks4{b-,36,37,Lbl,,,}
-...\marks4{b+,36,37,Lbl,,,}
-...\marks4{e-,36,37,}
-...\marks4{e+,36,37,}
-...\marks4{b-,37,32,text,,,}
-...\marks4{b+,37,32,text,,,}
-...\marks4{e-,37,32,}
-...\marks4{e+,37,32,}
-...\marks4{b-,40,32,text,,,}
-...\marks4{b+,40,32,text,,,}
-...\marks4{e-,40,32,}
-...\marks4{e+,40,32,}
+...\marks4{b-,30,27,text,,,}
+...\marks4{b+,30,27,text,,,}
+...\marks4{e-,30,27,}
+...\marks4{e+,30,27,}
+...\marks4{b-,31,28,Lbl,,,}
+...\marks4{b+,31,28,Lbl,,,}
+...\marks4{e-,31,28,}
+...\marks4{e+,31,28,}
+...\marks4{b-,32,27,text,,,}
+...\marks4{b+,32,27,text,,,}
+...\marks4{e-,32,27,}
+...\marks4{e+,32,27,}
+...\marks4{b-,35,27,text,,,}
+...\marks4{b+,35,27,text,,,}
+...\marks4{e-,35,27,}
+...\marks4{e+,35,27,}
+...\marks4{b-,36,31,Lbl,,,}
+...\marks4{b+,36,31,Lbl,,,}
+...\marks4{e-,36,31,}
+...\marks4{e+,36,31,}
+...\marks4{b-,37,27,text,,,}
+...\marks4{b+,37,27,text,,,}
+...\marks4{e-,37,27,}
+...\marks4{e+,37,27,}
+...\marks4{b-,40,27,text,,,}
+...\marks4{b+,40,27,text,,,}
+...\marks4{e-,40,27,}
+...\marks4{e+,40,27,}
 ...\glue 0.0 plus 1.0fil
 ...\kern 0.0
 ...\hbox(0.0+0.0)x0.0
@@ -596,44 +596,44 @@ Completed box being shipped out [1]
 ....\rule(6.64996+2.85002)x0.0
 ....\penalty -10
 ....\glue(\rightskip) 0.0
-...\marks4{b-,4,8,Lbl,,,}
-...\marks4{b+,4,8,Lbl,,,}
-...\marks4{e-,4,8,}
-...\marks4{e+,4,8,}
+...\marks4{b-,4,7,Lbl,,,}
+...\marks4{b+,4,7,Lbl,,,}
+...\marks4{e-,4,7,}
+...\marks4{e+,4,7,}
 ...\marks4{b-,5,6,footnote,,,}
 ...\marks4{b+,5,6,footnote,,,}
 ...\marks4{e-,5,6,}
 ...\marks4{e+,5,6,}
-...\marks4{b-,10,14,Lbl,,,}
-...\marks4{b+,10,14,Lbl,,,}
-...\marks4{e-,10,14,}
-...\marks4{e+,10,14,}
-...\marks4{b-,11,12,footnote,,,}
-...\marks4{b+,11,12,footnote,,,}
-...\marks4{e-,11,12,}
-...\marks4{e+,11,12,}
-...\marks4{b-,16,20,Lbl,,,}
-...\marks4{b+,16,20,Lbl,,,}
-...\marks4{e-,16,20,}
-...\marks4{e+,16,20,}
-...\marks4{b-,17,18,footnote,,,}
-...\marks4{b+,17,18,footnote,,,}
-...\marks4{e-,17,18,}
-...\marks4{e+,17,18,}
-...\marks4{b-,21,24,Lbl,,,}
-...\marks4{b+,21,24,Lbl,,,}
-...\marks4{e-,21,24,}
-...\marks4{e+,21,24,}
-...\marks4{b-,22,22,footnote,,,}
-...\marks4{b+,22,22,footnote,,,}
-...\marks4{e-,22,22,}
-...\marks4{e+,22,22,}
-...\marks4{b-,27,30,Lbl,,,}
-...\marks4{b+,27,30,Lbl,,,}
-...\marks4{e-,27,30,}
-...\marks4{e+,27,30,}
-...\marks4{b-,28,28,footnote,,,}
-...\marks4{b+,28,28,footnote,,,}
+...\marks4{b-,10,12,Lbl,,,}
+...\marks4{b+,10,12,Lbl,,,}
+...\marks4{e-,10,12,}
+...\marks4{e+,10,12,}
+...\marks4{b-,11,11,footnote,,,}
+...\marks4{b+,11,11,footnote,,,}
+...\marks4{e-,11,11,}
+...\marks4{e+,11,11,}
+...\marks4{b-,16,17,Lbl,,,}
+...\marks4{b+,16,17,Lbl,,,}
+...\marks4{e-,16,17,}
+...\marks4{e+,16,17,}
+...\marks4{b-,17,16,footnote,,,}
+...\marks4{b+,17,16,footnote,,,}
+...\marks4{e-,17,16,}
+...\marks4{e+,17,16,}
+...\marks4{b-,21,20,Lbl,,,}
+...\marks4{b+,21,20,Lbl,,,}
+...\marks4{e-,21,20,}
+...\marks4{e+,21,20,}
+...\marks4{b-,22,19,footnote,,,}
+...\marks4{b+,22,19,footnote,,,}
+...\marks4{e-,22,19,}
+...\marks4{e+,22,19,}
+...\marks4{b-,27,25,Lbl,,,}
+...\marks4{b+,27,25,Lbl,,,}
+...\marks4{e-,27,25,}
+...\marks4{e+,27,25,}
+...\marks4{b-,28,24,footnote,,,}
+...\marks4{b+,28,24,footnote,,,}
 ...\penalty 300
 ...\glue(\lineskip) 1.0
 ...\hbox(6.6724+2.85002)x345.0, glue set 141.30095fil
@@ -724,24 +724,24 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{e-,28,28,}
-...\marks4{e+,28,28,}
-...\marks4{b-,33,36,Lbl,,,}
-...\marks4{b+,33,36,Lbl,,,}
-...\marks4{e-,33,36,}
-...\marks4{e+,33,36,}
-...\marks4{b-,34,34,footnote,,,}
-...\marks4{b+,34,34,footnote,,,}
-...\marks4{e-,34,34,}
-...\marks4{e+,34,34,}
-...\marks4{b-,38,40,Lbl,,,}
-...\marks4{b+,38,40,Lbl,,,}
-...\marks4{e-,38,40,}
-...\marks4{e+,38,40,}
-...\marks4{b-,39,38,footnote,,,}
-...\marks4{b+,39,38,footnote,,,}
-...\marks4{e-,39,38,}
-...\marks4{e+,39,38,}
+...\marks4{e-,28,24,}
+...\marks4{e+,28,24,}
+...\marks4{b-,33,30,Lbl,,,}
+...\marks4{b+,33,30,Lbl,,,}
+...\marks4{e-,33,30,}
+...\marks4{e+,33,30,}
+...\marks4{b-,34,29,footnote,,,}
+...\marks4{b+,34,29,footnote,,,}
+...\marks4{e-,34,29,}
+...\marks4{e+,34,29,}
+...\marks4{b-,38,33,Lbl,,,}
+...\marks4{b+,38,33,Lbl,,,}
+...\marks4{e-,38,33,}
+...\marks4{e+,38,33,}
+...\marks4{b-,39,32,footnote,,,}
+...\marks4{b+,39,32,footnote,,,}
+...\marks4{e-,39,32,}
+...\marks4{e+,39,32,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue -2.85002

--- a/required/latex-lab/testfiles-OR/footmisc-006.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-006.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -63,7 +63,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
@@ -227,7 +227,7 @@ Completed box being shipped out [1]
 .....\pdfliteral page{EMC}
 .....\write1{\new@label@record{mcid-11}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{11}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Link <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 3 } action goto name{footnote*.12}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 3 } action goto name{footnote*.11}
 .....\hbox(8.16115+0.0)x4.48514
 ......\mathon
 ......\hbox(4.53223+0.0)x4.48514, shifted -3.62892
@@ -248,30 +248,30 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,9,11,text,,,}
-....\marks4{b+,9,11,text,,,}
-....\marks4{e-,9,11,}
-....\marks4{e+,9,11,}
-....\marks4{b-,10,12,Lbl,,,}
-....\marks4{b+,10,12,Lbl,,,}
-....\marks4{e-,10,12,}
-....\marks4{e+,10,12,}
-....\marks4{b-,11,13,Link,,,}
-....\marks4{b+,11,13,Link,,,}
-....\marks4{e-,11,13,}
-....\marks4{e+,11,13,}
-....\marks4{b-,12,12,Lbl,,,}
-....\marks4{b+,12,12,Lbl,,,}
-....\marks4{e-,12,12,}
-....\marks4{e+,12,12,}
-....\marks4{b-,13,11,text,,,}
-....\marks4{b+,13,11,text,,,}
-....\marks4{e-,13,11,}
-....\marks4{e+,13,11,}
-....\marks4{b-,16,11,text,,,}
-....\marks4{b+,16,11,text,,,}
-....\marks4{e-,16,11,}
-....\marks4{e+,16,11,}
+....\marks4{b-,9,10,text,,,}
+....\marks4{b+,9,10,text,,,}
+....\marks4{e-,9,10,}
+....\marks4{e+,9,10,}
+....\marks4{b-,10,11,Lbl,,,}
+....\marks4{b+,10,11,Lbl,,,}
+....\marks4{e-,10,11,}
+....\marks4{e+,10,11,}
+....\marks4{b-,11,12,Link,,,}
+....\marks4{b+,11,12,Link,,,}
+....\marks4{e-,11,12,}
+....\marks4{e+,11,12,}
+....\marks4{b-,12,11,Lbl,,,}
+....\marks4{b+,12,11,Lbl,,,}
+....\marks4{e-,12,11,}
+....\marks4{e+,12,11,}
+....\marks4{b-,13,10,text,,,}
+....\marks4{b+,13,10,text,,,}
+....\marks4{e-,13,10,}
+....\marks4{e+,13,10,}
+....\marks4{b-,16,10,text,,,}
+....\marks4{b+,16,10,text,,,}
+....\marks4{e-,16,10,}
+....\marks4{e+,16,10,}
 ....\glue(\parskip) 0.0 plus 1.0
 ....\glue(\parskip) 0.0
 ....\glue(\baselineskip) 3.83885
@@ -293,7 +293,7 @@ Completed box being shipped out [1]
 .....\pdfliteral page{EMC}
 .....\write1{\new@label@record{mcid-19}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{19}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Link <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 4 } action goto name{footnote*.19}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 4 } action goto name{footnote*.17}
 .....\hbox(8.16115+0.0)x4.48514
 ......\mathon
 ......\hbox(4.53223+0.0)x4.48514, shifted -3.62892
@@ -319,7 +319,7 @@ Completed box being shipped out [1]
 .....\pdfliteral page{EMC}
 .....\write1{\new@label@record{mcid-26}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{26}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Link <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 5 } action goto name{footnote*.24}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 5 } action goto name{footnote*.21}
 .....\hbox(8.16115+0.0)x4.48514
 ......\mathon
 ......\hbox(4.53223+0.0)x4.48514, shifted -3.62892
@@ -340,50 +340,50 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,17,18,text,,,}
-....\marks4{b+,17,18,text,,,}
-....\marks4{e-,17,18,}
-....\marks4{e+,17,18,}
-....\marks4{b-,18,19,Lbl,,,}
-....\marks4{b+,18,19,Lbl,,,}
-....\marks4{e-,18,19,}
-....\marks4{e+,18,19,}
-....\marks4{b-,19,20,Link,,,}
-....\marks4{b+,19,20,Link,,,}
-....\marks4{e-,19,20,}
-....\marks4{e+,19,20,}
-....\marks4{b-,20,19,Lbl,,,}
-....\marks4{b+,20,19,Lbl,,,}
-....\marks4{e-,20,19,}
-....\marks4{e+,20,19,}
-....\marks4{b-,21,18,text,,,}
-....\marks4{b+,21,18,text,,,}
-....\marks4{e-,21,18,}
-....\marks4{e+,21,18,}
-....\marks4{b-,24,18,text,,,}
-....\marks4{b+,24,18,text,,,}
-....\marks4{e-,24,18,}
-....\marks4{e+,24,18,}
-....\marks4{b-,25,24,Lbl,,,}
-....\marks4{b+,25,24,Lbl,,,}
-....\marks4{e-,25,24,}
-....\marks4{e+,25,24,}
-....\marks4{b-,26,25,Link,,,}
-....\marks4{b+,26,25,Link,,,}
-....\marks4{e-,26,25,}
-....\marks4{e+,26,25,}
-....\marks4{b-,27,24,Lbl,,,}
-....\marks4{b+,27,24,Lbl,,,}
-....\marks4{e-,27,24,}
-....\marks4{e+,27,24,}
-....\marks4{b-,28,18,text,,,}
-....\marks4{b+,28,18,text,,,}
-....\marks4{e-,28,18,}
-....\marks4{e+,28,18,}
-....\marks4{b-,31,18,text,,,}
-....\marks4{b+,31,18,text,,,}
-....\marks4{e-,31,18,}
-....\marks4{e+,31,18,}
+....\marks4{b-,17,16,text,,,}
+....\marks4{b+,17,16,text,,,}
+....\marks4{e-,17,16,}
+....\marks4{e+,17,16,}
+....\marks4{b-,18,17,Lbl,,,}
+....\marks4{b+,18,17,Lbl,,,}
+....\marks4{e-,18,17,}
+....\marks4{e+,18,17,}
+....\marks4{b-,19,18,Link,,,}
+....\marks4{b+,19,18,Link,,,}
+....\marks4{e-,19,18,}
+....\marks4{e+,19,18,}
+....\marks4{b-,20,17,Lbl,,,}
+....\marks4{b+,20,17,Lbl,,,}
+....\marks4{e-,20,17,}
+....\marks4{e+,20,17,}
+....\marks4{b-,21,16,text,,,}
+....\marks4{b+,21,16,text,,,}
+....\marks4{e-,21,16,}
+....\marks4{e+,21,16,}
+....\marks4{b-,24,16,text,,,}
+....\marks4{b+,24,16,text,,,}
+....\marks4{e-,24,16,}
+....\marks4{e+,24,16,}
+....\marks4{b-,25,21,Lbl,,,}
+....\marks4{b+,25,21,Lbl,,,}
+....\marks4{e-,25,21,}
+....\marks4{e+,25,21,}
+....\marks4{b-,26,22,Link,,,}
+....\marks4{b+,26,22,Link,,,}
+....\marks4{e-,26,22,}
+....\marks4{e+,26,22,}
+....\marks4{b-,27,21,Lbl,,,}
+....\marks4{b+,27,21,Lbl,,,}
+....\marks4{e-,27,21,}
+....\marks4{e+,27,21,}
+....\marks4{b-,28,16,text,,,}
+....\marks4{b+,28,16,text,,,}
+....\marks4{e-,28,16,}
+....\marks4{e+,28,16,}
+....\marks4{b-,31,16,text,,,}
+....\marks4{b+,31,16,text,,,}
+....\marks4{e-,31,16,}
+....\marks4{e+,31,16,}
 ....\glue(\parskip) 0.0 plus 1.0
 ....\glue(\parskip) 0.0
 ....\glue(\baselineskip) 3.83885
@@ -405,7 +405,7 @@ Completed box being shipped out [1]
 .....\pdfliteral page{EMC}
 .....\write1{\new@label@record{mcid-34}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{34}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Link <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 6 } action goto name{footnote*.31}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 6 } action goto name{footnote*.27}
 .....\hbox(8.16115+0.0)x4.48514
 ......\mathon
 ......\hbox(4.53223+0.0)x4.48514, shifted -3.62892
@@ -426,30 +426,30 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,32,30,text,,,}
-....\marks4{b+,32,30,text,,,}
-....\marks4{e-,32,30,}
-....\marks4{e+,32,30,}
-....\marks4{b-,33,31,Lbl,,,}
-....\marks4{b+,33,31,Lbl,,,}
-....\marks4{e-,33,31,}
-....\marks4{e+,33,31,}
-....\marks4{b-,34,32,Link,,,}
-....\marks4{b+,34,32,Link,,,}
-....\marks4{e-,34,32,}
-....\marks4{e+,34,32,}
-....\marks4{b-,35,31,Lbl,,,}
-....\marks4{b+,35,31,Lbl,,,}
-....\marks4{e-,35,31,}
-....\marks4{e+,35,31,}
-....\marks4{b-,36,30,text,,,}
-....\marks4{b+,36,30,text,,,}
-....\marks4{e-,36,30,}
-....\marks4{e+,36,30,}
-....\marks4{b-,39,30,text,,,}
-....\marks4{b+,39,30,text,,,}
-....\marks4{e-,39,30,}
-....\marks4{e+,39,30,}
+....\marks4{b-,32,26,text,,,}
+....\marks4{b+,32,26,text,,,}
+....\marks4{e-,32,26,}
+....\marks4{e+,32,26,}
+....\marks4{b-,33,27,Lbl,,,}
+....\marks4{b+,33,27,Lbl,,,}
+....\marks4{e-,33,27,}
+....\marks4{e+,33,27,}
+....\marks4{b-,34,28,Link,,,}
+....\marks4{b+,34,28,Link,,,}
+....\marks4{e-,34,28,}
+....\marks4{e+,34,28,}
+....\marks4{b-,35,27,Lbl,,,}
+....\marks4{b+,35,27,Lbl,,,}
+....\marks4{e-,35,27,}
+....\marks4{e+,35,27,}
+....\marks4{b-,36,26,text,,,}
+....\marks4{b+,36,26,text,,,}
+....\marks4{e-,36,26,}
+....\marks4{e+,36,26,}
+....\marks4{b-,39,26,text,,,}
+....\marks4{b+,39,26,text,,,}
+....\marks4{e-,39,26,}
+....\marks4{e+,39,26,}
 ....\glue(\parskip) 0.0 plus 1.0
 ....\glue(\parskip) 0.0
 ....\glue(\baselineskip) 3.83885
@@ -471,7 +471,7 @@ Completed box being shipped out [1]
 .....\pdfliteral page{EMC}
 .....\write1{\new@label@record{mcid-42}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{42}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Link <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 7 } action goto name{footnote*.38}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 7 } action goto name{footnote*.33}
 .....\hbox(8.16115+0.0)x4.48514
 ......\mathon
 ......\hbox(4.53223+0.0)x4.48514, shifted -3.62892
@@ -502,7 +502,7 @@ Completed box being shipped out [1]
 .....\pdfliteral page{EMC}
 .....\write1{\new@label@record{mcid-49}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{49}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Link <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 8 } action goto name{footnote*.43}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 8 } action goto name{footnote*.37}
 .....\hbox(8.16115+0.0)x4.48514
 ......\mathon
 ......\hbox(4.53223+0.0)x4.48514, shifted -3.62892
@@ -523,50 +523,50 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,40,37,text,,,}
-....\marks4{b+,40,37,text,,,}
-....\marks4{e-,40,37,}
-....\marks4{e+,40,37,}
-....\marks4{b-,41,38,Lbl,,,}
-....\marks4{b+,41,38,Lbl,,,}
-....\marks4{e-,41,38,}
-....\marks4{e+,41,38,}
-....\marks4{b-,42,39,Link,,,}
-....\marks4{b+,42,39,Link,,,}
-....\marks4{e-,42,39,}
-....\marks4{e+,42,39,}
-....\marks4{b-,43,38,Lbl,,,}
-....\marks4{b+,43,38,Lbl,,,}
-....\marks4{e-,43,38,}
-....\marks4{e+,43,38,}
-....\marks4{b-,44,37,text,,,}
-....\marks4{b+,44,37,text,,,}
-....\marks4{e-,44,37,}
-....\marks4{e+,44,37,}
-....\marks4{b-,47,37,text,,,}
-....\marks4{b+,47,37,text,,,}
-....\marks4{e-,47,37,}
-....\marks4{e+,47,37,}
-....\marks4{b-,48,43,Lbl,,,}
-....\marks4{b+,48,43,Lbl,,,}
-....\marks4{e-,48,43,}
-....\marks4{e+,48,43,}
-....\marks4{b-,49,44,Link,,,}
-....\marks4{b+,49,44,Link,,,}
-....\marks4{e-,49,44,}
-....\marks4{e+,49,44,}
-....\marks4{b-,50,43,Lbl,,,}
-....\marks4{b+,50,43,Lbl,,,}
-....\marks4{e-,50,43,}
-....\marks4{e+,50,43,}
-....\marks4{b-,51,37,text,,,}
-....\marks4{b+,51,37,text,,,}
-....\marks4{e-,51,37,}
-....\marks4{e+,51,37,}
-....\marks4{b-,54,37,text,,,}
-....\marks4{b+,54,37,text,,,}
-....\marks4{e-,54,37,}
-....\marks4{e+,54,37,}
+....\marks4{b-,40,32,text,,,}
+....\marks4{b+,40,32,text,,,}
+....\marks4{e-,40,32,}
+....\marks4{e+,40,32,}
+....\marks4{b-,41,33,Lbl,,,}
+....\marks4{b+,41,33,Lbl,,,}
+....\marks4{e-,41,33,}
+....\marks4{e+,41,33,}
+....\marks4{b-,42,34,Link,,,}
+....\marks4{b+,42,34,Link,,,}
+....\marks4{e-,42,34,}
+....\marks4{e+,42,34,}
+....\marks4{b-,43,33,Lbl,,,}
+....\marks4{b+,43,33,Lbl,,,}
+....\marks4{e-,43,33,}
+....\marks4{e+,43,33,}
+....\marks4{b-,44,32,text,,,}
+....\marks4{b+,44,32,text,,,}
+....\marks4{e-,44,32,}
+....\marks4{e+,44,32,}
+....\marks4{b-,47,32,text,,,}
+....\marks4{b+,47,32,text,,,}
+....\marks4{e-,47,32,}
+....\marks4{e+,47,32,}
+....\marks4{b-,48,37,Lbl,,,}
+....\marks4{b+,48,37,Lbl,,,}
+....\marks4{e-,48,37,}
+....\marks4{e+,48,37,}
+....\marks4{b-,49,38,Link,,,}
+....\marks4{b+,49,38,Link,,,}
+....\marks4{e-,49,38,}
+....\marks4{e+,49,38,}
+....\marks4{b-,50,37,Lbl,,,}
+....\marks4{b+,50,37,Lbl,,,}
+....\marks4{e-,50,37,}
+....\marks4{e+,50,37,}
+....\marks4{b-,51,32,text,,,}
+....\marks4{b+,51,32,text,,,}
+....\marks4{e-,51,32,}
+....\marks4{e+,51,32,}
+....\marks4{b-,54,32,text,,,}
+....\marks4{b+,54,32,text,,,}
+....\marks4{e-,54,32,}
+....\marks4{e+,54,32,}
 ....\glue 0.0 plus 1.0fil
 ....\kern 0.0
 ....\hbox(0.0+0.0)x0.0
@@ -610,14 +610,14 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.12} xyz
-.......\pdfdest struct26 name{footnote*.12} xyz
+.......\pdfdest name{footnote*.11} xyz
+.......\pdfdest struct25 name{footnote*.11} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.14} xyz
-.......\pdfdest struct26 name{footnote*.14} xyz
+.......\pdfdest name{footnote*.13} xyz
+.......\pdfdest struct25 name{footnote*.13} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-14}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{14}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -639,14 +639,14 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.19} xyz
-.......\pdfdest struct35 name{footnote*.19} xyz
+.......\pdfdest name{footnote*.17} xyz
+.......\pdfdest struct33 name{footnote*.17} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.21} xyz
-.......\pdfdest struct35 name{footnote*.21} xyz
+.......\pdfdest name{footnote*.19} xyz
+.......\pdfdest struct33 name{footnote*.19} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-22}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{22}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -668,14 +668,14 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.24} xyz
-.......\pdfdest struct42 name{footnote*.24} xyz
+.......\pdfdest name{footnote*.21} xyz
+.......\pdfdest struct39 name{footnote*.21} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.26} xyz
-.......\pdfdest struct42 name{footnote*.26} xyz
+.......\pdfdest name{footnote*.23} xyz
+.......\pdfdest struct39 name{footnote*.23} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-29}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{29}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -727,14 +727,14 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.31} xyz
-.......\pdfdest struct51 name{footnote*.31} xyz
+.......\pdfdest name{footnote*.27} xyz
+.......\pdfdest struct47 name{footnote*.27} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.33} xyz
-.......\pdfdest struct51 name{footnote*.33} xyz
+.......\pdfdest name{footnote*.29} xyz
+.......\pdfdest struct47 name{footnote*.29} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-37}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{37}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -792,44 +792,44 @@ Completed box being shipped out [1]
 .....\rule(6.64996+2.85002)x0.0
 .....\penalty -10
 .....\glue(\rightskip) 0.0
-....\marks4{b-,6,9,Lbl,,,}
-....\marks4{b+,6,9,Lbl,,,}
-....\marks4{e-,6,9,}
-....\marks4{e+,6,9,}
+....\marks4{b-,6,8,Lbl,,,}
+....\marks4{b+,6,8,Lbl,,,}
+....\marks4{e-,6,8,}
+....\marks4{e+,6,8,}
 ....\marks4{b-,7,7,footnote,,,}
 ....\marks4{b+,7,7,footnote,,,}
 ....\marks4{e-,7,7,}
 ....\marks4{e+,7,7,}
-....\marks4{b-,14,16,Lbl,,,}
-....\marks4{b+,14,16,Lbl,,,}
-....\marks4{e-,14,16,}
-....\marks4{e+,14,16,}
-....\marks4{b-,15,14,footnote,,,}
-....\marks4{b+,15,14,footnote,,,}
-....\marks4{e-,15,14,}
-....\marks4{e+,15,14,}
-....\marks4{b-,22,23,Lbl,,,}
-....\marks4{b+,22,23,Lbl,,,}
-....\marks4{e-,22,23,}
-....\marks4{e+,22,23,}
-....\marks4{b-,23,21,footnote,,,}
-....\marks4{b+,23,21,footnote,,,}
-....\marks4{e-,23,21,}
-....\marks4{e+,23,21,}
-....\marks4{b-,29,28,Lbl,,,}
-....\marks4{b+,29,28,Lbl,,,}
-....\marks4{e-,29,28,}
-....\marks4{e+,29,28,}
-....\marks4{b-,30,26,footnote,,,}
-....\marks4{b+,30,26,footnote,,,}
-....\marks4{e-,30,26,}
-....\marks4{e+,30,26,}
-....\marks4{b-,37,35,Lbl,,,}
-....\marks4{b+,37,35,Lbl,,,}
-....\marks4{e-,37,35,}
-....\marks4{e+,37,35,}
-....\marks4{b-,38,33,footnote,,,}
-....\marks4{b+,38,33,footnote,,,}
+....\marks4{b-,14,14,Lbl,,,}
+....\marks4{b+,14,14,Lbl,,,}
+....\marks4{e-,14,14,}
+....\marks4{e+,14,14,}
+....\marks4{b-,15,13,footnote,,,}
+....\marks4{b+,15,13,footnote,,,}
+....\marks4{e-,15,13,}
+....\marks4{e+,15,13,}
+....\marks4{b-,22,20,Lbl,,,}
+....\marks4{b+,22,20,Lbl,,,}
+....\marks4{e-,22,20,}
+....\marks4{e+,22,20,}
+....\marks4{b-,23,19,footnote,,,}
+....\marks4{b+,23,19,footnote,,,}
+....\marks4{e-,23,19,}
+....\marks4{e+,23,19,}
+....\marks4{b-,29,24,Lbl,,,}
+....\marks4{b+,29,24,Lbl,,,}
+....\marks4{e-,29,24,}
+....\marks4{e+,29,24,}
+....\marks4{b-,30,23,footnote,,,}
+....\marks4{b+,30,23,footnote,,,}
+....\marks4{e-,30,23,}
+....\marks4{e+,30,23,}
+....\marks4{b-,37,30,Lbl,,,}
+....\marks4{b+,37,30,Lbl,,,}
+....\marks4{e-,37,30,}
+....\marks4{e+,37,30,}
+....\marks4{b-,38,29,footnote,,,}
+....\marks4{b+,38,29,footnote,,,}
 ....\penalty 300
 ....\glue(\lineskip) 1.0
 ....\hbox(6.6724+2.85002)x345.0, glue set 141.30095fil
@@ -837,14 +837,14 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.38} xyz
-.......\pdfdest struct60 name{footnote*.38} xyz
+.......\pdfdest name{footnote*.33} xyz
+.......\pdfdest struct55 name{footnote*.33} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.40} xyz
-.......\pdfdest struct60 name{footnote*.40} xyz
+.......\pdfdest name{footnote*.35} xyz
+.......\pdfdest struct55 name{footnote*.35} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-45}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{45}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -911,14 +911,14 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.43} xyz
-.......\pdfdest struct67 name{footnote*.43} xyz
+.......\pdfdest name{footnote*.37} xyz
+.......\pdfdest struct61 name{footnote*.37} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.45} xyz
-.......\pdfdest struct67 name{footnote*.45} xyz
+.......\pdfdest name{footnote*.39} xyz
+.......\pdfdest struct61 name{footnote*.39} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-52}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{52}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -940,24 +940,24 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{e-,38,33,}
-....\marks4{e+,38,33,}
-....\marks4{b-,45,42,Lbl,,,}
-....\marks4{b+,45,42,Lbl,,,}
-....\marks4{e-,45,42,}
-....\marks4{e+,45,42,}
-....\marks4{b-,46,40,footnote,,,}
-....\marks4{b+,46,40,footnote,,,}
-....\marks4{e-,46,40,}
-....\marks4{e+,46,40,}
-....\marks4{b-,52,47,Lbl,,,}
-....\marks4{b+,52,47,Lbl,,,}
-....\marks4{e-,52,47,}
-....\marks4{e+,52,47,}
-....\marks4{b-,53,45,footnote,,,}
-....\marks4{b+,53,45,footnote,,,}
-....\marks4{e-,53,45,}
-....\marks4{e+,53,45,}
+....\marks4{e-,38,29,}
+....\marks4{e+,38,29,}
+....\marks4{b-,45,36,Lbl,,,}
+....\marks4{b+,45,36,Lbl,,,}
+....\marks4{e-,45,36,}
+....\marks4{e+,45,36,}
+....\marks4{b-,46,35,footnote,,,}
+....\marks4{b+,46,35,footnote,,,}
+....\marks4{e-,46,35,}
+....\marks4{e+,46,35,}
+....\marks4{b-,52,40,Lbl,,,}
+....\marks4{b+,52,40,Lbl,,,}
+....\marks4{e-,52,40,}
+....\marks4{e+,52,40,}
+....\marks4{b-,53,39,footnote,,,}
+....\marks4{b+,53,39,footnote,,,}
+....\marks4{e-,53,39,}
+....\marks4{e+,53,39,}
 ....\kern -2.85002
 ....\hbox(0.0+2.85002)x0.0
 ....\glue -2.85002
@@ -1038,7 +1038,7 @@ Completed box being shipped out [2]
 .....\pdfliteral page{EMC}
 .....\write1{\new@label@record{mcid-59}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{59}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Link <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 9 } action goto name{footnote*.50}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 9 } action goto name{footnote*.43}
 .....\hbox(8.16115+0.0)x4.48514
 ......\mathon
 ......\hbox(4.53223+0.0)x4.48514, shifted -3.62892
@@ -1059,30 +1059,30 @@ Completed box being shipped out [2]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,57,49,text,,,}
-....\marks4{b+,57,49,text,,,}
-....\marks4{e-,57,49,}
-....\marks4{e+,57,49,}
-....\marks4{b-,58,50,Lbl,,,}
-....\marks4{b+,58,50,Lbl,,,}
-....\marks4{e-,58,50,}
-....\marks4{e+,58,50,}
-....\marks4{b-,59,51,Link,,,}
-....\marks4{b+,59,51,Link,,,}
-....\marks4{e-,59,51,}
-....\marks4{e+,59,51,}
-....\marks4{b-,60,50,Lbl,,,}
-....\marks4{b+,60,50,Lbl,,,}
-....\marks4{e-,60,50,}
-....\marks4{e+,60,50,}
-....\marks4{b-,61,49,text,,,}
-....\marks4{b+,61,49,text,,,}
-....\marks4{e-,61,49,}
-....\marks4{e+,61,49,}
-....\marks4{b-,64,49,text,,,}
-....\marks4{b+,64,49,text,,,}
-....\marks4{e-,64,49,}
-....\marks4{e+,64,49,}
+....\marks4{b-,57,42,text,,,}
+....\marks4{b+,57,42,text,,,}
+....\marks4{e-,57,42,}
+....\marks4{e+,57,42,}
+....\marks4{b-,58,43,Lbl,,,}
+....\marks4{b+,58,43,Lbl,,,}
+....\marks4{e-,58,43,}
+....\marks4{e+,58,43,}
+....\marks4{b-,59,44,Link,,,}
+....\marks4{b+,59,44,Link,,,}
+....\marks4{e-,59,44,}
+....\marks4{e+,59,44,}
+....\marks4{b-,60,43,Lbl,,,}
+....\marks4{b+,60,43,Lbl,,,}
+....\marks4{e-,60,43,}
+....\marks4{e+,60,43,}
+....\marks4{b-,61,42,text,,,}
+....\marks4{b+,61,42,text,,,}
+....\marks4{e-,61,42,}
+....\marks4{e+,61,42,}
+....\marks4{b-,64,42,text,,,}
+....\marks4{b+,64,42,text,,,}
+....\marks4{e-,64,42,}
+....\marks4{e+,64,42,}
 ....\glue 0.0 plus 1.0fil
 ....\kern 0.0
 ....\hbox(0.0+0.0)x0.0
@@ -1097,14 +1097,14 @@ Completed box being shipped out [2]
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.50} xyz
-.......\pdfdest struct117 name{footnote*.50} xyz
+.......\pdfdest name{footnote*.43} xyz
+.......\pdfdest struct110 name{footnote*.43} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.52} xyz
-.......\pdfdest struct117 name{footnote*.52} xyz
+.......\pdfdest name{footnote*.45} xyz
+.......\pdfdest struct110 name{footnote*.45} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-62}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{62}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -1126,14 +1126,14 @@ Completed box being shipped out [2]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,62,54,Lbl,,,}
-....\marks4{b+,62,54,Lbl,,,}
-....\marks4{e-,62,54,}
-....\marks4{e+,62,54,}
-....\marks4{b-,63,52,footnote,,,}
-....\marks4{b+,63,52,footnote,,,}
-....\marks4{e-,63,52,}
-....\marks4{e+,63,52,}
+....\marks4{b-,62,46,Lbl,,,}
+....\marks4{b+,62,46,Lbl,,,}
+....\marks4{e-,62,46,}
+....\marks4{e+,62,46,}
+....\marks4{b-,63,45,footnote,,,}
+....\marks4{b+,63,45,footnote,,,}
+....\marks4{e-,63,45,}
+....\marks4{e+,63,45,}
 ....\kern -2.85002
 ....\hbox(0.0+2.85002)x0.0
 ....\glue -2.85002

--- a/required/latex-lab/testfiles-OR/footmisc-007-rollback.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-007-rollback.tlg
@@ -74,7 +74,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -84,7 +84,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext

--- a/required/latex-lab/testfiles-OR/footmisc-009-multiple-tagging.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-009-multiple-tagging.tlg
@@ -71,7 +71,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -81,7 +81,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
@@ -217,7 +217,7 @@ Completed box being shipped out [1]
 .....\pdfliteral page{EMC}
 .....\write1{\new@label@record{mcid-15}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{15}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Link <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 2 } action goto name{footnote*.12}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 2 } action goto name{footnote*.11}
 .....\hbox(8.16115+0.0)x4.48514
 ......\mathon
 ......\hbox(4.53223+0.0)x4.48514, shifted -3.62892
@@ -258,7 +258,7 @@ Completed box being shipped out [1]
 .....\pdfliteral page{EMC}
 .....\write1{\new@label@record{mcid-27}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{27}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Link <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 3 } action goto name{footnote*.19}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 3 } action goto name{footnote*.17}
 .....\hbox(8.16115+0.0)x4.48514
 ......\mathon
 ......\hbox(4.53223+0.0)x4.48514, shifted -3.62892
@@ -305,18 +305,18 @@ Completed box being shipped out [1]
 ....\marks4{b+,11,4,text,,,}
 ....\marks4{e-,13,4,}
 ....\marks4{e+,13,4,}
-....\marks4{b-,14,12,Lbl,,,}
-....\marks4{b+,14,12,Lbl,,,}
-....\marks4{e-,14,12,}
-....\marks4{e+,14,12,}
-....\marks4{b-,15,13,Link,,,}
-....\marks4{b+,15,13,Link,,,}
-....\marks4{e-,15,13,}
-....\marks4{e+,15,13,}
-....\marks4{b-,16,12,Lbl,,,}
-....\marks4{b+,16,12,Lbl,,,}
-....\marks4{e-,16,12,}
-....\marks4{e+,16,12,}
+....\marks4{b-,14,11,Lbl,,,}
+....\marks4{b+,14,11,Lbl,,,}
+....\marks4{e-,14,11,}
+....\marks4{e+,14,11,}
+....\marks4{b-,15,12,Link,,,}
+....\marks4{b+,15,12,Link,,,}
+....\marks4{e-,15,12,}
+....\marks4{e+,15,12,}
+....\marks4{b-,16,11,Lbl,,,}
+....\marks4{b+,16,11,Lbl,,,}
+....\marks4{e-,16,11,}
+....\marks4{e+,16,11,}
 ....\marks4{b-,17,4,text,,,}
 ....\marks4{b+,17,4,text,,,}
 ....\marks4{e-,17,4,}
@@ -325,18 +325,18 @@ Completed box being shipped out [1]
 ....\marks4{b+,23,4,text,,,}
 ....\marks4{e-,25,4,}
 ....\marks4{e+,25,4,}
-....\marks4{b-,26,19,Lbl,,,}
-....\marks4{b+,26,19,Lbl,,,}
-....\marks4{e-,26,19,}
-....\marks4{e+,26,19,}
-....\marks4{b-,27,20,Link,,,}
-....\marks4{b+,27,20,Link,,,}
-....\marks4{e-,27,20,}
-....\marks4{e+,27,20,}
-....\marks4{b-,28,19,Lbl,,,}
-....\marks4{b+,28,19,Lbl,,,}
-....\marks4{e-,28,19,}
-....\marks4{e+,28,19,}
+....\marks4{b-,26,17,Lbl,,,}
+....\marks4{b+,26,17,Lbl,,,}
+....\marks4{e-,26,17,}
+....\marks4{e+,26,17,}
+....\marks4{b-,27,18,Link,,,}
+....\marks4{b+,27,18,Link,,,}
+....\marks4{e-,27,18,}
+....\marks4{e+,27,18,}
+....\marks4{b-,28,17,Lbl,,,}
+....\marks4{b+,28,17,Lbl,,,}
+....\marks4{e-,28,17,}
+....\marks4{e+,28,17,}
 ....\marks4{b-,29,4,text,,,}
 ....\marks4{b+,29,4,text,,,}
 ....\marks4{e-,29,4,}
@@ -364,7 +364,7 @@ Completed box being shipped out [1]
 .....\pdfliteral page{EMC}
 .....\write1{\new@label@record{mcid-38}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{38}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Link <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 4 } action goto name{footnote*.28}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 4 } action goto name{footnote*.25}
 .....\hbox(8.48885+0.0)x4.05469
 ......\mathon
 ......\hbox(4.85992+1.36078)x4.05469, shifted -3.62892
@@ -394,7 +394,7 @@ Completed box being shipped out [1]
 .....\pdfliteral page{EMC}
 .....\write1{\new@label@record{mcid-48}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{48}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Link <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 5 } action goto name{footnote*.35}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 5 } action goto name{footnote*.31}
 .....\hbox(8.44997+0.0)x4.05469
 ......\mathon
 ......\hbox(4.82104+1.36078)x4.05469, shifted -3.62892
@@ -414,19 +414,19 @@ Completed box being shipped out [1]
 .....\mathon
 .....\hbox(0.80536+1.36078)x2.76334, shifted -3.62892
 ......\pdfliteral page{EMC}
-......\marks4{e-,56,27,}
-......\marks4{e+,56,27,}
+......\marks4{e-,56,24,}
+......\marks4{e+,56,24,}
 ......\pdfliteral page{/Artifact BMC}
 ......\marks4{b-,57,-1,}
 ......\marks4{b+,57,-1,}
 ......\T1/cmr/m/n/7 ,
 ......\pdfliteral page{EMC}
-......\marks4{e-,57,27,}
-......\marks4{e+,57,27,}
+......\marks4{e-,57,24,}
+......\marks4{e+,57,24,}
 ......\write1{\new@label@record{mcid-58}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{58}{tagmcid}{\__property_code_tagmcid: }}}
 ......\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-......\marks4{b-,58,27,text,,,}
-......\marks4{b+,58,27,text,,,}
+......\marks4{b-,58,24,text,,,}
+......\marks4{b+,58,24,text,,,}
 .....\mathoff
 .....\penalty 10000
 .....\pdfliteral page{EMC}
@@ -435,7 +435,7 @@ Completed box being shipped out [1]
 .....\pdfliteral page{EMC}
 .....\write1{\new@label@record{mcid-60}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{60}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Link <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 6 } action goto name{footnote*.14}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 6 } action goto name{footnote*.13}
 .....\hbox(8.16115+0.0)x4.48514
 ......\mathon
 ......\hbox(4.53223+0.0)x4.48514, shifted -3.62892
@@ -456,66 +456,66 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,36,27,text,,,}
-....\marks4{b+,36,27,text,,,}
-....\marks4{e-,36,27,}
-....\marks4{e+,36,27,}
-....\marks4{b-,37,28,Lbl,,,}
-....\marks4{b+,37,28,Lbl,,,}
-....\marks4{e-,37,28,}
-....\marks4{e+,37,28,}
-....\marks4{b-,38,29,Link,,,}
-....\marks4{b+,38,29,Link,,,}
-....\marks4{e-,38,29,}
-....\marks4{e+,38,29,}
-....\marks4{b-,39,28,Lbl,,,}
-....\marks4{b+,39,28,Lbl,,,}
-....\marks4{e-,39,28,}
-....\marks4{e+,39,28,}
-....\marks4{b-,40,27,text,,,}
-....\marks4{b+,40,27,text,,,}
-....\marks4{e-,40,27,}
-....\marks4{e+,40,27,}
-....\marks4{b-,46,27,text,,,}
-....\marks4{b+,46,27,text,,,}
-....\marks4{e-,46,27,}
-....\marks4{e+,46,27,}
-....\marks4{b-,47,35,Lbl,,,}
-....\marks4{b+,47,35,Lbl,,,}
-....\marks4{e-,47,35,}
-....\marks4{e+,47,35,}
-....\marks4{b-,48,36,Link,,,}
-....\marks4{b+,48,36,Link,,,}
-....\marks4{e-,48,36,}
-....\marks4{e+,48,36,}
-....\marks4{b-,49,35,Lbl,,,}
-....\marks4{b+,49,35,Lbl,,,}
-....\marks4{e-,49,35,}
-....\marks4{e+,49,35,}
-....\marks4{b-,50,27,text,,,}
-....\marks4{b+,50,27,text,,,}
-....\marks4{e-,50,27,}
-....\marks4{e+,50,27,}
-....\marks4{b-,56,27,text,,,}
-....\marks4{b+,56,27,text,,,}
-....\marks4{e-,58,27,}
-....\marks4{e+,58,27,}
-....\marks4{b-,59,42,Lbl,,,}
-....\marks4{b+,59,42,Lbl,,,}
-....\marks4{e-,59,42,}
-....\marks4{e+,59,42,}
-....\marks4{b-,60,43,Link,,,}
-....\marks4{b+,60,43,Link,,,}
-....\marks4{e-,60,43,}
-....\marks4{e+,60,43,}
-....\marks4{b-,61,42,Lbl,,,}
-....\marks4{b+,61,42,Lbl,,,}
-....\marks4{e-,61,42,}
-....\marks4{e+,61,42,}
-....\marks4{b-,62,27,text,,,}
-....\marks4{b+,62,27,text,,,}
-....\marks4{e-,62,27,}
-....\marks4{e+,62,27,}
+....\marks4{b-,36,24,text,,,}
+....\marks4{b+,36,24,text,,,}
+....\marks4{e-,36,24,}
+....\marks4{e+,36,24,}
+....\marks4{b-,37,25,Lbl,,,}
+....\marks4{b+,37,25,Lbl,,,}
+....\marks4{e-,37,25,}
+....\marks4{e+,37,25,}
+....\marks4{b-,38,26,Link,,,}
+....\marks4{b+,38,26,Link,,,}
+....\marks4{e-,38,26,}
+....\marks4{e+,38,26,}
+....\marks4{b-,39,25,Lbl,,,}
+....\marks4{b+,39,25,Lbl,,,}
+....\marks4{e-,39,25,}
+....\marks4{e+,39,25,}
+....\marks4{b-,40,24,text,,,}
+....\marks4{b+,40,24,text,,,}
+....\marks4{e-,40,24,}
+....\marks4{e+,40,24,}
+....\marks4{b-,46,24,text,,,}
+....\marks4{b+,46,24,text,,,}
+....\marks4{e-,46,24,}
+....\marks4{e+,46,24,}
+....\marks4{b-,47,31,Lbl,,,}
+....\marks4{b+,47,31,Lbl,,,}
+....\marks4{e-,47,31,}
+....\marks4{e+,47,31,}
+....\marks4{b-,48,32,Link,,,}
+....\marks4{b+,48,32,Link,,,}
+....\marks4{e-,48,32,}
+....\marks4{e+,48,32,}
+....\marks4{b-,49,31,Lbl,,,}
+....\marks4{b+,49,31,Lbl,,,}
+....\marks4{e-,49,31,}
+....\marks4{e+,49,31,}
+....\marks4{b-,50,24,text,,,}
+....\marks4{b+,50,24,text,,,}
+....\marks4{e-,50,24,}
+....\marks4{e+,50,24,}
+....\marks4{b-,56,24,text,,,}
+....\marks4{b+,56,24,text,,,}
+....\marks4{e-,58,24,}
+....\marks4{e+,58,24,}
+....\marks4{b-,59,37,Lbl,,,}
+....\marks4{b+,59,37,Lbl,,,}
+....\marks4{e-,59,37,}
+....\marks4{e+,59,37,}
+....\marks4{b-,60,38,Link,,,}
+....\marks4{b+,60,38,Link,,,}
+....\marks4{e-,60,38,}
+....\marks4{e+,60,38,}
+....\marks4{b-,61,37,Lbl,,,}
+....\marks4{b+,61,37,Lbl,,,}
+....\marks4{e-,61,37,}
+....\marks4{e+,61,37,}
+....\marks4{b-,62,24,text,,,}
+....\marks4{b+,62,24,text,,,}
+....\marks4{e-,62,24,}
+....\marks4{e+,62,24,}
 ....\glue(\parskip) 0.0 plus 1.0
 ....\glue(\parskip) 0.0
 ....\glue(\baselineskip) 3.51115
@@ -530,7 +530,7 @@ Completed box being shipped out [1]
 .....\pdfliteral page{EMC}
 .....\write1{\new@label@record{mcid-70}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{70}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Link <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 7 } action goto name{footnote*.51}
+.....\pdfstartlink(*+*)x* attr{/Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 7 } action goto name{footnote*.45}
 .....\hbox(8.48885+0.0)x5.34604
 ......\mathon
 ......\hbox(4.85992+1.36078)x5.34604, shifted -3.62892
@@ -580,30 +580,30 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,68,50,text,,,}
-....\marks4{b+,68,50,text,,,}
-....\marks4{e-,68,50,}
-....\marks4{e+,68,50,}
-....\marks4{b-,69,51,Lbl,,,}
-....\marks4{b+,69,51,Lbl,,,}
-....\marks4{e-,69,51,}
-....\marks4{e+,69,51,}
-....\marks4{b-,70,52,Link,,,}
-....\marks4{b+,70,52,Link,,,}
-....\marks4{e-,70,52,}
-....\marks4{e+,70,52,}
-....\marks4{b-,71,51,Lbl,,,}
-....\marks4{b+,71,51,Lbl,,,}
-....\marks4{e-,71,51,}
-....\marks4{e+,71,51,}
-....\marks4{b-,72,50,text,,,}
-....\marks4{b+,72,50,text,,,}
-....\marks4{e-,72,50,}
-....\marks4{e+,72,50,}
-....\marks4{b-,78,50,text,,,}
-....\marks4{b+,78,50,text,,,}
-....\marks4{e-,78,50,}
-....\marks4{e+,78,50,}
+....\marks4{b-,68,44,text,,,}
+....\marks4{b+,68,44,text,,,}
+....\marks4{e-,68,44,}
+....\marks4{e+,68,44,}
+....\marks4{b-,69,45,Lbl,,,}
+....\marks4{b+,69,45,Lbl,,,}
+....\marks4{e-,69,45,}
+....\marks4{e+,69,45,}
+....\marks4{b-,70,46,Link,,,}
+....\marks4{b+,70,46,Link,,,}
+....\marks4{e-,70,46,}
+....\marks4{e+,70,46,}
+....\marks4{b-,71,45,Lbl,,,}
+....\marks4{b+,71,45,Lbl,,,}
+....\marks4{e-,71,45,}
+....\marks4{e+,71,45,}
+....\marks4{b-,72,44,text,,,}
+....\marks4{b+,72,44,text,,,}
+....\marks4{e-,72,44,}
+....\marks4{e+,72,44,}
+....\marks4{b-,78,44,text,,,}
+....\marks4{b+,78,44,text,,,}
+....\marks4{e-,78,44,}
+....\marks4{e+,78,44,}
 ....\glue 0.0 plus 1.0fil
 ....\kern 0.0
 ....\hbox(0.0+0.0)x0.0
@@ -620,13 +620,13 @@ Completed box being shipped out [1]
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
 .......\pdfdest name{footnote*.5} xyz
-.......\pdfdest struct20 name{footnote*.5} xyz
+.......\pdfdest struct19 name{footnote*.5} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
 .......\pdfdest name{footnote*.7} xyz
-.......\pdfdest struct20 name{footnote*.7} xyz
+.......\pdfdest struct19 name{footnote*.7} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-7}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{7}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -655,26 +655,26 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,6,10,text,,,}
-....\marks4{b+,6,10,text,,,}
-....\marks4{e-,6,10,}
-....\marks4{e+,6,10,}
-....\marks4{b-,7,11,Lbl,,,}
-....\marks4{b+,7,11,Lbl,,,}
-....\marks4{e-,7,11,}
-....\marks4{e+,7,11,}
-....\marks4{b-,8,10,text,,,}
-....\marks4{b+,8,10,text,,,}
-....\marks4{e-,8,10,}
-....\marks4{e+,8,10,}
-....\marks4{b-,9,10,text,,,}
-....\marks4{b+,9,10,text,,,}
-....\marks4{e-,9,10,}
-....\marks4{e+,9,10,}
-....\marks4{b-,10,10,text,,,}
-....\marks4{b+,10,10,text,,,}
-....\marks4{e-,10,10,}
-....\marks4{e+,10,10,}
+....\marks4{b-,6,9,text,,,}
+....\marks4{b+,6,9,text,,,}
+....\marks4{e-,6,9,}
+....\marks4{e+,6,9,}
+....\marks4{b-,7,10,Lbl,,,}
+....\marks4{b+,7,10,Lbl,,,}
+....\marks4{e-,7,10,}
+....\marks4{e+,7,10,}
+....\marks4{b-,8,9,text,,,}
+....\marks4{b+,8,9,text,,,}
+....\marks4{e-,8,9,}
+....\marks4{e+,8,9,}
+....\marks4{b-,9,9,text,,,}
+....\marks4{b+,9,9,text,,,}
+....\marks4{e-,9,9,}
+....\marks4{e+,9,9,}
+....\marks4{b-,10,9,text,,,}
+....\marks4{b+,10,9,text,,,}
+....\marks4{e-,10,9,}
+....\marks4{e+,10,9,}
 ....\hbox(6.6724+2.85002)x345.0, glue set 320.98918fil
 .....\write1{\new@label@record{mcid-18}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{18}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -682,14 +682,14 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.12} xyz
-.......\pdfdest struct29 name{footnote*.12} xyz
+.......\pdfdest name{footnote*.11} xyz
+.......\pdfdest struct27 name{footnote*.11} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.14} xyz
-.......\pdfdest struct29 name{footnote*.14} xyz
+.......\pdfdest name{footnote*.13} xyz
+.......\pdfdest struct27 name{footnote*.13} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-19}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{19}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -708,8 +708,8 @@ Completed box being shipped out [1]
 .....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
 .....\hbox(6.65+0.0)x0.0
 ......\rule(6.65+0.0)x0.0
-.....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{14}}}
-.....\write1{\newlabel{foo}{{2}{\thepage }{}{footnote*.14}{}}}
+.....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{13}}}
+.....\write1{\newlabel{foo}{{2}{\thepage }{}{footnote*.13}{}}}
 .....\T1/cmr/m/n/8 B
 .....\penalty 10000
 .....\rule(0.0+2.85002)x0.0
@@ -720,26 +720,26 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,18,17,text,,,}
-....\marks4{b+,18,17,text,,,}
-....\marks4{e-,18,17,}
-....\marks4{e+,18,17,}
-....\marks4{b-,19,18,Lbl,,,}
-....\marks4{b+,19,18,Lbl,,,}
-....\marks4{e-,19,18,}
-....\marks4{e+,19,18,}
-....\marks4{b-,20,17,text,,,}
-....\marks4{b+,20,17,text,,,}
-....\marks4{e-,20,17,}
-....\marks4{e+,20,17,}
-....\marks4{b-,21,17,text,,,}
-....\marks4{b+,21,17,text,,,}
-....\marks4{e-,21,17,}
-....\marks4{e+,21,17,}
-....\marks4{b-,22,17,text,,,}
-....\marks4{b+,22,17,text,,,}
-....\marks4{e-,22,17,}
-....\marks4{e+,22,17,}
+....\marks4{b-,18,15,text,,,}
+....\marks4{b+,18,15,text,,,}
+....\marks4{e-,18,15,}
+....\marks4{e+,18,15,}
+....\marks4{b-,19,16,Lbl,,,}
+....\marks4{b+,19,16,Lbl,,,}
+....\marks4{e-,19,16,}
+....\marks4{e+,19,16,}
+....\marks4{b-,20,15,text,,,}
+....\marks4{b+,20,15,text,,,}
+....\marks4{e-,20,15,}
+....\marks4{e+,20,15,}
+....\marks4{b-,21,15,text,,,}
+....\marks4{b+,21,15,text,,,}
+....\marks4{e-,21,15,}
+....\marks4{e+,21,15,}
+....\marks4{b-,22,15,text,,,}
+....\marks4{b+,22,15,text,,,}
+....\marks4{e-,22,15,}
+....\marks4{e+,22,15,}
 ....\hbox(6.6724+2.85002)x345.0, glue set 320.86699fil
 .....\write1{\new@label@record{mcid-30}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{30}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -747,14 +747,14 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.19} xyz
-.......\pdfdest struct38 name{footnote*.19} xyz
+.......\pdfdest name{footnote*.17} xyz
+.......\pdfdest struct35 name{footnote*.17} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.21} xyz
-.......\pdfdest struct38 name{footnote*.21} xyz
+.......\pdfdest name{footnote*.19} xyz
+.......\pdfdest struct35 name{footnote*.19} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-31}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{31}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -783,26 +783,26 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,30,24,text,,,}
-....\marks4{b+,30,24,text,,,}
-....\marks4{e-,30,24,}
-....\marks4{e+,30,24,}
-....\marks4{b-,31,25,Lbl,,,}
-....\marks4{b+,31,25,Lbl,,,}
-....\marks4{e-,31,25,}
-....\marks4{e+,31,25,}
-....\marks4{b-,32,24,text,,,}
-....\marks4{b+,32,24,text,,,}
-....\marks4{e-,32,24,}
-....\marks4{e+,32,24,}
-....\marks4{b-,33,24,text,,,}
-....\marks4{b+,33,24,text,,,}
-....\marks4{e-,33,24,}
-....\marks4{e+,33,24,}
-....\marks4{b-,34,24,text,,,}
-....\marks4{b+,34,24,text,,,}
-....\marks4{e-,34,24,}
-....\marks4{e+,34,24,}
+....\marks4{b-,30,21,text,,,}
+....\marks4{b+,30,21,text,,,}
+....\marks4{e-,30,21,}
+....\marks4{e+,30,21,}
+....\marks4{b-,31,22,Lbl,,,}
+....\marks4{b+,31,22,Lbl,,,}
+....\marks4{e-,31,22,}
+....\marks4{e+,31,22,}
+....\marks4{b-,32,21,text,,,}
+....\marks4{b+,32,21,text,,,}
+....\marks4{e-,32,21,}
+....\marks4{e+,32,21,}
+....\marks4{b-,33,21,text,,,}
+....\marks4{b+,33,21,text,,,}
+....\marks4{e-,33,21,}
+....\marks4{e+,33,21,}
+....\marks4{b-,34,21,text,,,}
+....\marks4{b+,34,21,text,,,}
+....\marks4{e-,34,21,}
+....\marks4{e+,34,21,}
 ....\hbox(6.98898+2.85002)x345.0, glue set 320.51707fil
 .....\write1{\new@label@record{mcid-41}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{41}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -810,14 +810,14 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.28} xyz
-.......\pdfdest struct49 name{footnote*.28} xyz
+.......\pdfdest name{footnote*.25} xyz
+.......\pdfdest struct45 name{footnote*.25} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.30} xyz
-.......\pdfdest struct49 name{footnote*.30} xyz
+.......\pdfdest name{footnote*.27} xyz
+.......\pdfdest struct45 name{footnote*.27} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-42}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{42}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -846,26 +846,26 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,41,33,text,,,}
-....\marks4{b+,41,33,text,,,}
-....\marks4{e-,41,33,}
-....\marks4{e+,41,33,}
-....\marks4{b-,42,34,Lbl,,,}
-....\marks4{b+,42,34,Lbl,,,}
-....\marks4{e-,42,34,}
-....\marks4{e+,42,34,}
-....\marks4{b-,43,33,text,,,}
-....\marks4{b+,43,33,text,,,}
-....\marks4{e-,43,33,}
-....\marks4{e+,43,33,}
-....\marks4{b-,44,33,text,,,}
-....\marks4{b+,44,33,text,,,}
-....\marks4{e-,44,33,}
-....\marks4{e+,44,33,}
-....\marks4{b-,45,33,text,,,}
-....\marks4{b+,45,33,text,,,}
-....\marks4{e-,45,33,}
-....\marks4{e+,45,33,}
+....\marks4{b-,41,29,text,,,}
+....\marks4{b+,41,29,text,,,}
+....\marks4{e-,41,29,}
+....\marks4{e+,41,29,}
+....\marks4{b-,42,30,Lbl,,,}
+....\marks4{b+,42,30,Lbl,,,}
+....\marks4{e-,42,30,}
+....\marks4{e+,42,30,}
+....\marks4{b-,43,29,text,,,}
+....\marks4{b+,43,29,text,,,}
+....\marks4{e-,43,29,}
+....\marks4{e+,43,29,}
+....\marks4{b-,44,29,text,,,}
+....\marks4{b+,44,29,text,,,}
+....\marks4{e-,44,29,}
+....\marks4{e+,44,29,}
+....\marks4{b-,45,29,text,,,}
+....\marks4{b+,45,29,text,,,}
+....\marks4{e-,45,29,}
+....\marks4{e+,45,29,}
 ....\hbox(6.98898+2.85002)x345.0, glue set 321.22523fil
 .....\write1{\new@label@record{mcid-51}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{51}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -873,14 +873,14 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.35} xyz
-.......\pdfdest struct58 name{footnote*.35} xyz
+.......\pdfdest name{footnote*.31} xyz
+.......\pdfdest struct53 name{footnote*.31} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.37} xyz
-.......\pdfdest struct58 name{footnote*.37} xyz
+.......\pdfdest name{footnote*.33} xyz
+.......\pdfdest struct53 name{footnote*.33} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-52}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{52}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -909,26 +909,26 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,51,40,text,,,}
-....\marks4{b+,51,40,text,,,}
-....\marks4{e-,51,40,}
-....\marks4{e+,51,40,}
-....\marks4{b-,52,41,Lbl,,,}
-....\marks4{b+,52,41,Lbl,,,}
-....\marks4{e-,52,41,}
-....\marks4{e+,52,41,}
-....\marks4{b-,53,40,text,,,}
-....\marks4{b+,53,40,text,,,}
-....\marks4{e-,53,40,}
-....\marks4{e+,53,40,}
-....\marks4{b-,54,40,text,,,}
-....\marks4{b+,54,40,text,,,}
-....\marks4{e-,54,40,}
-....\marks4{e+,54,40,}
-....\marks4{b-,55,40,text,,,}
-....\marks4{b+,55,40,text,,,}
-....\marks4{e-,55,40,}
-....\marks4{e+,55,40,}
+....\marks4{b-,51,35,text,,,}
+....\marks4{b+,51,35,text,,,}
+....\marks4{e-,51,35,}
+....\marks4{e+,51,35,}
+....\marks4{b-,52,36,Lbl,,,}
+....\marks4{b+,52,36,Lbl,,,}
+....\marks4{e-,52,36,}
+....\marks4{e+,52,36,}
+....\marks4{b-,53,35,text,,,}
+....\marks4{b+,53,35,text,,,}
+....\marks4{e-,53,35,}
+....\marks4{e+,53,35,}
+....\marks4{b-,54,35,text,,,}
+....\marks4{b+,54,35,text,,,}
+....\marks4{e-,54,35,}
+....\marks4{e+,54,35,}
+....\marks4{b-,55,35,text,,,}
+....\marks4{b+,55,35,text,,,}
+....\marks4{e-,55,35,}
+....\marks4{e+,55,35,}
 ....\hbox(6.98898+2.85002)x345.0, glue set 321.46129fil
 .....\write1{\new@label@record{mcid-63}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{63}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -936,8 +936,8 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.44} xyz
-.......\pdfdest struct67 name{footnote*.44} xyz
+.......\pdfdest name{footnote*.39} xyz
+.......\pdfdest struct61 name{footnote*.39} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-64}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{64}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -966,26 +966,26 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,63,47,text,,,}
-....\marks4{b+,63,47,text,,,}
-....\marks4{e-,63,47,}
-....\marks4{e+,63,47,}
-....\marks4{b-,64,48,Lbl,,,}
-....\marks4{b+,64,48,Lbl,,,}
-....\marks4{e-,64,48,}
-....\marks4{e+,64,48,}
-....\marks4{b-,65,47,text,,,}
-....\marks4{b+,65,47,text,,,}
-....\marks4{e-,65,47,}
-....\marks4{e+,65,47,}
-....\marks4{b-,66,47,text,,,}
-....\marks4{b+,66,47,text,,,}
-....\marks4{e-,66,47,}
-....\marks4{e+,66,47,}
-....\marks4{b-,67,47,text,,,}
-....\marks4{b+,67,47,text,,,}
-....\marks4{e-,67,47,}
-....\marks4{e+,67,47,}
+....\marks4{b-,63,41,text,,,}
+....\marks4{b+,63,41,text,,,}
+....\marks4{e-,63,41,}
+....\marks4{e+,63,41,}
+....\marks4{b-,64,42,Lbl,,,}
+....\marks4{b+,64,42,Lbl,,,}
+....\marks4{e-,64,42,}
+....\marks4{e+,64,42,}
+....\marks4{b-,65,41,text,,,}
+....\marks4{b+,65,41,text,,,}
+....\marks4{e-,65,41,}
+....\marks4{e+,65,41,}
+....\marks4{b-,66,41,text,,,}
+....\marks4{b+,66,41,text,,,}
+....\marks4{e-,66,41,}
+....\marks4{e+,66,41,}
+....\marks4{b-,67,41,text,,,}
+....\marks4{b+,67,41,text,,,}
+....\marks4{e-,67,41,}
+....\marks4{e+,67,41,}
 ....\hbox(6.98898+2.85002)x345.0, glue set 320.33795fil
 .....\write1{\new@label@record{mcid-73}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{73}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -993,14 +993,14 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.51} xyz
-.......\pdfdest struct78 name{footnote*.51} xyz
+.......\pdfdest name{footnote*.45} xyz
+.......\pdfdest struct71 name{footnote*.45} xyz
 .......\penalty 10000
 .....\penalty 10000
 .....\hbox(0.0+0.0)x0.0
 ......\hbox(0.0+0.0)x0.0, shifted -9.5
-.......\pdfdest name{footnote*.53} xyz
-.......\pdfdest struct78 name{footnote*.53} xyz
+.......\pdfdest name{footnote*.47} xyz
+.......\pdfdest struct71 name{footnote*.47} xyz
 .......\penalty 10000
 .....\write1{\new@label@record{mcid-74}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{74}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Lbl <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -1029,26 +1029,26 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\marks4{b-,73,56,text,,,}
-....\marks4{b+,73,56,text,,,}
-....\marks4{e-,73,56,}
-....\marks4{e+,73,56,}
-....\marks4{b-,74,57,Lbl,,,}
-....\marks4{b+,74,57,Lbl,,,}
-....\marks4{e-,74,57,}
-....\marks4{e+,74,57,}
-....\marks4{b-,75,56,text,,,}
-....\marks4{b+,75,56,text,,,}
-....\marks4{e-,75,56,}
-....\marks4{e+,75,56,}
-....\marks4{b-,76,56,text,,,}
-....\marks4{b+,76,56,text,,,}
-....\marks4{e-,76,56,}
-....\marks4{e+,76,56,}
-....\marks4{b-,77,56,text,,,}
-....\marks4{b+,77,56,text,,,}
-....\marks4{e-,77,56,}
-....\marks4{e+,77,56,}
+....\marks4{b-,73,49,text,,,}
+....\marks4{b+,73,49,text,,,}
+....\marks4{e-,73,49,}
+....\marks4{e+,73,49,}
+....\marks4{b-,74,50,Lbl,,,}
+....\marks4{b+,74,50,Lbl,,,}
+....\marks4{e-,74,50,}
+....\marks4{e+,74,50,}
+....\marks4{b-,75,49,text,,,}
+....\marks4{b+,75,49,text,,,}
+....\marks4{e-,75,49,}
+....\marks4{e+,75,49,}
+....\marks4{b-,76,49,text,,,}
+....\marks4{b+,76,49,text,,,}
+....\marks4{e-,76,49,}
+....\marks4{e+,76,49,}
+....\marks4{b-,77,49,text,,,}
+....\marks4{b+,77,49,text,,,}
+....\marks4{e-,77,49,}
+....\marks4{e+,77,49,}
 ....\kern -2.85002
 ....\hbox(0.0+2.85002)x0.0
 ....\glue -2.85002

--- a/required/latex-lab/testfiles-OR/footmisc-009-multiple.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-009-multiple.tlg
@@ -71,7 +71,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -81,7 +81,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
@@ -329,7 +329,7 @@ Completed box being shipped out [1]
 ....\special{}
 ....\hbox(6.65+0.0)x0.0
 .....\rule(6.65+0.0)x0.0
-....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{7}}}
+....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{6}}}
 ....\write1{\newlabel{foo}{{2}{\thepage }{}{}{}}}
 ....\T1/cmr/m/n/8 B
 ....\penalty 10000

--- a/required/latex-lab/testfiles-OR/footmisc-010-setspace-tagging.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-010-setspace-tagging.tlg
@@ -66,7 +66,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -76,7 +76,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
@@ -621,10 +621,10 @@ Completed box being shipped out [1]
 ...\marks4{b+,10,6,text,,,}
 ...\marks4{e-,10,6,}
 ...\marks4{e+,10,6,}
-...\marks4{b-,11,13,Lbl,,,}
-...\marks4{b+,11,13,Lbl,,,}
-...\marks4{e-,11,13,}
-...\marks4{e+,11,13,}
+...\marks4{b-,11,12,Lbl,,,}
+...\marks4{b+,11,12,Lbl,,,}
+...\marks4{e-,11,12,}
+...\marks4{e+,11,12,}
 ...\marks4{b-,12,6,text,,,}
 ...\marks4{b+,12,6,text,,,}
 ...\marks4{e-,12,6,}
@@ -633,10 +633,10 @@ Completed box being shipped out [1]
 ...\marks4{b+,18,6,text,,,}
 ...\marks4{e-,18,6,}
 ...\marks4{e+,18,6,}
-...\marks4{b-,19,19,Lbl,,,}
-...\marks4{b+,19,19,Lbl,,,}
-...\marks4{e-,19,19,}
-...\marks4{e+,19,19,}
+...\marks4{b-,19,17,Lbl,,,}
+...\marks4{b+,19,17,Lbl,,,}
+...\marks4{e-,19,17,}
+...\marks4{e+,19,17,}
 ...\marks4{b-,20,6,text,,,}
 ...\marks4{b+,20,6,text,,,}
 ...\marks4{e-,20,6,}
@@ -708,42 +708,42 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,27,26,text,,,}
-...\marks4{b+,27,26,text,,,}
-...\marks4{e-,27,26,}
-...\marks4{e+,27,26,}
-...\marks4{b-,28,27,Lbl,,,}
-...\marks4{b+,28,27,Lbl,,,}
-...\marks4{e-,28,27,}
-...\marks4{e+,28,27,}
-...\marks4{b-,29,26,text,,,}
-...\marks4{b+,29,26,text,,,}
-...\marks4{e-,29,26,}
-...\marks4{e+,29,26,}
-...\marks4{b-,35,26,text,,,}
-...\marks4{b+,35,26,text,,,}
-...\marks4{e-,35,26,}
-...\marks4{e+,35,26,}
-...\marks4{b-,36,33,Lbl,,,}
-...\marks4{b+,36,33,Lbl,,,}
-...\marks4{e-,36,33,}
-...\marks4{e+,36,33,}
-...\marks4{b-,37,26,text,,,}
-...\marks4{b+,37,26,text,,,}
-...\marks4{e-,37,26,}
-...\marks4{e+,37,26,}
-...\marks4{b-,43,26,text,,,}
-...\marks4{b+,43,26,text,,,}
-...\marks4{e-,43,26,}
-...\marks4{e+,43,26,}
-...\marks4{b-,44,39,Lbl,,,}
-...\marks4{b+,44,39,Lbl,,,}
-...\marks4{e-,44,39,}
-...\marks4{e+,44,39,}
-...\marks4{b-,45,26,text,,,}
-...\marks4{b+,45,26,text,,,}
-...\marks4{e-,45,26,}
-...\marks4{e+,45,26,}
+...\marks4{b-,27,23,text,,,}
+...\marks4{b+,27,23,text,,,}
+...\marks4{e-,27,23,}
+...\marks4{e+,27,23,}
+...\marks4{b-,28,24,Lbl,,,}
+...\marks4{b+,28,24,Lbl,,,}
+...\marks4{e-,28,24,}
+...\marks4{e+,28,24,}
+...\marks4{b-,29,23,text,,,}
+...\marks4{b+,29,23,text,,,}
+...\marks4{e-,29,23,}
+...\marks4{e+,29,23,}
+...\marks4{b-,35,23,text,,,}
+...\marks4{b+,35,23,text,,,}
+...\marks4{e-,35,23,}
+...\marks4{e+,35,23,}
+...\marks4{b-,36,29,Lbl,,,}
+...\marks4{b+,36,29,Lbl,,,}
+...\marks4{e-,36,29,}
+...\marks4{e+,36,29,}
+...\marks4{b-,37,23,text,,,}
+...\marks4{b+,37,23,text,,,}
+...\marks4{e-,37,23,}
+...\marks4{e+,37,23,}
+...\marks4{b-,43,23,text,,,}
+...\marks4{b+,43,23,text,,,}
+...\marks4{e-,43,23,}
+...\marks4{e+,43,23,}
+...\marks4{b-,44,34,Lbl,,,}
+...\marks4{b+,44,34,Lbl,,,}
+...\marks4{e-,44,34,}
+...\marks4{e+,44,34,}
+...\marks4{b-,45,23,text,,,}
+...\marks4{b+,45,23,text,,,}
+...\marks4{e-,45,23,}
+...\marks4{e+,45,23,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 11.51524
@@ -807,26 +807,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,46,41,text,,,}
-...\marks4{b+,46,41,text,,,}
-...\marks4{e-,46,41,}
-...\marks4{e+,46,41,}
-...\marks4{b-,52,41,text,,,}
-...\marks4{b+,52,41,text,,,}
-...\marks4{e-,52,41,}
-...\marks4{e+,52,41,}
-...\marks4{b-,53,47,Lbl,,,}
-...\marks4{b+,53,47,Lbl,,,}
-...\marks4{e-,53,47,}
-...\marks4{e+,53,47,}
-...\marks4{b-,54,41,text,,,}
-...\marks4{b+,54,41,text,,,}
-...\marks4{e-,54,41,}
-...\marks4{e+,54,41,}
-...\marks4{b-,60,41,text,,,}
-...\marks4{b+,60,41,text,,,}
-...\marks4{e-,60,41,}
-...\marks4{e+,60,41,}
+...\marks4{b-,46,36,text,,,}
+...\marks4{b+,46,36,text,,,}
+...\marks4{e-,46,36,}
+...\marks4{e+,46,36,}
+...\marks4{b-,52,36,text,,,}
+...\marks4{b+,52,36,text,,,}
+...\marks4{e-,52,36,}
+...\marks4{e+,52,36,}
+...\marks4{b-,53,41,Lbl,,,}
+...\marks4{b+,53,41,Lbl,,,}
+...\marks4{e-,53,41,}
+...\marks4{e+,53,41,}
+...\marks4{b-,54,36,text,,,}
+...\marks4{b+,54,36,text,,,}
+...\marks4{e-,54,36,}
+...\marks4{e+,54,36,}
+...\marks4{b-,60,36,text,,,}
+...\marks4{b+,60,36,text,,,}
+...\marks4{e-,60,36,}
+...\marks4{e+,60,36,}
 ...\glue -1.94397
 ...\glue 0.0 plus 1.0fil
 ...\kern 0.0
@@ -962,20 +962,20 @@ Completed box being shipped out [1]
 ....\T1/cmr/m/n/8 t
 ....\T1/cmr/m/n/8 ,
 ....\glue(\rightskip) 0.0
-...\marks4{b-,5,11,text,,,}
-...\marks4{b+,5,11,text,,,}
-...\marks4{e-,5,11,}
-...\marks4{e+,5,11,}
-...\marks4{b-,6,12,Lbl,,,}
-...\marks4{b+,6,12,Lbl,,,}
-...\marks4{e-,6,12,}
-...\marks4{e+,6,12,}
-...\marks4{b-,7,11,text,,,}
-...\marks4{b+,7,11,text,,,}
-...\marks4{e-,7,11,}
-...\marks4{e+,7,11,}
-...\marks4{b-,8,11,text,,,}
-...\marks4{b+,8,11,text,,,}
+...\marks4{b-,5,10,text,,,}
+...\marks4{b+,5,10,text,,,}
+...\marks4{e-,5,10,}
+...\marks4{e+,5,10,}
+...\marks4{b-,6,11,Lbl,,,}
+...\marks4{b+,6,11,Lbl,,,}
+...\marks4{e-,6,11,}
+...\marks4{e+,6,11,}
+...\marks4{b-,7,10,text,,,}
+...\marks4{b+,7,10,text,,,}
+...\marks4{e-,7,10,}
+...\marks4{e+,7,10,}
+...\marks4{b-,8,10,text,,,}
+...\marks4{b+,8,10,text,,,}
 ...\penalty 250
 ...\glue(\baselineskip) 2.43506
 ...\hbox(5.50977+1.55518)x345.0, glue set 0.1469
@@ -1330,12 +1330,12 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{e-,8,11,}
-...\marks4{e+,8,11,}
-...\marks4{b-,9,11,text,,,}
-...\marks4{b+,9,11,text,,,}
-...\marks4{e-,9,11,}
-...\marks4{e+,9,11,}
+...\marks4{e-,8,10,}
+...\marks4{e+,8,10,}
+...\marks4{b-,9,10,text,,,}
+...\marks4{b+,9,10,text,,,}
+...\marks4{e-,9,10,}
+...\marks4{e+,9,10,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 320.98918fil
 ....\write1{\new@label@record{mcid-13}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{13}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -1359,7 +1359,7 @@ Completed box being shipped out [1]
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
 ....\hbox(6.65+0.0)x0.0
 .....\rule(6.65+0.0)x0.0
-....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{14}}}
+....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{13}}}
 ....\write1{\newlabel{foo}{{2}{\thepage }{}{}{}}}
 ....\T1/cmr/m/n/8 B
 ....\penalty 10000
@@ -1371,26 +1371,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,13,17,text,,,}
-...\marks4{b+,13,17,text,,,}
-...\marks4{e-,13,17,}
-...\marks4{e+,13,17,}
-...\marks4{b-,14,18,Lbl,,,}
-...\marks4{b+,14,18,Lbl,,,}
-...\marks4{e-,14,18,}
-...\marks4{e+,14,18,}
-...\marks4{b-,15,17,text,,,}
-...\marks4{b+,15,17,text,,,}
-...\marks4{e-,15,17,}
-...\marks4{e+,15,17,}
-...\marks4{b-,16,17,text,,,}
-...\marks4{b+,16,17,text,,,}
-...\marks4{e-,16,17,}
-...\marks4{e+,16,17,}
-...\marks4{b-,17,17,text,,,}
-...\marks4{b+,17,17,text,,,}
-...\marks4{e-,17,17,}
-...\marks4{e+,17,17,}
+...\marks4{b-,13,15,text,,,}
+...\marks4{b+,13,15,text,,,}
+...\marks4{e-,13,15,}
+...\marks4{e+,13,15,}
+...\marks4{b-,14,16,Lbl,,,}
+...\marks4{b+,14,16,Lbl,,,}
+...\marks4{e-,14,16,}
+...\marks4{e+,14,16,}
+...\marks4{b-,15,15,text,,,}
+...\marks4{b+,15,15,text,,,}
+...\marks4{e-,15,15,}
+...\marks4{e+,15,15,}
+...\marks4{b-,16,15,text,,,}
+...\marks4{b+,16,15,text,,,}
+...\marks4{e-,16,15,}
+...\marks4{e+,16,15,}
+...\marks4{b-,17,15,text,,,}
+...\marks4{b+,17,15,text,,,}
+...\marks4{e-,17,15,}
+...\marks4{e+,17,15,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 320.86699fil
 ....\write1{\new@label@record{mcid-21}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{21}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -1424,26 +1424,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,21,23,text,,,}
-...\marks4{b+,21,23,text,,,}
-...\marks4{e-,21,23,}
-...\marks4{e+,21,23,}
-...\marks4{b-,22,24,Lbl,,,}
-...\marks4{b+,22,24,Lbl,,,}
-...\marks4{e-,22,24,}
-...\marks4{e+,22,24,}
-...\marks4{b-,23,23,text,,,}
-...\marks4{b+,23,23,text,,,}
-...\marks4{e-,23,23,}
-...\marks4{e+,23,23,}
-...\marks4{b-,24,23,text,,,}
-...\marks4{b+,24,23,text,,,}
-...\marks4{e-,24,23,}
-...\marks4{e+,24,23,}
-...\marks4{b-,25,23,text,,,}
-...\marks4{b+,25,23,text,,,}
-...\marks4{e-,25,23,}
-...\marks4{e+,25,23,}
+...\marks4{b-,21,20,text,,,}
+...\marks4{b+,21,20,text,,,}
+...\marks4{e-,21,20,}
+...\marks4{e+,21,20,}
+...\marks4{b-,22,21,Lbl,,,}
+...\marks4{b+,22,21,Lbl,,,}
+...\marks4{e-,22,21,}
+...\marks4{e+,22,21,}
+...\marks4{b-,23,20,text,,,}
+...\marks4{b+,23,20,text,,,}
+...\marks4{e-,23,20,}
+...\marks4{e+,23,20,}
+...\marks4{b-,24,20,text,,,}
+...\marks4{b+,24,20,text,,,}
+...\marks4{e-,24,20,}
+...\marks4{e+,24,20,}
+...\marks4{b-,25,20,text,,,}
+...\marks4{b+,25,20,text,,,}
+...\marks4{e-,25,20,}
+...\marks4{e+,25,20,}
 ...\hbox(6.98898+2.85002)x345.0, glue set 320.51707fil
 ....\write1{\new@label@record{mcid-30}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{30}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -1477,26 +1477,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,30,31,text,,,}
-...\marks4{b+,30,31,text,,,}
-...\marks4{e-,30,31,}
-...\marks4{e+,30,31,}
-...\marks4{b-,31,32,Lbl,,,}
-...\marks4{b+,31,32,Lbl,,,}
-...\marks4{e-,31,32,}
-...\marks4{e+,31,32,}
-...\marks4{b-,32,31,text,,,}
-...\marks4{b+,32,31,text,,,}
-...\marks4{e-,32,31,}
-...\marks4{e+,32,31,}
-...\marks4{b-,33,31,text,,,}
-...\marks4{b+,33,31,text,,,}
-...\marks4{e-,33,31,}
-...\marks4{e+,33,31,}
-...\marks4{b-,34,31,text,,,}
-...\marks4{b+,34,31,text,,,}
-...\marks4{e-,34,31,}
-...\marks4{e+,34,31,}
+...\marks4{b-,30,27,text,,,}
+...\marks4{b+,30,27,text,,,}
+...\marks4{e-,30,27,}
+...\marks4{e+,30,27,}
+...\marks4{b-,31,28,Lbl,,,}
+...\marks4{b+,31,28,Lbl,,,}
+...\marks4{e-,31,28,}
+...\marks4{e+,31,28,}
+...\marks4{b-,32,27,text,,,}
+...\marks4{b+,32,27,text,,,}
+...\marks4{e-,32,27,}
+...\marks4{e+,32,27,}
+...\marks4{b-,33,27,text,,,}
+...\marks4{b+,33,27,text,,,}
+...\marks4{e-,33,27,}
+...\marks4{e+,33,27,}
+...\marks4{b-,34,27,text,,,}
+...\marks4{b+,34,27,text,,,}
+...\marks4{e-,34,27,}
+...\marks4{e+,34,27,}
 ...\hbox(6.98898+2.85002)x345.0, glue set 321.22523fil
 ....\write1{\new@label@record{mcid-38}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{38}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -1530,26 +1530,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,38,37,text,,,}
-...\marks4{b+,38,37,text,,,}
-...\marks4{e-,38,37,}
-...\marks4{e+,38,37,}
-...\marks4{b-,39,38,Lbl,,,}
-...\marks4{b+,39,38,Lbl,,,}
-...\marks4{e-,39,38,}
-...\marks4{e+,39,38,}
-...\marks4{b-,40,37,text,,,}
-...\marks4{b+,40,37,text,,,}
-...\marks4{e-,40,37,}
-...\marks4{e+,40,37,}
-...\marks4{b-,41,37,text,,,}
-...\marks4{b+,41,37,text,,,}
-...\marks4{e-,41,37,}
-...\marks4{e+,41,37,}
-...\marks4{b-,42,37,text,,,}
-...\marks4{b+,42,37,text,,,}
-...\marks4{e-,42,37,}
-...\marks4{e+,42,37,}
+...\marks4{b-,38,32,text,,,}
+...\marks4{b+,38,32,text,,,}
+...\marks4{e-,38,32,}
+...\marks4{e+,38,32,}
+...\marks4{b-,39,33,Lbl,,,}
+...\marks4{b+,39,33,Lbl,,,}
+...\marks4{e-,39,33,}
+...\marks4{e+,39,33,}
+...\marks4{b-,40,32,text,,,}
+...\marks4{b+,40,32,text,,,}
+...\marks4{e-,40,32,}
+...\marks4{e+,40,32,}
+...\marks4{b-,41,32,text,,,}
+...\marks4{b+,41,32,text,,,}
+...\marks4{e-,41,32,}
+...\marks4{e+,41,32,}
+...\marks4{b-,42,32,text,,,}
+...\marks4{b+,42,32,text,,,}
+...\marks4{e-,42,32,}
+...\marks4{e+,42,32,}
 ...\hbox(6.98898+2.85002)x345.0, glue set 223.02005fil
 ....\write1{\new@label@record{mcid-47}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{47}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -1608,26 +1608,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,47,45,text,,,}
-...\marks4{b+,47,45,text,,,}
-...\marks4{e-,47,45,}
-...\marks4{e+,47,45,}
-...\marks4{b-,48,46,Lbl,,,}
-...\marks4{b+,48,46,Lbl,,,}
-...\marks4{e-,48,46,}
-...\marks4{e+,48,46,}
-...\marks4{b-,49,45,text,,,}
-...\marks4{b+,49,45,text,,,}
-...\marks4{e-,49,45,}
-...\marks4{e+,49,45,}
-...\marks4{b-,50,45,text,,,}
-...\marks4{b+,50,45,text,,,}
-...\marks4{e-,50,45,}
-...\marks4{e+,50,45,}
-...\marks4{b-,51,45,text,,,}
-...\marks4{b+,51,45,text,,,}
-...\marks4{e-,51,45,}
-...\marks4{e+,51,45,}
+...\marks4{b-,47,39,text,,,}
+...\marks4{b+,47,39,text,,,}
+...\marks4{e-,47,39,}
+...\marks4{e+,47,39,}
+...\marks4{b-,48,40,Lbl,,,}
+...\marks4{b+,48,40,Lbl,,,}
+...\marks4{e-,48,40,}
+...\marks4{e+,48,40,}
+...\marks4{b-,49,39,text,,,}
+...\marks4{b+,49,39,text,,,}
+...\marks4{e-,49,39,}
+...\marks4{e+,49,39,}
+...\marks4{b-,50,39,text,,,}
+...\marks4{b+,50,39,text,,,}
+...\marks4{e-,50,39,}
+...\marks4{e+,50,39,}
+...\marks4{b-,51,39,text,,,}
+...\marks4{b+,51,39,text,,,}
+...\marks4{e-,51,39,}
+...\marks4{e+,51,39,}
 ...\hbox(6.98898+2.85002)x345.0, glue set 320.33795fil
 ....\write1{\new@label@record{mcid-55}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{55}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -1661,26 +1661,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,55,51,text,,,}
-...\marks4{b+,55,51,text,,,}
-...\marks4{e-,55,51,}
-...\marks4{e+,55,51,}
-...\marks4{b-,56,52,Lbl,,,}
-...\marks4{b+,56,52,Lbl,,,}
-...\marks4{e-,56,52,}
-...\marks4{e+,56,52,}
-...\marks4{b-,57,51,text,,,}
-...\marks4{b+,57,51,text,,,}
-...\marks4{e-,57,51,}
-...\marks4{e+,57,51,}
-...\marks4{b-,58,51,text,,,}
-...\marks4{b+,58,51,text,,,}
-...\marks4{e-,58,51,}
-...\marks4{e+,58,51,}
-...\marks4{b-,59,51,text,,,}
-...\marks4{b+,59,51,text,,,}
-...\marks4{e-,59,51,}
-...\marks4{e+,59,51,}
+...\marks4{b-,55,44,text,,,}
+...\marks4{b+,55,44,text,,,}
+...\marks4{e-,55,44,}
+...\marks4{e+,55,44,}
+...\marks4{b-,56,45,Lbl,,,}
+...\marks4{b+,56,45,Lbl,,,}
+...\marks4{e-,56,45,}
+...\marks4{e+,56,45,}
+...\marks4{b-,57,44,text,,,}
+...\marks4{b+,57,44,text,,,}
+...\marks4{e-,57,44,}
+...\marks4{e+,57,44,}
+...\marks4{b-,58,44,text,,,}
+...\marks4{b+,58,44,text,,,}
+...\marks4{e-,58,44,}
+...\marks4{e+,58,44,}
+...\marks4{b-,59,44,text,,,}
+...\marks4{b+,59,44,text,,,}
+...\marks4{e-,59,44,}
+...\marks4{e+,59,44,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue -2.85002

--- a/required/latex-lab/testfiles-OR/footmisc-010-setspace.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-010-setspace.tlg
@@ -66,7 +66,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -76,7 +76,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
@@ -1147,7 +1147,7 @@ Completed box being shipped out [1]
 ....\special{}
 ....\hbox(6.65+0.0)x0.0
 .....\rule(6.65+0.0)x0.0
-....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{7}}}
+....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{6}}}
 ....\write1{\newlabel{foo}{{2}{\thepage }{}{}{}}}
 ....\T1/cmr/m/n/8 B
 ....\penalty 10000

--- a/required/latex-lab/testfiles-OR/footmisc-011-para.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-011-para.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -63,7 +63,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
@@ -200,10 +200,10 @@ Completed box being shipped out [1]
 ...\marks4{b+,6,4,text,,,}
 ...\marks4{e-,6,4,}
 ...\marks4{e+,6,4,}
-...\marks4{b-,7,9,Lbl,,,}
-...\marks4{b+,7,9,Lbl,,,}
-...\marks4{e-,7,9,}
-...\marks4{e+,7,9,}
+...\marks4{b-,7,8,Lbl,,,}
+...\marks4{b+,7,8,Lbl,,,}
+...\marks4{e-,7,8,}
+...\marks4{e+,7,8,}
 ...\marks4{b-,8,4,text,,,}
 ...\marks4{b+,8,4,text,,,}
 ...\marks4{e-,8,4,}
@@ -212,10 +212,10 @@ Completed box being shipped out [1]
 ...\marks4{b+,11,4,text,,,}
 ...\marks4{e-,11,4,}
 ...\marks4{e+,11,4,}
-...\marks4{b-,12,13,Lbl,,,}
-...\marks4{b+,12,13,Lbl,,,}
-...\marks4{e-,12,13,}
-...\marks4{e+,12,13,}
+...\marks4{b-,12,11,Lbl,,,}
+...\marks4{b+,12,11,Lbl,,,}
+...\marks4{e-,12,11,}
+...\marks4{e+,12,11,}
 ...\marks4{b-,13,4,text,,,}
 ...\marks4{b+,13,4,text,,,}
 ...\marks4{e-,13,4,}
@@ -287,42 +287,42 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,17,18,text,,,}
-...\marks4{b+,17,18,text,,,}
-...\marks4{e-,17,18,}
-...\marks4{e+,17,18,}
-...\marks4{b-,18,19,Lbl,,,}
-...\marks4{b+,18,19,Lbl,,,}
-...\marks4{e-,18,19,}
-...\marks4{e+,18,19,}
-...\marks4{b-,19,18,text,,,}
-...\marks4{b+,19,18,text,,,}
-...\marks4{e-,19,18,}
-...\marks4{e+,19,18,}
-...\marks4{b-,22,18,text,,,}
-...\marks4{b+,22,18,text,,,}
-...\marks4{e-,22,18,}
-...\marks4{e+,22,18,}
-...\marks4{b-,23,23,Lbl,,,}
-...\marks4{b+,23,23,Lbl,,,}
-...\marks4{e-,23,23,}
-...\marks4{e+,23,23,}
-...\marks4{b-,24,18,text,,,}
-...\marks4{b+,24,18,text,,,}
-...\marks4{e-,24,18,}
-...\marks4{e+,24,18,}
-...\marks4{b-,27,18,text,,,}
-...\marks4{b+,27,18,text,,,}
-...\marks4{e-,27,18,}
-...\marks4{e+,27,18,}
-...\marks4{b-,28,27,Lbl,,,}
-...\marks4{b+,28,27,Lbl,,,}
-...\marks4{e-,28,27,}
-...\marks4{e+,28,27,}
-...\marks4{b-,29,18,text,,,}
-...\marks4{b+,29,18,text,,,}
-...\marks4{e-,29,18,}
-...\marks4{e+,29,18,}
+...\marks4{b-,17,15,text,,,}
+...\marks4{b+,17,15,text,,,}
+...\marks4{e-,17,15,}
+...\marks4{e+,17,15,}
+...\marks4{b-,18,16,Lbl,,,}
+...\marks4{b+,18,16,Lbl,,,}
+...\marks4{e-,18,16,}
+...\marks4{e+,18,16,}
+...\marks4{b-,19,15,text,,,}
+...\marks4{b+,19,15,text,,,}
+...\marks4{e-,19,15,}
+...\marks4{e+,19,15,}
+...\marks4{b-,22,15,text,,,}
+...\marks4{b+,22,15,text,,,}
+...\marks4{e-,22,15,}
+...\marks4{e+,22,15,}
+...\marks4{b-,23,19,Lbl,,,}
+...\marks4{b+,23,19,Lbl,,,}
+...\marks4{e-,23,19,}
+...\marks4{e+,23,19,}
+...\marks4{b-,24,15,text,,,}
+...\marks4{b+,24,15,text,,,}
+...\marks4{e-,24,15,}
+...\marks4{e+,24,15,}
+...\marks4{b-,27,15,text,,,}
+...\marks4{b+,27,15,text,,,}
+...\marks4{e-,27,15,}
+...\marks4{e+,27,15,}
+...\marks4{b-,28,22,Lbl,,,}
+...\marks4{b+,28,22,Lbl,,,}
+...\marks4{e-,28,22,}
+...\marks4{e+,28,22,}
+...\marks4{b-,29,15,text,,,}
+...\marks4{b+,29,15,text,,,}
+...\marks4{e-,29,15,}
+...\marks4{e+,29,15,}
 ...\glue 0.0 plus 1.0fil
 ...\kern 0.0
 ...\hbox(0.0+0.0)x0.0
@@ -367,7 +367,7 @@ Completed box being shipped out [1]
 ....\pdfliteral shipout page{/footnote <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
 ....\penalty 10000
 ....\glue 1.69955
-....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{10}}}
+....\write1{\new@label@record{__fnote/foo}{{fnote/struct}{9}}}
 ....\write1{\newlabel{foo}{{2}{\thepage }{}{}{}}}
 ....\penalty 10000
 ....\glue 0.0
@@ -436,46 +436,46 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,4,8,Lbl,,,}
-...\marks4{b+,4,8,Lbl,,,}
-...\marks4{e-,4,8,}
-...\marks4{e+,4,8,}
+...\marks4{b-,4,7,Lbl,,,}
+...\marks4{b+,4,7,Lbl,,,}
+...\marks4{e-,4,7,}
+...\marks4{e+,4,7,}
 ...\marks4{b-,5,6,footnote,,,}
 ...\marks4{b+,5,6,footnote,,,}
 ...\marks4{e-,5,6,}
 ...\marks4{e+,5,6,}
-...\marks4{b-,9,12,Lbl,,,}
-...\marks4{b+,9,12,Lbl,,,}
-...\marks4{e-,9,12,}
-...\marks4{e+,9,12,}
-...\marks4{b-,10,10,footnote,,,}
-...\marks4{b+,10,10,footnote,,,}
-...\marks4{e-,10,10,}
-...\marks4{e+,10,10,}
-...\marks4{b-,14,16,Lbl,,,}
-...\marks4{b+,14,16,Lbl,,,}
-...\marks4{e-,14,16,}
-...\marks4{e+,14,16,}
-...\marks4{b-,15,14,footnote,,,}
-...\marks4{b+,15,14,footnote,,,}
-...\marks4{e-,15,14,}
-...\marks4{e+,15,14,}
-...\marks4{b-,20,22,Lbl,,,}
-...\marks4{b+,20,22,Lbl,,,}
-...\marks4{e-,20,22,}
-...\marks4{e+,20,22,}
-...\marks4{b-,21,20,footnote,,,}
-...\marks4{b+,21,20,footnote,,,}
-...\marks4{e-,21,20,}
-...\marks4{e+,21,20,}
-...\marks4{b-,25,26,Lbl,,,}
-...\marks4{b+,25,26,Lbl,,,}
-...\marks4{e-,25,26,}
-...\marks4{e+,25,26,}
-...\marks4{b-,26,24,footnote,,,}
-...\marks4{b+,26,24,footnote,,,}
-...\marks4{e-,26,24,}
-...\marks4{e+,26,24,}
+...\marks4{b-,9,10,Lbl,,,}
+...\marks4{b+,9,10,Lbl,,,}
+...\marks4{e-,9,10,}
+...\marks4{e+,9,10,}
+...\marks4{b-,10,9,footnote,,,}
+...\marks4{b+,10,9,footnote,,,}
+...\marks4{e-,10,9,}
+...\marks4{e+,10,9,}
+...\marks4{b-,14,13,Lbl,,,}
+...\marks4{b+,14,13,Lbl,,,}
+...\marks4{e-,14,13,}
+...\marks4{e+,14,13,}
+...\marks4{b-,15,12,footnote,,,}
+...\marks4{b+,15,12,footnote,,,}
+...\marks4{e-,15,12,}
+...\marks4{e+,15,12,}
+...\marks4{b-,20,18,Lbl,,,}
+...\marks4{b+,20,18,Lbl,,,}
+...\marks4{e-,20,18,}
+...\marks4{e+,20,18,}
+...\marks4{b-,21,17,footnote,,,}
+...\marks4{b+,21,17,footnote,,,}
+...\marks4{e-,21,17,}
+...\marks4{e+,21,17,}
+...\marks4{b-,25,21,Lbl,,,}
+...\marks4{b+,25,21,Lbl,,,}
+...\marks4{e-,25,21,}
+...\marks4{e+,25,21,}
+...\marks4{b-,26,20,footnote,,,}
+...\marks4{b+,26,20,footnote,,,}
+...\marks4{e-,26,20,}
+...\marks4{e+,26,20,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue -2.85002

--- a/required/latex-lab/testfiles-OR/footmisc-012-side-hyperref.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-012-side-hyperref.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -63,7 +63,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
@@ -162,7 +162,7 @@ Completed box being shipped out [1]
 .....\special{}
 .....\penalty 10000
 .....\special{}
-.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.6}
+.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.5}
 .....\hbox(8.16115+0.0)x4.48514
 ......\mathon
 ......\hbox(4.53223+0.0)x4.48514, shifted -3.62892
@@ -172,7 +172,7 @@ Completed box being shipped out [1]
 .....\special{}
 .....\penalty 10000
 .....\special{}
-.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.10}
+.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.8}
 .....\hbox(8.16115+0.0)x4.48514
 ......\mathon
 ......\hbox(4.53223+0.0)x4.48514, shifted -3.62892
@@ -299,12 +299,12 @@ Completed box being shipped out [1]
 .........\penalty 10000
 .........\hbox(0.0+0.0)x0.0
 ..........\hbox(0.0+0.0)x0.0, shifted -9.5
-...........\pdfdest name{footnote*.6} xyz
+...........\pdfdest name{footnote*.5} xyz
 ...........\penalty 10000
 .........\penalty 10000
 .........\hbox(0.0+0.0)x0.0
 ..........\hbox(0.0+0.0)x0.0, shifted -9.5
-...........\pdfdest name{footnote*.7} xyz
+...........\pdfdest name{footnote*.6} xyz
 ...........\penalty 10000
 .........\special{}
 .........\hbox(6.6724+0.0)x17.99562, glue set 13.82985fil
@@ -316,8 +316,8 @@ Completed box being shipped out [1]
 ...........\mathoff
 .........\special{}
 .........\special{}
-.........\write1{\new@label@record{__fnote/foo}{{fnote/struct}{7}}}
-.........\write1{\newlabel{foo}{{2}{\thepage }{}{footnote*.7}{}}}
+.........\write1{\new@label@record{__fnote/foo}{{fnote/struct}{6}}}
+.........\write1{\newlabel{foo}{{2}{\thepage }{}{footnote*.6}{}}}
 .........\T1/cmr/m/n/8 B
 .........\special{}
 .........\penalty 10000
@@ -340,12 +340,12 @@ Completed box being shipped out [1]
 .........\penalty 10000
 .........\hbox(0.0+0.0)x0.0
 ..........\hbox(0.0+0.0)x0.0, shifted -9.5
-...........\pdfdest name{footnote*.10} xyz
+...........\pdfdest name{footnote*.8} xyz
 ...........\penalty 10000
 .........\penalty 10000
 .........\hbox(0.0+0.0)x0.0
 ..........\hbox(0.0+0.0)x0.0, shifted -9.5
-...........\pdfdest name{footnote*.11} xyz
+...........\pdfdest name{footnote*.9} xyz
 ...........\penalty 10000
 .........\special{}
 .........\hbox(6.6724+0.0)x17.99562, glue set 13.82985fil
@@ -659,7 +659,7 @@ Completed box being shipped out [1]
 .....\T1/cmr/m/n/10 t
 .....\penalty 10000
 .....\special{}
-.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.14}
+.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.11}
 .....\hbox(8.48885+0.0)x4.05469
 ......\mathon
 ......\hbox(4.85992+1.36078)x4.05469, shifted -3.62892
@@ -684,12 +684,12 @@ Completed box being shipped out [1]
 .........\penalty 10000
 .........\hbox(0.0+0.0)x0.0
 ..........\hbox(0.0+0.0)x0.0, shifted -9.5
-...........\pdfdest name{footnote*.14} xyz
+...........\pdfdest name{footnote*.11} xyz
 ...........\penalty 10000
 .........\penalty 10000
 .........\hbox(0.0+0.0)x0.0
 ..........\hbox(0.0+0.0)x0.0, shifted -9.5
-...........\pdfdest name{footnote*.15} xyz
+...........\pdfdest name{footnote*.12} xyz
 ...........\penalty 10000
 .........\special{}
 .........\hbox(6.98898+0.0)x17.99562, glue set 14.21866fil
@@ -720,7 +720,7 @@ Completed box being shipped out [1]
 .....\T1/cmr/m/n/10 o
 .....\penalty 10000
 .....\special{}
-.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.18}
+.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.14}
 .....\hbox(8.44997+0.0)x4.05469
 ......\mathon
 ......\hbox(4.82104+1.36078)x4.05469, shifted -3.62892
@@ -730,7 +730,7 @@ Completed box being shipped out [1]
 .....\special{}
 .....\penalty 10000
 .....\special{}
-.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.7}
+.....\pdfstartlink(*+*)x* attr{/Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] } action goto name{footnote*.6}
 .....\hbox(8.16115+0.0)x4.48514
 ......\mathon
 ......\hbox(4.53223+0.0)x4.48514, shifted -3.62892
@@ -754,12 +754,12 @@ Completed box being shipped out [1]
 .........\penalty 10000
 .........\hbox(0.0+0.0)x0.0
 ..........\hbox(0.0+0.0)x0.0, shifted -9.5
-...........\pdfdest name{footnote*.18} xyz
+...........\pdfdest name{footnote*.14} xyz
 ...........\penalty 10000
 .........\penalty 10000
 .........\hbox(0.0+0.0)x0.0
 ..........\hbox(0.0+0.0)x0.0, shifted -9.5
-...........\pdfdest name{footnote*.19} xyz
+...........\pdfdest name{footnote*.15} xyz
 ...........\penalty 10000
 .........\special{}
 .........\hbox(6.98898+0.0)x17.99562, glue set 14.21866fil

--- a/required/latex-lab/testfiles-OR/footmisc-012-side.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-012-side.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -63,7 +63,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
@@ -278,7 +278,7 @@ Completed box being shipped out [1]
 ..........\mathoff
 ........\special{}
 ........\special{}
-........\write1{\new@label@record{__fnote/foo}{{fnote/struct}{7}}}
+........\write1{\new@label@record{__fnote/foo}{{fnote/struct}{6}}}
 ........\write1{\newlabel{foo}{{2}{\thepage }{}{}{}}}
 ........\T1/cmr/m/n/8 B
 ........\special{}

--- a/required/latex-lab/testfiles-OR/footmisc-013-scrartcl.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-013-scrartcl.tlg
@@ -60,7 +60,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -70,7 +70,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
@@ -211,22 +211,22 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,10,12,text,,,}
-...\marks4{b+,10,12,text,,,}
-...\marks4{e-,10,12,}
-...\marks4{e+,10,12,}
-...\marks4{b-,11,13,Lbl,,,}
-...\marks4{b+,11,13,Lbl,,,}
-...\marks4{e-,11,13,}
-...\marks4{e+,11,13,}
-...\marks4{b-,12,12,text,,,}
-...\marks4{b+,12,12,text,,,}
-...\marks4{e-,12,12,}
-...\marks4{e+,12,12,}
-...\marks4{b-,18,12,text,,,}
-...\marks4{b+,18,12,text,,,}
-...\marks4{e-,18,12,}
-...\marks4{e+,18,12,}
+...\marks4{b-,10,11,text,,,}
+...\marks4{b+,10,11,text,,,}
+...\marks4{e-,10,11,}
+...\marks4{e+,10,11,}
+...\marks4{b-,11,12,Lbl,,,}
+...\marks4{b+,11,12,Lbl,,,}
+...\marks4{e-,11,12,}
+...\marks4{e+,11,12,}
+...\marks4{b-,12,11,text,,,}
+...\marks4{b+,12,11,text,,,}
+...\marks4{e-,12,11,}
+...\marks4{e+,12,11,}
+...\marks4{b-,18,11,text,,,}
+...\marks4{b+,18,11,text,,,}
+...\marks4{e-,18,11,}
+...\marks4{e+,18,11,}
 ...\glue 0.0 plus 1.0fil
 ...\kern 0.0
 ...\hbox(0.0+0.0)x0.0
@@ -271,26 +271,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,4,9,text,,,}
-...\marks4{b+,4,9,text,,,}
-...\marks4{e-,4,9,}
-...\marks4{e+,4,9,}
-...\marks4{b-,5,10,Lbl,,,}
-...\marks4{b+,5,10,Lbl,,,}
-...\marks4{e-,5,10,}
-...\marks4{e+,5,10,}
-...\marks4{b-,6,9,text,,,}
-...\marks4{b+,6,9,text,,,}
-...\marks4{e-,6,9,}
-...\marks4{e+,6,9,}
-...\marks4{b-,7,9,text,,,}
-...\marks4{b+,7,9,text,,,}
-...\marks4{e-,7,9,}
-...\marks4{e+,7,9,}
-...\marks4{b-,8,9,text,,,}
-...\marks4{b+,8,9,text,,,}
-...\marks4{e-,8,9,}
-...\marks4{e+,8,9,}
+...\marks4{b-,4,8,text,,,}
+...\marks4{b+,4,8,text,,,}
+...\marks4{e-,4,8,}
+...\marks4{e+,4,8,}
+...\marks4{b-,5,9,Lbl,,,}
+...\marks4{b+,5,9,Lbl,,,}
+...\marks4{e-,5,9,}
+...\marks4{e+,5,9,}
+...\marks4{b-,6,8,text,,,}
+...\marks4{b+,6,8,text,,,}
+...\marks4{e-,6,8,}
+...\marks4{e+,6,8,}
+...\marks4{b-,7,8,text,,,}
+...\marks4{b+,7,8,text,,,}
+...\marks4{e-,7,8,}
+...\marks4{e+,7,8,}
+...\marks4{b-,8,8,text,,,}
+...\marks4{b+,8,8,text,,,}
+...\marks4{e-,8,8,}
+...\marks4{e+,8,8,}
 ...\hbox(7.7+3.30003)x418.25555, glue set 402.45802fil
 ....\glue(\leftskip) 13.87161
 ....\write1{\new@label@record{mcid-13}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{13}{tagmcid}{\__property_code_tagmcid: }}}
@@ -326,26 +326,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,13,17,text,,,}
-...\marks4{b+,13,17,text,,,}
-...\marks4{e-,13,17,}
-...\marks4{e+,13,17,}
-...\marks4{b-,14,18,Lbl,,,}
-...\marks4{b+,14,18,Lbl,,,}
-...\marks4{e-,14,18,}
-...\marks4{e+,14,18,}
-...\marks4{b-,15,17,text,,,}
-...\marks4{b+,15,17,text,,,}
-...\marks4{e-,15,17,}
-...\marks4{e+,15,17,}
-...\marks4{b-,16,17,text,,,}
-...\marks4{b+,16,17,text,,,}
-...\marks4{e-,16,17,}
-...\marks4{e+,16,17,}
-...\marks4{b-,17,17,text,,,}
-...\marks4{b+,17,17,text,,,}
-...\marks4{e-,17,17,}
-...\marks4{e+,17,17,}
+...\marks4{b-,13,15,text,,,}
+...\marks4{b+,13,15,text,,,}
+...\marks4{e-,13,15,}
+...\marks4{e+,13,15,}
+...\marks4{b-,14,16,Lbl,,,}
+...\marks4{b+,14,16,Lbl,,,}
+...\marks4{e-,14,16,}
+...\marks4{e+,14,16,}
+...\marks4{b-,15,15,text,,,}
+...\marks4{b+,15,15,text,,,}
+...\marks4{e-,15,15,}
+...\marks4{e+,15,15,}
+...\marks4{b-,16,15,text,,,}
+...\marks4{b+,16,15,text,,,}
+...\marks4{e-,16,15,}
+...\marks4{e+,16,15,}
+...\marks4{b-,17,15,text,,,}
+...\marks4{b+,17,15,text,,,}
+...\marks4{e-,17,15,}
+...\marks4{e+,17,15,}
 ...\kern -3.30003
 ...\hbox(0.0+3.30003)x0.0
 ...\glue -3.30003
@@ -428,22 +428,22 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,21,20,text,,,}
-...\marks4{b+,21,20,text,,,}
-...\marks4{e-,21,20,}
-...\marks4{e+,21,20,}
-...\marks4{b-,22,21,Lbl,,,}
-...\marks4{b+,22,21,Lbl,,,}
-...\marks4{e-,22,21,}
-...\marks4{e+,22,21,}
-...\marks4{b-,23,20,text,,,}
-...\marks4{b+,23,20,text,,,}
-...\marks4{e-,23,20,}
-...\marks4{e+,23,20,}
-...\marks4{b-,29,20,text,,,}
-...\marks4{b+,29,20,text,,,}
-...\marks4{e-,29,20,}
-...\marks4{e+,29,20,}
+...\marks4{b-,21,18,text,,,}
+...\marks4{b+,21,18,text,,,}
+...\marks4{e-,21,18,}
+...\marks4{e+,21,18,}
+...\marks4{b-,22,19,Lbl,,,}
+...\marks4{b+,22,19,Lbl,,,}
+...\marks4{e-,22,19,}
+...\marks4{e+,22,19,}
+...\marks4{b-,23,18,text,,,}
+...\marks4{b+,23,18,text,,,}
+...\marks4{e-,23,18,}
+...\marks4{e+,23,18,}
+...\marks4{b-,29,18,text,,,}
+...\marks4{b+,29,18,text,,,}
+...\marks4{e-,29,18,}
+...\marks4{e+,29,18,}
 ...\glue 0.0 plus 1.0fil
 ...\kern 0.0
 ...\hbox(0.0+0.0)x0.0
@@ -488,26 +488,26 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,24,25,text,,,}
-...\marks4{b+,24,25,text,,,}
-...\marks4{e-,24,25,}
-...\marks4{e+,24,25,}
-...\marks4{b-,25,26,Lbl,,,}
-...\marks4{b+,25,26,Lbl,,,}
-...\marks4{e-,25,26,}
-...\marks4{e+,25,26,}
-...\marks4{b-,26,25,text,,,}
-...\marks4{b+,26,25,text,,,}
-...\marks4{e-,26,25,}
-...\marks4{e+,26,25,}
-...\marks4{b-,27,25,text,,,}
-...\marks4{b+,27,25,text,,,}
-...\marks4{e-,27,25,}
-...\marks4{e+,27,25,}
-...\marks4{b-,28,25,text,,,}
-...\marks4{b+,28,25,text,,,}
-...\marks4{e-,28,25,}
-...\marks4{e+,28,25,}
+...\marks4{b-,24,22,text,,,}
+...\marks4{b+,24,22,text,,,}
+...\marks4{e-,24,22,}
+...\marks4{e+,24,22,}
+...\marks4{b-,25,23,Lbl,,,}
+...\marks4{b+,25,23,Lbl,,,}
+...\marks4{e-,25,23,}
+...\marks4{e+,25,23,}
+...\marks4{b-,26,22,text,,,}
+...\marks4{b+,26,22,text,,,}
+...\marks4{e-,26,22,}
+...\marks4{e+,26,22,}
+...\marks4{b-,27,22,text,,,}
+...\marks4{b+,27,22,text,,,}
+...\marks4{e-,27,22,}
+...\marks4{e+,27,22,}
+...\marks4{b-,28,22,text,,,}
+...\marks4{b+,28,22,text,,,}
+...\marks4{e-,28,22,}
+...\marks4{e+,28,22,}
 ...\kern -3.30003
 ...\hbox(0.0+3.30003)x0.0
 ...\glue -3.30003

--- a/required/latex-lab/testfiles-OR/footmisc-014-hang.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-014-hang.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -63,7 +63,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext

--- a/required/latex-lab/testfiles-OR/footmisc-floats-abovefloats-flushbottom.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-floats-abovefloats-flushbottom.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -63,7 +63,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
@@ -96,7 +96,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 (Font)              <6> on input line ....
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 15) on line ...
+(tagpdf)                struct 14) on line ...
 Completed box being shipped out [1]
 \vbox(633.0+0.0)x407.0
 .\hbox(0.0+0.0)x0.0
@@ -285,22 +285,22 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,13,17,text,,,}
-...\marks4{b+,13,17,text,,,}
-...\marks4{e-,13,17,}
-...\marks4{e+,13,17,}
-...\marks4{b-,14,18,Lbl,,,}
-...\marks4{b+,14,18,Lbl,,,}
-...\marks4{e-,14,18,}
-...\marks4{e+,14,18,}
-...\marks4{b-,15,17,text,,,}
-...\marks4{b+,15,17,text,,,}
-...\marks4{e-,15,17,}
-...\marks4{e+,15,17,}
-...\marks4{b-,21,17,text,,,}
-...\marks4{b+,21,17,text,,,}
-...\marks4{e-,21,17,}
-...\marks4{e+,21,17,}
+...\marks4{b-,13,16,text,,,}
+...\marks4{b+,13,16,text,,,}
+...\marks4{e-,13,16,}
+...\marks4{e+,13,16,}
+...\marks4{b-,14,17,Lbl,,,}
+...\marks4{b+,14,17,Lbl,,,}
+...\marks4{e-,14,17,}
+...\marks4{e+,14,17,}
+...\marks4{b-,15,16,text,,,}
+...\marks4{b+,15,16,text,,,}
+...\marks4{e-,15,16,}
+...\marks4{e+,15,16,}
+...\marks4{b-,21,16,text,,,}
+...\marks4{b+,21,16,text,,,}
+...\marks4{e-,21,16,}
+...\marks4{e+,21,16,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.83885
@@ -347,34 +347,34 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,22,25,text,,,}
-...\marks4{b+,22,25,text,,,}
-...\marks4{e-,22,25,}
-...\marks4{e+,22,25,}
-...\marks4{b-,23,26,Lbl,,,}
-...\marks4{b+,23,26,Lbl,,,}
-...\marks4{e-,23,26,}
-...\marks4{e+,23,26,}
-...\marks4{b-,24,25,text,,,}
-...\marks4{b+,24,25,text,,,}
-...\marks4{e-,24,25,}
-...\marks4{e+,24,25,}
-...\marks4{b-,30,25,text,,,}
-...\marks4{b+,30,25,text,,,}
-...\marks4{e-,30,25,}
-...\marks4{e+,30,25,}
-...\marks4{b-,31,32,Lbl,,,}
-...\marks4{b+,31,32,Lbl,,,}
-...\marks4{e-,31,32,}
-...\marks4{e+,31,32,}
-...\marks4{b-,32,25,text,,,}
-...\marks4{b+,32,25,text,,,}
-...\marks4{e-,32,25,}
-...\marks4{e+,32,25,}
-...\marks4{b-,38,25,text,,,}
-...\marks4{b+,38,25,text,,,}
-...\marks4{e-,38,25,}
-...\marks4{e+,38,25,}
+...\marks4{b-,22,23,text,,,}
+...\marks4{b+,22,23,text,,,}
+...\marks4{e-,22,23,}
+...\marks4{e+,22,23,}
+...\marks4{b-,23,24,Lbl,,,}
+...\marks4{b+,23,24,Lbl,,,}
+...\marks4{e-,23,24,}
+...\marks4{e+,23,24,}
+...\marks4{b-,24,23,text,,,}
+...\marks4{b+,24,23,text,,,}
+...\marks4{e-,24,23,}
+...\marks4{e+,24,23,}
+...\marks4{b-,30,23,text,,,}
+...\marks4{b+,30,23,text,,,}
+...\marks4{e-,30,23,}
+...\marks4{e+,30,23,}
+...\marks4{b-,31,29,Lbl,,,}
+...\marks4{b+,31,29,Lbl,,,}
+...\marks4{e-,31,29,}
+...\marks4{e+,31,29,}
+...\marks4{b-,32,23,text,,,}
+...\marks4{b+,32,23,text,,,}
+...\marks4{e-,32,23,}
+...\marks4{e+,32,23,}
+...\marks4{b-,38,23,text,,,}
+...\marks4{b+,38,23,text,,,}
+...\marks4{e-,38,23,}
+...\marks4{e+,38,23,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.83885
@@ -406,22 +406,22 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,39,39,text,,,}
-...\marks4{b+,39,39,text,,,}
-...\marks4{e-,39,39,}
-...\marks4{e+,39,39,}
-...\marks4{b-,40,40,Lbl,,,}
-...\marks4{b+,40,40,Lbl,,,}
-...\marks4{e-,40,40,}
-...\marks4{e+,40,40,}
-...\marks4{b-,41,39,text,,,}
-...\marks4{b+,41,39,text,,,}
-...\marks4{e-,41,39,}
-...\marks4{e+,41,39,}
-...\marks4{b-,47,39,text,,,}
-...\marks4{b+,47,39,text,,,}
-...\marks4{e-,47,39,}
-...\marks4{e+,47,39,}
+...\marks4{b-,39,35,text,,,}
+...\marks4{b+,39,35,text,,,}
+...\marks4{e-,39,35,}
+...\marks4{e+,39,35,}
+...\marks4{b-,40,36,Lbl,,,}
+...\marks4{b+,40,36,Lbl,,,}
+...\marks4{e-,40,36,}
+...\marks4{e+,40,36,}
+...\marks4{b-,41,35,text,,,}
+...\marks4{b+,41,35,text,,,}
+...\marks4{e-,41,35,}
+...\marks4{e+,41,35,}
+...\marks4{b-,47,35,text,,,}
+...\marks4{b+,47,35,text,,,}
+...\marks4{e-,47,35,}
+...\marks4{e+,47,35,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.83885
@@ -473,34 +473,34 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,48,47,text,,,}
-...\marks4{b+,48,47,text,,,}
-...\marks4{e-,48,47,}
-...\marks4{e+,48,47,}
-...\marks4{b-,49,48,Lbl,,,}
-...\marks4{b+,49,48,Lbl,,,}
-...\marks4{e-,49,48,}
-...\marks4{e+,49,48,}
-...\marks4{b-,50,47,text,,,}
-...\marks4{b+,50,47,text,,,}
-...\marks4{e-,50,47,}
-...\marks4{e+,50,47,}
-...\marks4{b-,56,47,text,,,}
-...\marks4{b+,56,47,text,,,}
-...\marks4{e-,56,47,}
-...\marks4{e+,56,47,}
-...\marks4{b-,57,54,Lbl,,,}
-...\marks4{b+,57,54,Lbl,,,}
-...\marks4{e-,57,54,}
-...\marks4{e+,57,54,}
-...\marks4{b-,58,47,text,,,}
-...\marks4{b+,58,47,text,,,}
-...\marks4{e-,58,47,}
-...\marks4{e+,58,47,}
-...\marks4{b-,64,47,text,,,}
-...\marks4{b+,64,47,text,,,}
-...\marks4{e-,64,47,}
-...\marks4{e+,64,47,}
+...\marks4{b-,48,42,text,,,}
+...\marks4{b+,48,42,text,,,}
+...\marks4{e-,48,42,}
+...\marks4{e+,48,42,}
+...\marks4{b-,49,43,Lbl,,,}
+...\marks4{b+,49,43,Lbl,,,}
+...\marks4{e-,49,43,}
+...\marks4{e+,49,43,}
+...\marks4{b-,50,42,text,,,}
+...\marks4{b+,50,42,text,,,}
+...\marks4{e-,50,42,}
+...\marks4{e+,50,42,}
+...\marks4{b-,56,42,text,,,}
+...\marks4{b+,56,42,text,,,}
+...\marks4{e-,56,42,}
+...\marks4{e+,56,42,}
+...\marks4{b-,57,48,Lbl,,,}
+...\marks4{b+,57,48,Lbl,,,}
+...\marks4{e-,57,48,}
+...\marks4{e+,57,48,}
+...\marks4{b-,58,42,text,,,}
+...\marks4{b+,58,42,text,,,}
+...\marks4{e-,58,42,}
+...\marks4{e+,58,42,}
+...\marks4{b-,64,42,text,,,}
+...\marks4{b+,64,42,text,,,}
+...\marks4{e-,64,42,}
+...\marks4{e+,64,42,}
 ...\kern 0.0
 ...\hbox(0.0+0.0)x0.0
 ...\glue 9.0 plus 4.0 minus 2.0
@@ -541,26 +541,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,5,11,text,,,}
-...\marks4{b+,5,11,text,,,}
-...\marks4{e-,5,11,}
-...\marks4{e+,5,11,}
-...\marks4{b-,6,12,Lbl,,,}
-...\marks4{b+,6,12,Lbl,,,}
-...\marks4{e-,6,12,}
-...\marks4{e+,6,12,}
-...\marks4{b-,7,11,text,,,}
-...\marks4{b+,7,11,text,,,}
-...\marks4{e-,7,11,}
-...\marks4{e+,7,11,}
-...\marks4{b-,8,11,text,,,}
-...\marks4{b+,8,11,text,,,}
-...\marks4{e-,8,11,}
-...\marks4{e+,8,11,}
-...\marks4{b-,9,11,text,,,}
-...\marks4{b+,9,11,text,,,}
-...\marks4{e-,9,11,}
-...\marks4{e+,9,11,}
+...\marks4{b-,5,10,text,,,}
+...\marks4{b+,5,10,text,,,}
+...\marks4{e-,5,10,}
+...\marks4{e+,5,10,}
+...\marks4{b-,6,11,Lbl,,,}
+...\marks4{b+,6,11,Lbl,,,}
+...\marks4{e-,6,11,}
+...\marks4{e+,6,11,}
+...\marks4{b-,7,10,text,,,}
+...\marks4{b+,7,10,text,,,}
+...\marks4{e-,7,10,}
+...\marks4{e+,7,10,}
+...\marks4{b-,8,10,text,,,}
+...\marks4{b+,8,10,text,,,}
+...\marks4{e-,8,10,}
+...\marks4{e+,8,10,}
+...\marks4{b-,9,10,text,,,}
+...\marks4{b+,9,10,text,,,}
+...\marks4{e-,9,10,}
+...\marks4{e+,9,10,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 320.98918fil
 ....\write1{\new@label@record{mcid-16}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{16}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -594,26 +594,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,16,22,text,,,}
-...\marks4{b+,16,22,text,,,}
-...\marks4{e-,16,22,}
-...\marks4{e+,16,22,}
-...\marks4{b-,17,23,Lbl,,,}
-...\marks4{b+,17,23,Lbl,,,}
-...\marks4{e-,17,23,}
-...\marks4{e+,17,23,}
-...\marks4{b-,18,22,text,,,}
-...\marks4{b+,18,22,text,,,}
-...\marks4{e-,18,22,}
-...\marks4{e+,18,22,}
-...\marks4{b-,19,22,text,,,}
-...\marks4{b+,19,22,text,,,}
-...\marks4{e-,19,22,}
-...\marks4{e+,19,22,}
-...\marks4{b-,20,22,text,,,}
-...\marks4{b+,20,22,text,,,}
-...\marks4{e-,20,22,}
-...\marks4{e+,20,22,}
+...\marks4{b-,16,20,text,,,}
+...\marks4{b+,16,20,text,,,}
+...\marks4{e-,16,20,}
+...\marks4{e+,16,20,}
+...\marks4{b-,17,21,Lbl,,,}
+...\marks4{b+,17,21,Lbl,,,}
+...\marks4{e-,17,21,}
+...\marks4{e+,17,21,}
+...\marks4{b-,18,20,text,,,}
+...\marks4{b+,18,20,text,,,}
+...\marks4{e-,18,20,}
+...\marks4{e+,18,20,}
+...\marks4{b-,19,20,text,,,}
+...\marks4{b+,19,20,text,,,}
+...\marks4{e-,19,20,}
+...\marks4{e+,19,20,}
+...\marks4{b-,20,20,text,,,}
+...\marks4{b+,20,20,text,,,}
+...\marks4{e-,20,20,}
+...\marks4{e+,20,20,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 320.86699fil
 ....\write1{\new@label@record{mcid-25}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{25}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -647,26 +647,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,25,30,text,,,}
-...\marks4{b+,25,30,text,,,}
-...\marks4{e-,25,30,}
-...\marks4{e+,25,30,}
-...\marks4{b-,26,31,Lbl,,,}
-...\marks4{b+,26,31,Lbl,,,}
-...\marks4{e-,26,31,}
-...\marks4{e+,26,31,}
-...\marks4{b-,27,30,text,,,}
-...\marks4{b+,27,30,text,,,}
-...\marks4{e-,27,30,}
-...\marks4{e+,27,30,}
-...\marks4{b-,28,30,text,,,}
-...\marks4{b+,28,30,text,,,}
-...\marks4{e-,28,30,}
-...\marks4{e+,28,30,}
-...\marks4{b-,29,30,text,,,}
-...\marks4{b+,29,30,text,,,}
-...\marks4{e-,29,30,}
-...\marks4{e+,29,30,}
+...\marks4{b-,25,27,text,,,}
+...\marks4{b+,25,27,text,,,}
+...\marks4{e-,25,27,}
+...\marks4{e+,25,27,}
+...\marks4{b-,26,28,Lbl,,,}
+...\marks4{b+,26,28,Lbl,,,}
+...\marks4{e-,26,28,}
+...\marks4{e+,26,28,}
+...\marks4{b-,27,27,text,,,}
+...\marks4{b+,27,27,text,,,}
+...\marks4{e-,27,27,}
+...\marks4{e+,27,27,}
+...\marks4{b-,28,27,text,,,}
+...\marks4{b+,28,27,text,,,}
+...\marks4{e-,28,27,}
+...\marks4{e+,28,27,}
+...\marks4{b-,29,27,text,,,}
+...\marks4{b+,29,27,text,,,}
+...\marks4{e-,29,27,}
+...\marks4{e+,29,27,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 216.28975fil
 ....\write1{\new@label@record{mcid-33}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{33}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -730,26 +730,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,33,36,text,,,}
-...\marks4{b+,33,36,text,,,}
-...\marks4{e-,33,36,}
-...\marks4{e+,33,36,}
-...\marks4{b-,34,37,Lbl,,,}
-...\marks4{b+,34,37,Lbl,,,}
-...\marks4{e-,34,37,}
-...\marks4{e+,34,37,}
-...\marks4{b-,35,36,text,,,}
-...\marks4{b+,35,36,text,,,}
-...\marks4{e-,35,36,}
-...\marks4{e+,35,36,}
-...\marks4{b-,36,36,text,,,}
-...\marks4{b+,36,36,text,,,}
-...\marks4{e-,36,36,}
-...\marks4{e+,36,36,}
-...\marks4{b-,37,36,text,,,}
-...\marks4{b+,37,36,text,,,}
-...\marks4{e-,37,36,}
-...\marks4{e+,37,36,}
+...\marks4{b-,33,32,text,,,}
+...\marks4{b+,33,32,text,,,}
+...\marks4{e-,33,32,}
+...\marks4{e+,33,32,}
+...\marks4{b-,34,33,Lbl,,,}
+...\marks4{b+,34,33,Lbl,,,}
+...\marks4{e-,34,33,}
+...\marks4{e+,34,33,}
+...\marks4{b-,35,32,text,,,}
+...\marks4{b+,35,32,text,,,}
+...\marks4{e-,35,32,}
+...\marks4{e+,35,32,}
+...\marks4{b-,36,32,text,,,}
+...\marks4{b+,36,32,text,,,}
+...\marks4{e-,36,32,}
+...\marks4{e+,36,32,}
+...\marks4{b-,37,32,text,,,}
+...\marks4{b+,37,32,text,,,}
+...\marks4{e-,37,32,}
+...\marks4{e+,37,32,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 175.68161fil
 ....\write1{\new@label@record{mcid-42}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{42}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -823,26 +823,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,42,44,text,,,}
-...\marks4{b+,42,44,text,,,}
-...\marks4{e-,42,44,}
-...\marks4{e+,42,44,}
-...\marks4{b-,43,45,Lbl,,,}
-...\marks4{b+,43,45,Lbl,,,}
-...\marks4{e-,43,45,}
-...\marks4{e+,43,45,}
-...\marks4{b-,44,44,text,,,}
-...\marks4{b+,44,44,text,,,}
-...\marks4{e-,44,44,}
-...\marks4{e+,44,44,}
-...\marks4{b-,45,44,text,,,}
-...\marks4{b+,45,44,text,,,}
-...\marks4{e-,45,44,}
-...\marks4{e+,45,44,}
-...\marks4{b-,46,44,text,,,}
-...\marks4{b+,46,44,text,,,}
-...\marks4{e-,46,44,}
-...\marks4{e+,46,44,}
+...\marks4{b-,42,39,text,,,}
+...\marks4{b+,42,39,text,,,}
+...\marks4{e-,42,39,}
+...\marks4{e+,42,39,}
+...\marks4{b-,43,40,Lbl,,,}
+...\marks4{b+,43,40,Lbl,,,}
+...\marks4{e-,43,40,}
+...\marks4{e+,43,40,}
+...\marks4{b-,44,39,text,,,}
+...\marks4{b+,44,39,text,,,}
+...\marks4{e-,44,39,}
+...\marks4{e+,44,39,}
+...\marks4{b-,45,39,text,,,}
+...\marks4{b+,45,39,text,,,}
+...\marks4{e-,45,39,}
+...\marks4{e+,45,39,}
+...\marks4{b-,46,39,text,,,}
+...\marks4{b+,46,39,text,,,}
+...\marks4{e-,46,39,}
+...\marks4{e+,46,39,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 161.5184fil
 ....\write1{\new@label@record{mcid-51}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{51}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -921,26 +921,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,51,52,text,,,}
-...\marks4{b+,51,52,text,,,}
-...\marks4{e-,51,52,}
-...\marks4{e+,51,52,}
-...\marks4{b-,52,53,Lbl,,,}
-...\marks4{b+,52,53,Lbl,,,}
-...\marks4{e-,52,53,}
-...\marks4{e+,52,53,}
-...\marks4{b-,53,52,text,,,}
-...\marks4{b+,53,52,text,,,}
-...\marks4{e-,53,52,}
-...\marks4{e+,53,52,}
-...\marks4{b-,54,52,text,,,}
-...\marks4{b+,54,52,text,,,}
-...\marks4{e-,54,52,}
-...\marks4{e+,54,52,}
-...\marks4{b-,55,52,text,,,}
-...\marks4{b+,55,52,text,,,}
-...\marks4{e-,55,52,}
-...\marks4{e+,55,52,}
+...\marks4{b-,51,46,text,,,}
+...\marks4{b+,51,46,text,,,}
+...\marks4{e-,51,46,}
+...\marks4{e+,51,46,}
+...\marks4{b-,52,47,Lbl,,,}
+...\marks4{b+,52,47,Lbl,,,}
+...\marks4{e-,52,47,}
+...\marks4{e+,52,47,}
+...\marks4{b-,53,46,text,,,}
+...\marks4{b+,53,46,text,,,}
+...\marks4{e-,53,46,}
+...\marks4{e+,53,46,}
+...\marks4{b-,54,46,text,,,}
+...\marks4{b+,54,46,text,,,}
+...\marks4{e-,54,46,}
+...\marks4{e+,54,46,}
+...\marks4{b-,55,46,text,,,}
+...\marks4{b+,55,46,text,,,}
+...\marks4{e-,55,46,}
+...\marks4{e+,55,46,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 320.51707fil
 ....\write1{\new@label@record{mcid-59}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{59}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -974,26 +974,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,59,58,text,,,}
-...\marks4{b+,59,58,text,,,}
-...\marks4{e-,59,58,}
-...\marks4{e+,59,58,}
-...\marks4{b-,60,59,Lbl,,,}
-...\marks4{b+,60,59,Lbl,,,}
-...\marks4{e-,60,59,}
-...\marks4{e+,60,59,}
-...\marks4{b-,61,58,text,,,}
-...\marks4{b+,61,58,text,,,}
-...\marks4{e-,61,58,}
-...\marks4{e+,61,58,}
-...\marks4{b-,62,58,text,,,}
-...\marks4{b+,62,58,text,,,}
-...\marks4{e-,62,58,}
-...\marks4{e+,62,58,}
-...\marks4{b-,63,58,text,,,}
-...\marks4{b+,63,58,text,,,}
-...\marks4{e-,63,58,}
-...\marks4{e+,63,58,}
+...\marks4{b-,59,51,text,,,}
+...\marks4{b+,59,51,text,,,}
+...\marks4{e-,59,51,}
+...\marks4{e+,59,51,}
+...\marks4{b-,60,52,Lbl,,,}
+...\marks4{b+,60,52,Lbl,,,}
+...\marks4{e-,60,52,}
+...\marks4{e+,60,52,}
+...\marks4{b-,61,51,text,,,}
+...\marks4{b+,61,51,text,,,}
+...\marks4{e-,61,51,}
+...\marks4{e+,61,51,}
+...\marks4{b-,62,51,text,,,}
+...\marks4{b+,62,51,text,,,}
+...\marks4{e-,62,51,}
+...\marks4{e+,62,51,}
+...\marks4{b-,63,51,text,,,}
+...\marks4{b+,63,51,text,,,}
+...\marks4{e-,63,51,}
+...\marks4{e+,63,51,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue 20.0 plus 2.0 minus 4.0
@@ -1025,15 +1025,15 @@ Completed box being shipped out [1]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,11,14,text,,,}
-.....\marks4{b+,11,14,text,,,}
-.....\marks4{e-,11,14,}
-.....\marks4{e+,11,14,}
+.....\marks4{b-,11,13,text,,,}
+.....\marks4{b+,11,13,text,,,}
+.....\marks4{e-,11,13,}
+.....\marks4{e+,11,13,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-12}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{12}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,12,15,Caption,,,}
-.....\marks4{b+,12,15,Caption,,,}
+.....\marks4{b-,12,14,Caption,,,}
+.....\marks4{b+,12,14,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {1}{\ignorespaces A}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 146.86737fil
@@ -1054,8 +1054,8 @@ Completed box being shipped out [1]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,12,15,}
-.....\marks4{e+,12,15,}
+.....\marks4{e-,12,14,}
+.....\marks4{e+,12,14,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -1078,10 +1078,10 @@ Completed box being shipped out [1]
 .\kern 0.0
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 62) on line ...
+(tagpdf)                struct 55) on line ...
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 73) on line ...
+(tagpdf)                struct 65) on line ...
 Completed box being shipped out [2]
 \vbox(633.0+0.0)x407.0
 .\hbox(0.0+0.0)x0.0
@@ -1136,15 +1136,15 @@ Completed box being shipped out [2]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,67,61,text,,,}
-.....\marks4{b+,67,61,text,,,}
-.....\marks4{e-,67,61,}
-.....\marks4{e+,67,61,}
+.....\marks4{b-,67,54,text,,,}
+.....\marks4{b+,67,54,text,,,}
+.....\marks4{e-,67,54,}
+.....\marks4{e+,67,54,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-68}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{68}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,68,62,Caption,,,}
-.....\marks4{b+,68,62,Caption,,,}
+.....\marks4{b-,68,55,Caption,,,}
+.....\marks4{b+,68,55,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {2}{\ignorespaces B}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 147.07565fil
@@ -1165,8 +1165,8 @@ Completed box being shipped out [2]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,68,62,}
-.....\marks4{e+,68,62,}
+.....\marks4{e-,68,55,}
+.....\marks4{e+,68,55,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -1230,22 +1230,22 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,69,64,text,,,}
-...\marks4{b+,69,64,text,,,}
-...\marks4{e-,69,64,}
-...\marks4{e+,69,64,}
-...\marks4{b-,70,65,Lbl,,,}
-...\marks4{b+,70,65,Lbl,,,}
-...\marks4{e-,70,65,}
-...\marks4{e+,70,65,}
-...\marks4{b-,71,64,text,,,}
-...\marks4{b+,71,64,text,,,}
-...\marks4{e-,71,64,}
-...\marks4{e+,71,64,}
-...\marks4{b-,77,64,text,,,}
-...\marks4{b+,77,64,text,,,}
-...\marks4{e-,77,64,}
-...\marks4{e+,77,64,}
+...\marks4{b-,69,57,text,,,}
+...\marks4{b+,69,57,text,,,}
+...\marks4{e-,69,57,}
+...\marks4{e+,69,57,}
+...\marks4{b-,70,58,Lbl,,,}
+...\marks4{b+,70,58,Lbl,,,}
+...\marks4{e-,70,58,}
+...\marks4{e+,70,58,}
+...\marks4{b-,71,57,text,,,}
+...\marks4{b+,71,57,text,,,}
+...\marks4{e-,71,57,}
+...\marks4{e+,71,57,}
+...\marks4{b-,77,57,text,,,}
+...\marks4{b+,77,57,text,,,}
+...\marks4{e-,77,57,}
+...\marks4{e+,77,57,}
 ...\penalty 0
 ...\penalty 10000
 ...\glue 0.0
@@ -1290,26 +1290,26 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,72,69,text,,,}
-...\marks4{b+,72,69,text,,,}
-...\marks4{e-,72,69,}
-...\marks4{e+,72,69,}
-...\marks4{b-,73,70,Lbl,,,}
-...\marks4{b+,73,70,Lbl,,,}
-...\marks4{e-,73,70,}
-...\marks4{e+,73,70,}
-...\marks4{b-,74,69,text,,,}
-...\marks4{b+,74,69,text,,,}
-...\marks4{e-,74,69,}
-...\marks4{e+,74,69,}
-...\marks4{b-,75,69,text,,,}
-...\marks4{b+,75,69,text,,,}
-...\marks4{e-,75,69,}
-...\marks4{e+,75,69,}
-...\marks4{b-,76,69,text,,,}
-...\marks4{b+,76,69,text,,,}
-...\marks4{e-,76,69,}
-...\marks4{e+,76,69,}
+...\marks4{b-,72,61,text,,,}
+...\marks4{b+,72,61,text,,,}
+...\marks4{e-,72,61,}
+...\marks4{e+,72,61,}
+...\marks4{b-,73,62,Lbl,,,}
+...\marks4{b+,73,62,Lbl,,,}
+...\marks4{e-,73,62,}
+...\marks4{e+,73,62,}
+...\marks4{b-,74,61,text,,,}
+...\marks4{b+,74,61,text,,,}
+...\marks4{e-,74,61,}
+...\marks4{e+,74,61,}
+...\marks4{b-,75,61,text,,,}
+...\marks4{b+,75,61,text,,,}
+...\marks4{e-,75,61,}
+...\marks4{e+,75,61,}
+...\marks4{b-,76,61,text,,,}
+...\marks4{b+,76,61,text,,,}
+...\marks4{e-,76,61,}
+...\marks4{e+,76,61,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue 20.0 plus 2.0 minus 4.0
@@ -1341,15 +1341,15 @@ Completed box being shipped out [2]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,78,72,text,,,}
-.....\marks4{b+,78,72,text,,,}
-.....\marks4{e-,78,72,}
-.....\marks4{e+,78,72,}
+.....\marks4{b-,78,64,text,,,}
+.....\marks4{b+,78,64,text,,,}
+.....\marks4{e-,78,64,}
+.....\marks4{e+,78,64,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-79}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{79}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,79,73,Caption,,,}
-.....\marks4{b+,79,73,Caption,,,}
+.....\marks4{b-,79,65,Caption,,,}
+.....\marks4{b+,79,65,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {3}{\ignorespaces C}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 147.00623fil
@@ -1370,8 +1370,8 @@ Completed box being shipped out [2]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,79,73,}
-.....\marks4{e+,79,73,}
+.....\marks4{e-,79,65,}
+.....\marks4{e+,79,65,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -1481,22 +1481,22 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,82,75,text,,,}
-...\marks4{b+,82,75,text,,,}
-...\marks4{e-,82,75,}
-...\marks4{e+,82,75,}
-...\marks4{b-,83,76,Lbl,,,}
-...\marks4{b+,83,76,Lbl,,,}
-...\marks4{e-,83,76,}
-...\marks4{e+,83,76,}
-...\marks4{b-,84,75,text,,,}
-...\marks4{b+,84,75,text,,,}
-...\marks4{e-,84,75,}
-...\marks4{e+,84,75,}
-...\marks4{b-,90,75,text,,,}
-...\marks4{b+,90,75,text,,,}
-...\marks4{e-,90,75,}
-...\marks4{e+,90,75,}
+...\marks4{b-,82,67,text,,,}
+...\marks4{b+,82,67,text,,,}
+...\marks4{e-,82,67,}
+...\marks4{e+,82,67,}
+...\marks4{b-,83,68,Lbl,,,}
+...\marks4{b+,83,68,Lbl,,,}
+...\marks4{e-,83,68,}
+...\marks4{e+,83,68,}
+...\marks4{b-,84,67,text,,,}
+...\marks4{b+,84,67,text,,,}
+...\marks4{e-,84,67,}
+...\marks4{e+,84,67,}
+...\marks4{b-,90,67,text,,,}
+...\marks4{b+,90,67,text,,,}
+...\marks4{e-,90,67,}
+...\marks4{e+,90,67,}
 ...\kern -1.94397
 ...\hbox(0.0+1.94397)x0.0
 ...\glue 9.0 plus 4.0 minus 2.0
@@ -1537,26 +1537,26 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,85,80,text,,,}
-...\marks4{b+,85,80,text,,,}
-...\marks4{e-,85,80,}
-...\marks4{e+,85,80,}
-...\marks4{b-,86,81,Lbl,,,}
-...\marks4{b+,86,81,Lbl,,,}
-...\marks4{e-,86,81,}
-...\marks4{e+,86,81,}
-...\marks4{b-,87,80,text,,,}
-...\marks4{b+,87,80,text,,,}
-...\marks4{e-,87,80,}
-...\marks4{e+,87,80,}
-...\marks4{b-,88,80,text,,,}
-...\marks4{b+,88,80,text,,,}
-...\marks4{e-,88,80,}
-...\marks4{e+,88,80,}
-...\marks4{b-,89,80,text,,,}
-...\marks4{b+,89,80,text,,,}
-...\marks4{e-,89,80,}
-...\marks4{e+,89,80,}
+...\marks4{b-,85,71,text,,,}
+...\marks4{b+,85,71,text,,,}
+...\marks4{e-,85,71,}
+...\marks4{e+,85,71,}
+...\marks4{b-,86,72,Lbl,,,}
+...\marks4{b+,86,72,Lbl,,,}
+...\marks4{e-,86,72,}
+...\marks4{e+,86,72,}
+...\marks4{b-,87,71,text,,,}
+...\marks4{b+,87,71,text,,,}
+...\marks4{e-,87,71,}
+...\marks4{e+,87,71,}
+...\marks4{b-,88,71,text,,,}
+...\marks4{b+,88,71,text,,,}
+...\marks4{e-,88,71,}
+...\marks4{e+,88,71,}
+...\marks4{b-,89,71,text,,,}
+...\marks4{b+,89,71,text,,,}
+...\marks4{e-,89,71,}
+...\marks4{e+,89,71,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue -2.85002
@@ -1664,22 +1664,22 @@ Completed box being shipped out [4]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,93,83,text,,,}
-...\marks4{b+,93,83,text,,,}
-...\marks4{e-,93,83,}
-...\marks4{e+,93,83,}
-...\marks4{b-,94,84,Lbl,,,}
-...\marks4{b+,94,84,Lbl,,,}
-...\marks4{e-,94,84,}
-...\marks4{e+,94,84,}
-...\marks4{b-,95,83,text,,,}
-...\marks4{b+,95,83,text,,,}
-...\marks4{e-,95,83,}
-...\marks4{e+,95,83,}
-...\marks4{b-,101,83,text,,,}
-...\marks4{b+,101,83,text,,,}
-...\marks4{e-,101,83,}
-...\marks4{e+,101,83,}
+...\marks4{b-,93,74,text,,,}
+...\marks4{b+,93,74,text,,,}
+...\marks4{e-,93,74,}
+...\marks4{e+,93,74,}
+...\marks4{b-,94,75,Lbl,,,}
+...\marks4{b+,94,75,Lbl,,,}
+...\marks4{e-,94,75,}
+...\marks4{e+,94,75,}
+...\marks4{b-,95,74,text,,,}
+...\marks4{b+,95,74,text,,,}
+...\marks4{e-,95,74,}
+...\marks4{e+,95,74,}
+...\marks4{b-,101,74,text,,,}
+...\marks4{b+,101,74,text,,,}
+...\marks4{e-,101,74,}
+...\marks4{e+,101,74,}
 ...\glue -1.94397
 ...\glue 0.0 plus 1.0fil
 ...\kern 0.0
@@ -1723,26 +1723,26 @@ Completed box being shipped out [4]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,96,88,text,,,}
-...\marks4{b+,96,88,text,,,}
-...\marks4{e-,96,88,}
-...\marks4{e+,96,88,}
-...\marks4{b-,97,89,Lbl,,,}
-...\marks4{b+,97,89,Lbl,,,}
-...\marks4{e-,97,89,}
-...\marks4{e+,97,89,}
-...\marks4{b-,98,88,text,,,}
-...\marks4{b+,98,88,text,,,}
-...\marks4{e-,98,88,}
-...\marks4{e+,98,88,}
-...\marks4{b-,99,88,text,,,}
-...\marks4{b+,99,88,text,,,}
-...\marks4{e-,99,88,}
-...\marks4{e+,99,88,}
-...\marks4{b-,100,88,text,,,}
-...\marks4{b+,100,88,text,,,}
-...\marks4{e-,100,88,}
-...\marks4{e+,100,88,}
+...\marks4{b-,96,78,text,,,}
+...\marks4{b+,96,78,text,,,}
+...\marks4{e-,96,78,}
+...\marks4{e+,96,78,}
+...\marks4{b-,97,79,Lbl,,,}
+...\marks4{b+,97,79,Lbl,,,}
+...\marks4{e-,97,79,}
+...\marks4{e+,97,79,}
+...\marks4{b-,98,78,text,,,}
+...\marks4{b+,98,78,text,,,}
+...\marks4{e-,98,78,}
+...\marks4{e+,98,78,}
+...\marks4{b-,99,78,text,,,}
+...\marks4{b+,99,78,text,,,}
+...\marks4{e-,99,78,}
+...\marks4{e+,99,78,}
+...\marks4{b-,100,78,text,,,}
+...\marks4{b+,100,78,text,,,}
+...\marks4{e-,100,78,}
+...\marks4{e+,100,78,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue -2.85002
@@ -1763,7 +1763,7 @@ Completed box being shipped out [4]
 .\kern 0.0
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 94) on line ...
+(tagpdf)                struct 84) on line ...
 Completed box being shipped out [5]
 \vbox(633.0+0.0)x407.0
 .\hbox(0.0+0.0)x0.0
@@ -1839,10 +1839,10 @@ Completed box being shipped out [5]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,104,91,text,,,}
-...\marks4{b+,104,91,text,,,}
-...\marks4{e-,104,91,}
-...\marks4{e+,104,91,}
+...\marks4{b-,104,81,text,,,}
+...\marks4{b+,104,81,text,,,}
+...\marks4{e-,104,81,}
+...\marks4{e+,104,81,}
 ...\penalty 0
 ...\penalty 10000
 ...\kern 0.0
@@ -1876,15 +1876,15 @@ Completed box being shipped out [5]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,105,93,text,,,}
-.....\marks4{b+,105,93,text,,,}
-.....\marks4{e-,105,93,}
-.....\marks4{e+,105,93,}
+.....\marks4{b-,105,83,text,,,}
+.....\marks4{b+,105,83,text,,,}
+.....\marks4{e-,105,83,}
+.....\marks4{e+,105,83,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-106}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{106}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,106,94,Caption,,,}
-.....\marks4{b+,106,94,Caption,,,}
+.....\marks4{b-,106,84,Caption,,,}
+.....\marks4{b+,106,84,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {4}{\ignorespaces D}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 146.79794fil
@@ -1905,8 +1905,8 @@ Completed box being shipped out [5]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,106,94,}
-.....\marks4{e+,106,94,}
+.....\marks4{e-,106,84,}
+.....\marks4{e+,106,84,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -1928,7 +1928,7 @@ Completed box being shipped out [5]
 .\kern 0.0
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 99) on line ...
+(tagpdf)                struct 89) on line ...
 Completed box being shipped out [6]
 \vbox(633.0+0.0)x407.0
 .\hbox(0.0+0.0)x0.0
@@ -2002,10 +2002,10 @@ Completed box being shipped out [6]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,109,96,text,,,}
-...\marks4{b+,109,96,text,,,}
-...\marks4{e-,109,96,}
-...\marks4{e+,109,96,}
+...\marks4{b-,109,86,text,,,}
+...\marks4{b+,109,86,text,,,}
+...\marks4{e-,109,86,}
+...\marks4{e+,109,86,}
 ...\penalty 0
 ...\penalty 10000
 ...\glue 0.0
@@ -2041,15 +2041,15 @@ Completed box being shipped out [6]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,110,98,text,,,}
-.....\marks4{b+,110,98,text,,,}
-.....\marks4{e-,110,98,}
-.....\marks4{e+,110,98,}
+.....\marks4{b-,110,88,text,,,}
+.....\marks4{b+,110,88,text,,,}
+.....\marks4{e-,110,88,}
+.....\marks4{e+,110,88,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-111}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{111}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,111,99,Caption,,,}
-.....\marks4{b+,111,99,Caption,,,}
+.....\marks4{b-,111,89,Caption,,,}
+.....\marks4{b+,111,89,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {5}{\ignorespaces E}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 147.21451fil
@@ -2070,8 +2070,8 @@ Completed box being shipped out [6]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,111,99,}
-.....\marks4{e+,111,99,}
+.....\marks4{e-,111,89,}
+.....\marks4{e+,111,89,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -2149,10 +2149,10 @@ Completed box being shipped out [7]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,114,101,text,,,}
-...\marks4{b+,114,101,text,,,}
-...\marks4{e-,114,101,}
-...\marks4{e+,114,101,}
+...\marks4{b-,114,91,text,,,}
+...\marks4{b+,114,91,text,,,}
+...\marks4{e-,114,91,}
+...\marks4{e+,114,91,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.16882
@@ -2182,10 +2182,10 @@ Completed box being shipped out [7]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,115,103,text,,,}
-...\marks4{b+,115,103,text,,,}
-...\marks4{e-,115,103,}
-...\marks4{e+,115,103,}
+...\marks4{b-,115,93,text,,,}
+...\marks4{b+,115,93,text,,,}
+...\marks4{e-,115,93,}
+...\marks4{e+,115,93,}
 ...\kern -1.94397
 ...\hbox(0.0+1.94397)x0.0
 ...\glue -1.94397
@@ -2260,10 +2260,10 @@ Completed box being shipped out [8]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,118,105,text,,,}
-...\marks4{b+,118,105,text,,,}
-...\marks4{e-,118,105,}
-...\marks4{e+,118,105,}
+...\marks4{b-,118,95,text,,,}
+...\marks4{b+,118,95,text,,,}
+...\marks4{e-,118,95,}
+...\marks4{e+,118,95,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.16882
@@ -2293,10 +2293,10 @@ Completed box being shipped out [8]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,119,107,text,,,}
-...\marks4{b+,119,107,text,,,}
-...\marks4{e-,119,107,}
-...\marks4{e+,119,107,}
+...\marks4{b-,119,97,text,,,}
+...\marks4{b+,119,97,text,,,}
+...\marks4{e-,119,97,}
+...\marks4{e+,119,97,}
 ...\glue -1.94397
 ...\glue 0.0 plus 1.0fil
 ...\kern 0.0

--- a/required/latex-lab/testfiles-OR/footmisc-floats-abovefloats.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-floats-abovefloats.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -63,7 +63,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
@@ -96,7 +96,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 (Font)              <6> on input line ....
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 15) on line ...
+(tagpdf)                struct 14) on line ...
 Completed box being shipped out [1]
 \vbox(633.0+0.0)x407.0
 .\hbox(0.0+0.0)x0.0
@@ -269,22 +269,22 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,13,17,text,,,}
-...\marks4{b+,13,17,text,,,}
-...\marks4{e-,13,17,}
-...\marks4{e+,13,17,}
-...\marks4{b-,14,18,Lbl,,,}
-...\marks4{b+,14,18,Lbl,,,}
-...\marks4{e-,14,18,}
-...\marks4{e+,14,18,}
-...\marks4{b-,15,17,text,,,}
-...\marks4{b+,15,17,text,,,}
-...\marks4{e-,15,17,}
-...\marks4{e+,15,17,}
-...\marks4{b-,21,17,text,,,}
-...\marks4{b+,21,17,text,,,}
-...\marks4{e-,21,17,}
-...\marks4{e+,21,17,}
+...\marks4{b-,13,16,text,,,}
+...\marks4{b+,13,16,text,,,}
+...\marks4{e-,13,16,}
+...\marks4{e+,13,16,}
+...\marks4{b-,14,17,Lbl,,,}
+...\marks4{b+,14,17,Lbl,,,}
+...\marks4{e-,14,17,}
+...\marks4{e+,14,17,}
+...\marks4{b-,15,16,text,,,}
+...\marks4{b+,15,16,text,,,}
+...\marks4{e-,15,16,}
+...\marks4{e+,15,16,}
+...\marks4{b-,21,16,text,,,}
+...\marks4{b+,21,16,text,,,}
+...\marks4{e-,21,16,}
+...\marks4{e+,21,16,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.83885
@@ -331,34 +331,34 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,22,25,text,,,}
-...\marks4{b+,22,25,text,,,}
-...\marks4{e-,22,25,}
-...\marks4{e+,22,25,}
-...\marks4{b-,23,26,Lbl,,,}
-...\marks4{b+,23,26,Lbl,,,}
-...\marks4{e-,23,26,}
-...\marks4{e+,23,26,}
-...\marks4{b-,24,25,text,,,}
-...\marks4{b+,24,25,text,,,}
-...\marks4{e-,24,25,}
-...\marks4{e+,24,25,}
-...\marks4{b-,30,25,text,,,}
-...\marks4{b+,30,25,text,,,}
-...\marks4{e-,30,25,}
-...\marks4{e+,30,25,}
-...\marks4{b-,31,32,Lbl,,,}
-...\marks4{b+,31,32,Lbl,,,}
-...\marks4{e-,31,32,}
-...\marks4{e+,31,32,}
-...\marks4{b-,32,25,text,,,}
-...\marks4{b+,32,25,text,,,}
-...\marks4{e-,32,25,}
-...\marks4{e+,32,25,}
-...\marks4{b-,38,25,text,,,}
-...\marks4{b+,38,25,text,,,}
-...\marks4{e-,38,25,}
-...\marks4{e+,38,25,}
+...\marks4{b-,22,23,text,,,}
+...\marks4{b+,22,23,text,,,}
+...\marks4{e-,22,23,}
+...\marks4{e+,22,23,}
+...\marks4{b-,23,24,Lbl,,,}
+...\marks4{b+,23,24,Lbl,,,}
+...\marks4{e-,23,24,}
+...\marks4{e+,23,24,}
+...\marks4{b-,24,23,text,,,}
+...\marks4{b+,24,23,text,,,}
+...\marks4{e-,24,23,}
+...\marks4{e+,24,23,}
+...\marks4{b-,30,23,text,,,}
+...\marks4{b+,30,23,text,,,}
+...\marks4{e-,30,23,}
+...\marks4{e+,30,23,}
+...\marks4{b-,31,29,Lbl,,,}
+...\marks4{b+,31,29,Lbl,,,}
+...\marks4{e-,31,29,}
+...\marks4{e+,31,29,}
+...\marks4{b-,32,23,text,,,}
+...\marks4{b+,32,23,text,,,}
+...\marks4{e-,32,23,}
+...\marks4{e+,32,23,}
+...\marks4{b-,38,23,text,,,}
+...\marks4{b+,38,23,text,,,}
+...\marks4{e-,38,23,}
+...\marks4{e+,38,23,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.83885
@@ -390,22 +390,22 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,39,39,text,,,}
-...\marks4{b+,39,39,text,,,}
-...\marks4{e-,39,39,}
-...\marks4{e+,39,39,}
-...\marks4{b-,40,40,Lbl,,,}
-...\marks4{b+,40,40,Lbl,,,}
-...\marks4{e-,40,40,}
-...\marks4{e+,40,40,}
-...\marks4{b-,41,39,text,,,}
-...\marks4{b+,41,39,text,,,}
-...\marks4{e-,41,39,}
-...\marks4{e+,41,39,}
-...\marks4{b-,47,39,text,,,}
-...\marks4{b+,47,39,text,,,}
-...\marks4{e-,47,39,}
-...\marks4{e+,47,39,}
+...\marks4{b-,39,35,text,,,}
+...\marks4{b+,39,35,text,,,}
+...\marks4{e-,39,35,}
+...\marks4{e+,39,35,}
+...\marks4{b-,40,36,Lbl,,,}
+...\marks4{b+,40,36,Lbl,,,}
+...\marks4{e-,40,36,}
+...\marks4{e+,40,36,}
+...\marks4{b-,41,35,text,,,}
+...\marks4{b+,41,35,text,,,}
+...\marks4{e-,41,35,}
+...\marks4{e+,41,35,}
+...\marks4{b-,47,35,text,,,}
+...\marks4{b+,47,35,text,,,}
+...\marks4{e-,47,35,}
+...\marks4{e+,47,35,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.83885
@@ -457,34 +457,34 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,48,47,text,,,}
-...\marks4{b+,48,47,text,,,}
-...\marks4{e-,48,47,}
-...\marks4{e+,48,47,}
-...\marks4{b-,49,48,Lbl,,,}
-...\marks4{b+,49,48,Lbl,,,}
-...\marks4{e-,49,48,}
-...\marks4{e+,49,48,}
-...\marks4{b-,50,47,text,,,}
-...\marks4{b+,50,47,text,,,}
-...\marks4{e-,50,47,}
-...\marks4{e+,50,47,}
-...\marks4{b-,56,47,text,,,}
-...\marks4{b+,56,47,text,,,}
-...\marks4{e-,56,47,}
-...\marks4{e+,56,47,}
-...\marks4{b-,57,54,Lbl,,,}
-...\marks4{b+,57,54,Lbl,,,}
-...\marks4{e-,57,54,}
-...\marks4{e+,57,54,}
-...\marks4{b-,58,47,text,,,}
-...\marks4{b+,58,47,text,,,}
-...\marks4{e-,58,47,}
-...\marks4{e+,58,47,}
-...\marks4{b-,64,47,text,,,}
-...\marks4{b+,64,47,text,,,}
-...\marks4{e-,64,47,}
-...\marks4{e+,64,47,}
+...\marks4{b-,48,42,text,,,}
+...\marks4{b+,48,42,text,,,}
+...\marks4{e-,48,42,}
+...\marks4{e+,48,42,}
+...\marks4{b-,49,43,Lbl,,,}
+...\marks4{b+,49,43,Lbl,,,}
+...\marks4{e-,49,43,}
+...\marks4{e+,49,43,}
+...\marks4{b-,50,42,text,,,}
+...\marks4{b+,50,42,text,,,}
+...\marks4{e-,50,42,}
+...\marks4{e+,50,42,}
+...\marks4{b-,56,42,text,,,}
+...\marks4{b+,56,42,text,,,}
+...\marks4{e-,56,42,}
+...\marks4{e+,56,42,}
+...\marks4{b-,57,48,Lbl,,,}
+...\marks4{b+,57,48,Lbl,,,}
+...\marks4{e-,57,48,}
+...\marks4{e+,57,48,}
+...\marks4{b-,58,42,text,,,}
+...\marks4{b+,58,42,text,,,}
+...\marks4{e-,58,42,}
+...\marks4{e+,58,42,}
+...\marks4{b-,64,42,text,,,}
+...\marks4{b+,64,42,text,,,}
+...\marks4{e-,64,42,}
+...\marks4{e+,64,42,}
 ...\kern 0.0
 ...\hbox(0.0+0.0)x0.0
 ...\glue 9.0 plus 4.0 minus 2.0
@@ -525,26 +525,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,5,11,text,,,}
-...\marks4{b+,5,11,text,,,}
-...\marks4{e-,5,11,}
-...\marks4{e+,5,11,}
-...\marks4{b-,6,12,Lbl,,,}
-...\marks4{b+,6,12,Lbl,,,}
-...\marks4{e-,6,12,}
-...\marks4{e+,6,12,}
-...\marks4{b-,7,11,text,,,}
-...\marks4{b+,7,11,text,,,}
-...\marks4{e-,7,11,}
-...\marks4{e+,7,11,}
-...\marks4{b-,8,11,text,,,}
-...\marks4{b+,8,11,text,,,}
-...\marks4{e-,8,11,}
-...\marks4{e+,8,11,}
-...\marks4{b-,9,11,text,,,}
-...\marks4{b+,9,11,text,,,}
-...\marks4{e-,9,11,}
-...\marks4{e+,9,11,}
+...\marks4{b-,5,10,text,,,}
+...\marks4{b+,5,10,text,,,}
+...\marks4{e-,5,10,}
+...\marks4{e+,5,10,}
+...\marks4{b-,6,11,Lbl,,,}
+...\marks4{b+,6,11,Lbl,,,}
+...\marks4{e-,6,11,}
+...\marks4{e+,6,11,}
+...\marks4{b-,7,10,text,,,}
+...\marks4{b+,7,10,text,,,}
+...\marks4{e-,7,10,}
+...\marks4{e+,7,10,}
+...\marks4{b-,8,10,text,,,}
+...\marks4{b+,8,10,text,,,}
+...\marks4{e-,8,10,}
+...\marks4{e+,8,10,}
+...\marks4{b-,9,10,text,,,}
+...\marks4{b+,9,10,text,,,}
+...\marks4{e-,9,10,}
+...\marks4{e+,9,10,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 320.98918fil
 ....\write1{\new@label@record{mcid-16}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{16}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -578,26 +578,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,16,22,text,,,}
-...\marks4{b+,16,22,text,,,}
-...\marks4{e-,16,22,}
-...\marks4{e+,16,22,}
-...\marks4{b-,17,23,Lbl,,,}
-...\marks4{b+,17,23,Lbl,,,}
-...\marks4{e-,17,23,}
-...\marks4{e+,17,23,}
-...\marks4{b-,18,22,text,,,}
-...\marks4{b+,18,22,text,,,}
-...\marks4{e-,18,22,}
-...\marks4{e+,18,22,}
-...\marks4{b-,19,22,text,,,}
-...\marks4{b+,19,22,text,,,}
-...\marks4{e-,19,22,}
-...\marks4{e+,19,22,}
-...\marks4{b-,20,22,text,,,}
-...\marks4{b+,20,22,text,,,}
-...\marks4{e-,20,22,}
-...\marks4{e+,20,22,}
+...\marks4{b-,16,20,text,,,}
+...\marks4{b+,16,20,text,,,}
+...\marks4{e-,16,20,}
+...\marks4{e+,16,20,}
+...\marks4{b-,17,21,Lbl,,,}
+...\marks4{b+,17,21,Lbl,,,}
+...\marks4{e-,17,21,}
+...\marks4{e+,17,21,}
+...\marks4{b-,18,20,text,,,}
+...\marks4{b+,18,20,text,,,}
+...\marks4{e-,18,20,}
+...\marks4{e+,18,20,}
+...\marks4{b-,19,20,text,,,}
+...\marks4{b+,19,20,text,,,}
+...\marks4{e-,19,20,}
+...\marks4{e+,19,20,}
+...\marks4{b-,20,20,text,,,}
+...\marks4{b+,20,20,text,,,}
+...\marks4{e-,20,20,}
+...\marks4{e+,20,20,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 320.86699fil
 ....\write1{\new@label@record{mcid-25}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{25}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -631,26 +631,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,25,30,text,,,}
-...\marks4{b+,25,30,text,,,}
-...\marks4{e-,25,30,}
-...\marks4{e+,25,30,}
-...\marks4{b-,26,31,Lbl,,,}
-...\marks4{b+,26,31,Lbl,,,}
-...\marks4{e-,26,31,}
-...\marks4{e+,26,31,}
-...\marks4{b-,27,30,text,,,}
-...\marks4{b+,27,30,text,,,}
-...\marks4{e-,27,30,}
-...\marks4{e+,27,30,}
-...\marks4{b-,28,30,text,,,}
-...\marks4{b+,28,30,text,,,}
-...\marks4{e-,28,30,}
-...\marks4{e+,28,30,}
-...\marks4{b-,29,30,text,,,}
-...\marks4{b+,29,30,text,,,}
-...\marks4{e-,29,30,}
-...\marks4{e+,29,30,}
+...\marks4{b-,25,27,text,,,}
+...\marks4{b+,25,27,text,,,}
+...\marks4{e-,25,27,}
+...\marks4{e+,25,27,}
+...\marks4{b-,26,28,Lbl,,,}
+...\marks4{b+,26,28,Lbl,,,}
+...\marks4{e-,26,28,}
+...\marks4{e+,26,28,}
+...\marks4{b-,27,27,text,,,}
+...\marks4{b+,27,27,text,,,}
+...\marks4{e-,27,27,}
+...\marks4{e+,27,27,}
+...\marks4{b-,28,27,text,,,}
+...\marks4{b+,28,27,text,,,}
+...\marks4{e-,28,27,}
+...\marks4{e+,28,27,}
+...\marks4{b-,29,27,text,,,}
+...\marks4{b+,29,27,text,,,}
+...\marks4{e-,29,27,}
+...\marks4{e+,29,27,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 216.28975fil
 ....\write1{\new@label@record{mcid-33}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{33}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -714,26 +714,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,33,36,text,,,}
-...\marks4{b+,33,36,text,,,}
-...\marks4{e-,33,36,}
-...\marks4{e+,33,36,}
-...\marks4{b-,34,37,Lbl,,,}
-...\marks4{b+,34,37,Lbl,,,}
-...\marks4{e-,34,37,}
-...\marks4{e+,34,37,}
-...\marks4{b-,35,36,text,,,}
-...\marks4{b+,35,36,text,,,}
-...\marks4{e-,35,36,}
-...\marks4{e+,35,36,}
-...\marks4{b-,36,36,text,,,}
-...\marks4{b+,36,36,text,,,}
-...\marks4{e-,36,36,}
-...\marks4{e+,36,36,}
-...\marks4{b-,37,36,text,,,}
-...\marks4{b+,37,36,text,,,}
-...\marks4{e-,37,36,}
-...\marks4{e+,37,36,}
+...\marks4{b-,33,32,text,,,}
+...\marks4{b+,33,32,text,,,}
+...\marks4{e-,33,32,}
+...\marks4{e+,33,32,}
+...\marks4{b-,34,33,Lbl,,,}
+...\marks4{b+,34,33,Lbl,,,}
+...\marks4{e-,34,33,}
+...\marks4{e+,34,33,}
+...\marks4{b-,35,32,text,,,}
+...\marks4{b+,35,32,text,,,}
+...\marks4{e-,35,32,}
+...\marks4{e+,35,32,}
+...\marks4{b-,36,32,text,,,}
+...\marks4{b+,36,32,text,,,}
+...\marks4{e-,36,32,}
+...\marks4{e+,36,32,}
+...\marks4{b-,37,32,text,,,}
+...\marks4{b+,37,32,text,,,}
+...\marks4{e-,37,32,}
+...\marks4{e+,37,32,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 175.68161fil
 ....\write1{\new@label@record{mcid-42}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{42}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -807,26 +807,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,42,44,text,,,}
-...\marks4{b+,42,44,text,,,}
-...\marks4{e-,42,44,}
-...\marks4{e+,42,44,}
-...\marks4{b-,43,45,Lbl,,,}
-...\marks4{b+,43,45,Lbl,,,}
-...\marks4{e-,43,45,}
-...\marks4{e+,43,45,}
-...\marks4{b-,44,44,text,,,}
-...\marks4{b+,44,44,text,,,}
-...\marks4{e-,44,44,}
-...\marks4{e+,44,44,}
-...\marks4{b-,45,44,text,,,}
-...\marks4{b+,45,44,text,,,}
-...\marks4{e-,45,44,}
-...\marks4{e+,45,44,}
-...\marks4{b-,46,44,text,,,}
-...\marks4{b+,46,44,text,,,}
-...\marks4{e-,46,44,}
-...\marks4{e+,46,44,}
+...\marks4{b-,42,39,text,,,}
+...\marks4{b+,42,39,text,,,}
+...\marks4{e-,42,39,}
+...\marks4{e+,42,39,}
+...\marks4{b-,43,40,Lbl,,,}
+...\marks4{b+,43,40,Lbl,,,}
+...\marks4{e-,43,40,}
+...\marks4{e+,43,40,}
+...\marks4{b-,44,39,text,,,}
+...\marks4{b+,44,39,text,,,}
+...\marks4{e-,44,39,}
+...\marks4{e+,44,39,}
+...\marks4{b-,45,39,text,,,}
+...\marks4{b+,45,39,text,,,}
+...\marks4{e-,45,39,}
+...\marks4{e+,45,39,}
+...\marks4{b-,46,39,text,,,}
+...\marks4{b+,46,39,text,,,}
+...\marks4{e-,46,39,}
+...\marks4{e+,46,39,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 161.5184fil
 ....\write1{\new@label@record{mcid-51}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{51}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -905,26 +905,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,51,52,text,,,}
-...\marks4{b+,51,52,text,,,}
-...\marks4{e-,51,52,}
-...\marks4{e+,51,52,}
-...\marks4{b-,52,53,Lbl,,,}
-...\marks4{b+,52,53,Lbl,,,}
-...\marks4{e-,52,53,}
-...\marks4{e+,52,53,}
-...\marks4{b-,53,52,text,,,}
-...\marks4{b+,53,52,text,,,}
-...\marks4{e-,53,52,}
-...\marks4{e+,53,52,}
-...\marks4{b-,54,52,text,,,}
-...\marks4{b+,54,52,text,,,}
-...\marks4{e-,54,52,}
-...\marks4{e+,54,52,}
-...\marks4{b-,55,52,text,,,}
-...\marks4{b+,55,52,text,,,}
-...\marks4{e-,55,52,}
-...\marks4{e+,55,52,}
+...\marks4{b-,51,46,text,,,}
+...\marks4{b+,51,46,text,,,}
+...\marks4{e-,51,46,}
+...\marks4{e+,51,46,}
+...\marks4{b-,52,47,Lbl,,,}
+...\marks4{b+,52,47,Lbl,,,}
+...\marks4{e-,52,47,}
+...\marks4{e+,52,47,}
+...\marks4{b-,53,46,text,,,}
+...\marks4{b+,53,46,text,,,}
+...\marks4{e-,53,46,}
+...\marks4{e+,53,46,}
+...\marks4{b-,54,46,text,,,}
+...\marks4{b+,54,46,text,,,}
+...\marks4{e-,54,46,}
+...\marks4{e+,54,46,}
+...\marks4{b-,55,46,text,,,}
+...\marks4{b+,55,46,text,,,}
+...\marks4{e-,55,46,}
+...\marks4{e+,55,46,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 320.51707fil
 ....\write1{\new@label@record{mcid-59}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{59}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -958,26 +958,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,59,58,text,,,}
-...\marks4{b+,59,58,text,,,}
-...\marks4{e-,59,58,}
-...\marks4{e+,59,58,}
-...\marks4{b-,60,59,Lbl,,,}
-...\marks4{b+,60,59,Lbl,,,}
-...\marks4{e-,60,59,}
-...\marks4{e+,60,59,}
-...\marks4{b-,61,58,text,,,}
-...\marks4{b+,61,58,text,,,}
-...\marks4{e-,61,58,}
-...\marks4{e+,61,58,}
-...\marks4{b-,62,58,text,,,}
-...\marks4{b+,62,58,text,,,}
-...\marks4{e-,62,58,}
-...\marks4{e+,62,58,}
-...\marks4{b-,63,58,text,,,}
-...\marks4{b+,63,58,text,,,}
-...\marks4{e-,63,58,}
-...\marks4{e+,63,58,}
+...\marks4{b-,59,51,text,,,}
+...\marks4{b+,59,51,text,,,}
+...\marks4{e-,59,51,}
+...\marks4{e+,59,51,}
+...\marks4{b-,60,52,Lbl,,,}
+...\marks4{b+,60,52,Lbl,,,}
+...\marks4{e-,60,52,}
+...\marks4{e+,60,52,}
+...\marks4{b-,61,51,text,,,}
+...\marks4{b+,61,51,text,,,}
+...\marks4{e-,61,51,}
+...\marks4{e+,61,51,}
+...\marks4{b-,62,51,text,,,}
+...\marks4{b+,62,51,text,,,}
+...\marks4{e-,62,51,}
+...\marks4{e+,62,51,}
+...\marks4{b-,63,51,text,,,}
+...\marks4{b+,63,51,text,,,}
+...\marks4{e-,63,51,}
+...\marks4{e+,63,51,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue 20.0 plus 2.0 minus 4.0
@@ -1009,15 +1009,15 @@ Completed box being shipped out [1]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,11,14,text,,,}
-.....\marks4{b+,11,14,text,,,}
-.....\marks4{e-,11,14,}
-.....\marks4{e+,11,14,}
+.....\marks4{b-,11,13,text,,,}
+.....\marks4{b+,11,13,text,,,}
+.....\marks4{e-,11,13,}
+.....\marks4{e+,11,13,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-12}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{12}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,12,15,Caption,,,}
-.....\marks4{b+,12,15,Caption,,,}
+.....\marks4{b-,12,14,Caption,,,}
+.....\marks4{b+,12,14,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {1}{\ignorespaces A}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 146.86737fil
@@ -1038,8 +1038,8 @@ Completed box being shipped out [1]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,12,15,}
-.....\marks4{e+,12,15,}
+.....\marks4{e-,12,14,}
+.....\marks4{e+,12,14,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -1063,10 +1063,10 @@ Completed box being shipped out [1]
 .\kern 0.0
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 62) on line ...
+(tagpdf)                struct 55) on line ...
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 73) on line ...
+(tagpdf)                struct 65) on line ...
 Completed box being shipped out [2]
 \vbox(633.0+0.0)x407.0
 .\hbox(0.0+0.0)x0.0
@@ -1121,15 +1121,15 @@ Completed box being shipped out [2]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,67,61,text,,,}
-.....\marks4{b+,67,61,text,,,}
-.....\marks4{e-,67,61,}
-.....\marks4{e+,67,61,}
+.....\marks4{b-,67,54,text,,,}
+.....\marks4{b+,67,54,text,,,}
+.....\marks4{e-,67,54,}
+.....\marks4{e+,67,54,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-68}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{68}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,68,62,Caption,,,}
-.....\marks4{b+,68,62,Caption,,,}
+.....\marks4{b-,68,55,Caption,,,}
+.....\marks4{b+,68,55,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {2}{\ignorespaces B}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 147.07565fil
@@ -1150,8 +1150,8 @@ Completed box being shipped out [2]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,68,62,}
-.....\marks4{e+,68,62,}
+.....\marks4{e-,68,55,}
+.....\marks4{e+,68,55,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -1215,22 +1215,22 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,69,64,text,,,}
-...\marks4{b+,69,64,text,,,}
-...\marks4{e-,69,64,}
-...\marks4{e+,69,64,}
-...\marks4{b-,70,65,Lbl,,,}
-...\marks4{b+,70,65,Lbl,,,}
-...\marks4{e-,70,65,}
-...\marks4{e+,70,65,}
-...\marks4{b-,71,64,text,,,}
-...\marks4{b+,71,64,text,,,}
-...\marks4{e-,71,64,}
-...\marks4{e+,71,64,}
-...\marks4{b-,77,64,text,,,}
-...\marks4{b+,77,64,text,,,}
-...\marks4{e-,77,64,}
-...\marks4{e+,77,64,}
+...\marks4{b-,69,57,text,,,}
+...\marks4{b+,69,57,text,,,}
+...\marks4{e-,69,57,}
+...\marks4{e+,69,57,}
+...\marks4{b-,70,58,Lbl,,,}
+...\marks4{b+,70,58,Lbl,,,}
+...\marks4{e-,70,58,}
+...\marks4{e+,70,58,}
+...\marks4{b-,71,57,text,,,}
+...\marks4{b+,71,57,text,,,}
+...\marks4{e-,71,57,}
+...\marks4{e+,71,57,}
+...\marks4{b-,77,57,text,,,}
+...\marks4{b+,77,57,text,,,}
+...\marks4{e-,77,57,}
+...\marks4{e+,77,57,}
 ...\penalty 0
 ...\penalty 10000
 ...\glue 0.0
@@ -1276,26 +1276,26 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,72,69,text,,,}
-...\marks4{b+,72,69,text,,,}
-...\marks4{e-,72,69,}
-...\marks4{e+,72,69,}
-...\marks4{b-,73,70,Lbl,,,}
-...\marks4{b+,73,70,Lbl,,,}
-...\marks4{e-,73,70,}
-...\marks4{e+,73,70,}
-...\marks4{b-,74,69,text,,,}
-...\marks4{b+,74,69,text,,,}
-...\marks4{e-,74,69,}
-...\marks4{e+,74,69,}
-...\marks4{b-,75,69,text,,,}
-...\marks4{b+,75,69,text,,,}
-...\marks4{e-,75,69,}
-...\marks4{e+,75,69,}
-...\marks4{b-,76,69,text,,,}
-...\marks4{b+,76,69,text,,,}
-...\marks4{e-,76,69,}
-...\marks4{e+,76,69,}
+...\marks4{b-,72,61,text,,,}
+...\marks4{b+,72,61,text,,,}
+...\marks4{e-,72,61,}
+...\marks4{e+,72,61,}
+...\marks4{b-,73,62,Lbl,,,}
+...\marks4{b+,73,62,Lbl,,,}
+...\marks4{e-,73,62,}
+...\marks4{e+,73,62,}
+...\marks4{b-,74,61,text,,,}
+...\marks4{b+,74,61,text,,,}
+...\marks4{e-,74,61,}
+...\marks4{e+,74,61,}
+...\marks4{b-,75,61,text,,,}
+...\marks4{b+,75,61,text,,,}
+...\marks4{e-,75,61,}
+...\marks4{e+,75,61,}
+...\marks4{b-,76,61,text,,,}
+...\marks4{b+,76,61,text,,,}
+...\marks4{e-,76,61,}
+...\marks4{e+,76,61,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue 20.0 plus 2.0 minus 4.0
@@ -1327,15 +1327,15 @@ Completed box being shipped out [2]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,78,72,text,,,}
-.....\marks4{b+,78,72,text,,,}
-.....\marks4{e-,78,72,}
-.....\marks4{e+,78,72,}
+.....\marks4{b-,78,64,text,,,}
+.....\marks4{b+,78,64,text,,,}
+.....\marks4{e-,78,64,}
+.....\marks4{e+,78,64,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-79}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{79}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,79,73,Caption,,,}
-.....\marks4{b+,79,73,Caption,,,}
+.....\marks4{b-,79,65,Caption,,,}
+.....\marks4{b+,79,65,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {3}{\ignorespaces C}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 147.00623fil
@@ -1356,8 +1356,8 @@ Completed box being shipped out [2]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,79,73,}
-.....\marks4{e+,79,73,}
+.....\marks4{e-,79,65,}
+.....\marks4{e+,79,65,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -1469,22 +1469,22 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,82,75,text,,,}
-...\marks4{b+,82,75,text,,,}
-...\marks4{e-,82,75,}
-...\marks4{e+,82,75,}
-...\marks4{b-,83,76,Lbl,,,}
-...\marks4{b+,83,76,Lbl,,,}
-...\marks4{e-,83,76,}
-...\marks4{e+,83,76,}
-...\marks4{b-,84,75,text,,,}
-...\marks4{b+,84,75,text,,,}
-...\marks4{e-,84,75,}
-...\marks4{e+,84,75,}
-...\marks4{b-,90,75,text,,,}
-...\marks4{b+,90,75,text,,,}
-...\marks4{e-,90,75,}
-...\marks4{e+,90,75,}
+...\marks4{b-,82,67,text,,,}
+...\marks4{b+,82,67,text,,,}
+...\marks4{e-,82,67,}
+...\marks4{e+,82,67,}
+...\marks4{b-,83,68,Lbl,,,}
+...\marks4{b+,83,68,Lbl,,,}
+...\marks4{e-,83,68,}
+...\marks4{e+,83,68,}
+...\marks4{b-,84,67,text,,,}
+...\marks4{b+,84,67,text,,,}
+...\marks4{e-,84,67,}
+...\marks4{e+,84,67,}
+...\marks4{b-,90,67,text,,,}
+...\marks4{b+,90,67,text,,,}
+...\marks4{e-,90,67,}
+...\marks4{e+,90,67,}
 ...\kern -1.94397
 ...\hbox(0.0+1.94397)x0.0
 ...\glue 9.0 plus 4.0 minus 2.0
@@ -1525,26 +1525,26 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,85,80,text,,,}
-...\marks4{b+,85,80,text,,,}
-...\marks4{e-,85,80,}
-...\marks4{e+,85,80,}
-...\marks4{b-,86,81,Lbl,,,}
-...\marks4{b+,86,81,Lbl,,,}
-...\marks4{e-,86,81,}
-...\marks4{e+,86,81,}
-...\marks4{b-,87,80,text,,,}
-...\marks4{b+,87,80,text,,,}
-...\marks4{e-,87,80,}
-...\marks4{e+,87,80,}
-...\marks4{b-,88,80,text,,,}
-...\marks4{b+,88,80,text,,,}
-...\marks4{e-,88,80,}
-...\marks4{e+,88,80,}
-...\marks4{b-,89,80,text,,,}
-...\marks4{b+,89,80,text,,,}
-...\marks4{e-,89,80,}
-...\marks4{e+,89,80,}
+...\marks4{b-,85,71,text,,,}
+...\marks4{b+,85,71,text,,,}
+...\marks4{e-,85,71,}
+...\marks4{e+,85,71,}
+...\marks4{b-,86,72,Lbl,,,}
+...\marks4{b+,86,72,Lbl,,,}
+...\marks4{e-,86,72,}
+...\marks4{e+,86,72,}
+...\marks4{b-,87,71,text,,,}
+...\marks4{b+,87,71,text,,,}
+...\marks4{e-,87,71,}
+...\marks4{e+,87,71,}
+...\marks4{b-,88,71,text,,,}
+...\marks4{b+,88,71,text,,,}
+...\marks4{e-,88,71,}
+...\marks4{e+,88,71,}
+...\marks4{b-,89,71,text,,,}
+...\marks4{b+,89,71,text,,,}
+...\marks4{e-,89,71,}
+...\marks4{e+,89,71,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue -2.85002
@@ -1653,22 +1653,22 @@ Completed box being shipped out [4]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,93,83,text,,,}
-...\marks4{b+,93,83,text,,,}
-...\marks4{e-,93,83,}
-...\marks4{e+,93,83,}
-...\marks4{b-,94,84,Lbl,,,}
-...\marks4{b+,94,84,Lbl,,,}
-...\marks4{e-,94,84,}
-...\marks4{e+,94,84,}
-...\marks4{b-,95,83,text,,,}
-...\marks4{b+,95,83,text,,,}
-...\marks4{e-,95,83,}
-...\marks4{e+,95,83,}
-...\marks4{b-,101,83,text,,,}
-...\marks4{b+,101,83,text,,,}
-...\marks4{e-,101,83,}
-...\marks4{e+,101,83,}
+...\marks4{b-,93,74,text,,,}
+...\marks4{b+,93,74,text,,,}
+...\marks4{e-,93,74,}
+...\marks4{e+,93,74,}
+...\marks4{b-,94,75,Lbl,,,}
+...\marks4{b+,94,75,Lbl,,,}
+...\marks4{e-,94,75,}
+...\marks4{e+,94,75,}
+...\marks4{b-,95,74,text,,,}
+...\marks4{b+,95,74,text,,,}
+...\marks4{e-,95,74,}
+...\marks4{e+,95,74,}
+...\marks4{b-,101,74,text,,,}
+...\marks4{b+,101,74,text,,,}
+...\marks4{e-,101,74,}
+...\marks4{e+,101,74,}
 ...\glue -1.94397
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0 plus -1.0fil
@@ -1713,26 +1713,26 @@ Completed box being shipped out [4]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,96,88,text,,,}
-...\marks4{b+,96,88,text,,,}
-...\marks4{e-,96,88,}
-...\marks4{e+,96,88,}
-...\marks4{b-,97,89,Lbl,,,}
-...\marks4{b+,97,89,Lbl,,,}
-...\marks4{e-,97,89,}
-...\marks4{e+,97,89,}
-...\marks4{b-,98,88,text,,,}
-...\marks4{b+,98,88,text,,,}
-...\marks4{e-,98,88,}
-...\marks4{e+,98,88,}
-...\marks4{b-,99,88,text,,,}
-...\marks4{b+,99,88,text,,,}
-...\marks4{e-,99,88,}
-...\marks4{e+,99,88,}
-...\marks4{b-,100,88,text,,,}
-...\marks4{b+,100,88,text,,,}
-...\marks4{e-,100,88,}
-...\marks4{e+,100,88,}
+...\marks4{b-,96,78,text,,,}
+...\marks4{b+,96,78,text,,,}
+...\marks4{e-,96,78,}
+...\marks4{e+,96,78,}
+...\marks4{b-,97,79,Lbl,,,}
+...\marks4{b+,97,79,Lbl,,,}
+...\marks4{e-,97,79,}
+...\marks4{e+,97,79,}
+...\marks4{b-,98,78,text,,,}
+...\marks4{b+,98,78,text,,,}
+...\marks4{e-,98,78,}
+...\marks4{e+,98,78,}
+...\marks4{b-,99,78,text,,,}
+...\marks4{b+,99,78,text,,,}
+...\marks4{e-,99,78,}
+...\marks4{e+,99,78,}
+...\marks4{b-,100,78,text,,,}
+...\marks4{b+,100,78,text,,,}
+...\marks4{e-,100,78,}
+...\marks4{e+,100,78,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue 0.0 plus 1.0fil
@@ -1755,7 +1755,7 @@ Completed box being shipped out [4]
 .\kern 0.0
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 94) on line ...
+(tagpdf)                struct 84) on line ...
 Completed box being shipped out [5]
 \vbox(633.0+0.0)x407.0
 .\hbox(0.0+0.0)x0.0
@@ -1831,10 +1831,10 @@ Completed box being shipped out [5]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,104,91,text,,,}
-...\marks4{b+,104,91,text,,,}
-...\marks4{e-,104,91,}
-...\marks4{e+,104,91,}
+...\marks4{b-,104,81,text,,,}
+...\marks4{b+,104,81,text,,,}
+...\marks4{e-,104,81,}
+...\marks4{e+,104,81,}
 ...\penalty 0
 ...\penalty 10000
 ...\kern -1.94397
@@ -1868,15 +1868,15 @@ Completed box being shipped out [5]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,105,93,text,,,}
-.....\marks4{b+,105,93,text,,,}
-.....\marks4{e-,105,93,}
-.....\marks4{e+,105,93,}
+.....\marks4{b-,105,83,text,,,}
+.....\marks4{b+,105,83,text,,,}
+.....\marks4{e-,105,83,}
+.....\marks4{e+,105,83,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-106}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{106}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,106,94,Caption,,,}
-.....\marks4{b+,106,94,Caption,,,}
+.....\marks4{b-,106,84,Caption,,,}
+.....\marks4{b+,106,84,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {4}{\ignorespaces D}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 146.79794fil
@@ -1897,8 +1897,8 @@ Completed box being shipped out [5]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,106,94,}
-.....\marks4{e+,106,94,}
+.....\marks4{e-,106,84,}
+.....\marks4{e+,106,84,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -1921,7 +1921,7 @@ Completed box being shipped out [5]
 .\kern 0.0
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 99) on line ...
+(tagpdf)                struct 89) on line ...
 Completed box being shipped out [6]
 \vbox(633.0+0.0)x407.0
 .\hbox(0.0+0.0)x0.0
@@ -1995,10 +1995,10 @@ Completed box being shipped out [6]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,109,96,text,,,}
-...\marks4{b+,109,96,text,,,}
-...\marks4{e-,109,96,}
-...\marks4{e+,109,96,}
+...\marks4{b-,109,86,text,,,}
+...\marks4{b+,109,86,text,,,}
+...\marks4{e-,109,86,}
+...\marks4{e+,109,86,}
 ...\penalty 0
 ...\penalty 10000
 ...\glue 0.0
@@ -2035,15 +2035,15 @@ Completed box being shipped out [6]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,110,98,text,,,}
-.....\marks4{b+,110,98,text,,,}
-.....\marks4{e-,110,98,}
-.....\marks4{e+,110,98,}
+.....\marks4{b-,110,88,text,,,}
+.....\marks4{b+,110,88,text,,,}
+.....\marks4{e-,110,88,}
+.....\marks4{e+,110,88,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-111}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{111}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,111,99,Caption,,,}
-.....\marks4{b+,111,99,Caption,,,}
+.....\marks4{b-,111,89,Caption,,,}
+.....\marks4{b+,111,89,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {5}{\ignorespaces E}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 147.21451fil
@@ -2064,8 +2064,8 @@ Completed box being shipped out [6]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,111,99,}
-.....\marks4{e+,111,99,}
+.....\marks4{e-,111,89,}
+.....\marks4{e+,111,89,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -2145,10 +2145,10 @@ Completed box being shipped out [7]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,114,101,text,,,}
-...\marks4{b+,114,101,text,,,}
-...\marks4{e-,114,101,}
-...\marks4{e+,114,101,}
+...\marks4{b-,114,91,text,,,}
+...\marks4{b+,114,91,text,,,}
+...\marks4{e-,114,91,}
+...\marks4{e+,114,91,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.16882
@@ -2178,10 +2178,10 @@ Completed box being shipped out [7]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,115,103,text,,,}
-...\marks4{b+,115,103,text,,,}
-...\marks4{e-,115,103,}
-...\marks4{e+,115,103,}
+...\marks4{b-,115,93,text,,,}
+...\marks4{b+,115,93,text,,,}
+...\marks4{e-,115,93,}
+...\marks4{e+,115,93,}
 ...\kern -1.94397
 ...\hbox(0.0+1.94397)x0.0
 ...\glue -1.94397
@@ -2257,10 +2257,10 @@ Completed box being shipped out [8]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,118,105,text,,,}
-...\marks4{b+,118,105,text,,,}
-...\marks4{e-,118,105,}
-...\marks4{e+,118,105,}
+...\marks4{b-,118,95,text,,,}
+...\marks4{b+,118,95,text,,,}
+...\marks4{e-,118,95,}
+...\marks4{e+,118,95,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.16882
@@ -2290,10 +2290,10 @@ Completed box being shipped out [8]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,119,107,text,,,}
-...\marks4{b+,119,107,text,,,}
-...\marks4{e-,119,107,}
-...\marks4{e+,119,107,}
+...\marks4{b-,119,97,text,,,}
+...\marks4{b+,119,97,text,,,}
+...\marks4{e-,119,97,}
+...\marks4{e+,119,97,}
 ...\glue -1.94397
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0 plus -1.0fil

--- a/required/latex-lab/testfiles-OR/footmisc-floats-belowfloats-flushbottom.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-floats-belowfloats-flushbottom.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -63,7 +63,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
@@ -96,7 +96,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 (Font)              <6> on input line ....
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 15) on line ...
+(tagpdf)                struct 14) on line ...
 Completed box being shipped out [1]
 \vbox(633.0+0.0)x407.0
 .\hbox(0.0+0.0)x0.0
@@ -284,22 +284,22 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,13,17,text,,,}
-...\marks4{b+,13,17,text,,,}
-...\marks4{e-,13,17,}
-...\marks4{e+,13,17,}
-...\marks4{b-,14,18,Lbl,,,}
-...\marks4{b+,14,18,Lbl,,,}
-...\marks4{e-,14,18,}
-...\marks4{e+,14,18,}
-...\marks4{b-,15,17,text,,,}
-...\marks4{b+,15,17,text,,,}
-...\marks4{e-,15,17,}
-...\marks4{e+,15,17,}
-...\marks4{b-,21,17,text,,,}
-...\marks4{b+,21,17,text,,,}
-...\marks4{e-,21,17,}
-...\marks4{e+,21,17,}
+...\marks4{b-,13,16,text,,,}
+...\marks4{b+,13,16,text,,,}
+...\marks4{e-,13,16,}
+...\marks4{e+,13,16,}
+...\marks4{b-,14,17,Lbl,,,}
+...\marks4{b+,14,17,Lbl,,,}
+...\marks4{e-,14,17,}
+...\marks4{e+,14,17,}
+...\marks4{b-,15,16,text,,,}
+...\marks4{b+,15,16,text,,,}
+...\marks4{e-,15,16,}
+...\marks4{e+,15,16,}
+...\marks4{b-,21,16,text,,,}
+...\marks4{b+,21,16,text,,,}
+...\marks4{e-,21,16,}
+...\marks4{e+,21,16,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.83885
@@ -346,34 +346,34 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,22,25,text,,,}
-...\marks4{b+,22,25,text,,,}
-...\marks4{e-,22,25,}
-...\marks4{e+,22,25,}
-...\marks4{b-,23,26,Lbl,,,}
-...\marks4{b+,23,26,Lbl,,,}
-...\marks4{e-,23,26,}
-...\marks4{e+,23,26,}
-...\marks4{b-,24,25,text,,,}
-...\marks4{b+,24,25,text,,,}
-...\marks4{e-,24,25,}
-...\marks4{e+,24,25,}
-...\marks4{b-,30,25,text,,,}
-...\marks4{b+,30,25,text,,,}
-...\marks4{e-,30,25,}
-...\marks4{e+,30,25,}
-...\marks4{b-,31,32,Lbl,,,}
-...\marks4{b+,31,32,Lbl,,,}
-...\marks4{e-,31,32,}
-...\marks4{e+,31,32,}
-...\marks4{b-,32,25,text,,,}
-...\marks4{b+,32,25,text,,,}
-...\marks4{e-,32,25,}
-...\marks4{e+,32,25,}
-...\marks4{b-,38,25,text,,,}
-...\marks4{b+,38,25,text,,,}
-...\marks4{e-,38,25,}
-...\marks4{e+,38,25,}
+...\marks4{b-,22,23,text,,,}
+...\marks4{b+,22,23,text,,,}
+...\marks4{e-,22,23,}
+...\marks4{e+,22,23,}
+...\marks4{b-,23,24,Lbl,,,}
+...\marks4{b+,23,24,Lbl,,,}
+...\marks4{e-,23,24,}
+...\marks4{e+,23,24,}
+...\marks4{b-,24,23,text,,,}
+...\marks4{b+,24,23,text,,,}
+...\marks4{e-,24,23,}
+...\marks4{e+,24,23,}
+...\marks4{b-,30,23,text,,,}
+...\marks4{b+,30,23,text,,,}
+...\marks4{e-,30,23,}
+...\marks4{e+,30,23,}
+...\marks4{b-,31,29,Lbl,,,}
+...\marks4{b+,31,29,Lbl,,,}
+...\marks4{e-,31,29,}
+...\marks4{e+,31,29,}
+...\marks4{b-,32,23,text,,,}
+...\marks4{b+,32,23,text,,,}
+...\marks4{e-,32,23,}
+...\marks4{e+,32,23,}
+...\marks4{b-,38,23,text,,,}
+...\marks4{b+,38,23,text,,,}
+...\marks4{e-,38,23,}
+...\marks4{e+,38,23,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.83885
@@ -405,22 +405,22 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,39,39,text,,,}
-...\marks4{b+,39,39,text,,,}
-...\marks4{e-,39,39,}
-...\marks4{e+,39,39,}
-...\marks4{b-,40,40,Lbl,,,}
-...\marks4{b+,40,40,Lbl,,,}
-...\marks4{e-,40,40,}
-...\marks4{e+,40,40,}
-...\marks4{b-,41,39,text,,,}
-...\marks4{b+,41,39,text,,,}
-...\marks4{e-,41,39,}
-...\marks4{e+,41,39,}
-...\marks4{b-,47,39,text,,,}
-...\marks4{b+,47,39,text,,,}
-...\marks4{e-,47,39,}
-...\marks4{e+,47,39,}
+...\marks4{b-,39,35,text,,,}
+...\marks4{b+,39,35,text,,,}
+...\marks4{e-,39,35,}
+...\marks4{e+,39,35,}
+...\marks4{b-,40,36,Lbl,,,}
+...\marks4{b+,40,36,Lbl,,,}
+...\marks4{e-,40,36,}
+...\marks4{e+,40,36,}
+...\marks4{b-,41,35,text,,,}
+...\marks4{b+,41,35,text,,,}
+...\marks4{e-,41,35,}
+...\marks4{e+,41,35,}
+...\marks4{b-,47,35,text,,,}
+...\marks4{b+,47,35,text,,,}
+...\marks4{e-,47,35,}
+...\marks4{e+,47,35,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.83885
@@ -472,34 +472,34 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,48,47,text,,,}
-...\marks4{b+,48,47,text,,,}
-...\marks4{e-,48,47,}
-...\marks4{e+,48,47,}
-...\marks4{b-,49,48,Lbl,,,}
-...\marks4{b+,49,48,Lbl,,,}
-...\marks4{e-,49,48,}
-...\marks4{e+,49,48,}
-...\marks4{b-,50,47,text,,,}
-...\marks4{b+,50,47,text,,,}
-...\marks4{e-,50,47,}
-...\marks4{e+,50,47,}
-...\marks4{b-,56,47,text,,,}
-...\marks4{b+,56,47,text,,,}
-...\marks4{e-,56,47,}
-...\marks4{e+,56,47,}
-...\marks4{b-,57,54,Lbl,,,}
-...\marks4{b+,57,54,Lbl,,,}
-...\marks4{e-,57,54,}
-...\marks4{e+,57,54,}
-...\marks4{b-,58,47,text,,,}
-...\marks4{b+,58,47,text,,,}
-...\marks4{e-,58,47,}
-...\marks4{e+,58,47,}
-...\marks4{b-,64,47,text,,,}
-...\marks4{b+,64,47,text,,,}
-...\marks4{e-,64,47,}
-...\marks4{e+,64,47,}
+...\marks4{b-,48,42,text,,,}
+...\marks4{b+,48,42,text,,,}
+...\marks4{e-,48,42,}
+...\marks4{e+,48,42,}
+...\marks4{b-,49,43,Lbl,,,}
+...\marks4{b+,49,43,Lbl,,,}
+...\marks4{e-,49,43,}
+...\marks4{e+,49,43,}
+...\marks4{b-,50,42,text,,,}
+...\marks4{b+,50,42,text,,,}
+...\marks4{e-,50,42,}
+...\marks4{e+,50,42,}
+...\marks4{b-,56,42,text,,,}
+...\marks4{b+,56,42,text,,,}
+...\marks4{e-,56,42,}
+...\marks4{e+,56,42,}
+...\marks4{b-,57,48,Lbl,,,}
+...\marks4{b+,57,48,Lbl,,,}
+...\marks4{e-,57,48,}
+...\marks4{e+,57,48,}
+...\marks4{b-,58,42,text,,,}
+...\marks4{b+,58,42,text,,,}
+...\marks4{e-,58,42,}
+...\marks4{e+,58,42,}
+...\marks4{b-,64,42,text,,,}
+...\marks4{b+,64,42,text,,,}
+...\marks4{e-,64,42,}
+...\marks4{e+,64,42,}
 ...\kern 0.0
 ...\hbox(0.0+0.0)x0.0
 ...\glue 20.0 plus 2.0 minus 4.0
@@ -531,15 +531,15 @@ Completed box being shipped out [1]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,11,14,text,,,}
-.....\marks4{b+,11,14,text,,,}
-.....\marks4{e-,11,14,}
-.....\marks4{e+,11,14,}
+.....\marks4{b-,11,13,text,,,}
+.....\marks4{b+,11,13,text,,,}
+.....\marks4{e-,11,13,}
+.....\marks4{e+,11,13,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-12}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{12}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,12,15,Caption,,,}
-.....\marks4{b+,12,15,Caption,,,}
+.....\marks4{b-,12,14,Caption,,,}
+.....\marks4{b+,12,14,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {1}{\ignorespaces A}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 146.86737fil
@@ -560,8 +560,8 @@ Completed box being shipped out [1]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,12,15,}
-.....\marks4{e+,12,15,}
+.....\marks4{e-,12,14,}
+.....\marks4{e+,12,14,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -603,26 +603,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,5,11,text,,,}
-...\marks4{b+,5,11,text,,,}
-...\marks4{e-,5,11,}
-...\marks4{e+,5,11,}
-...\marks4{b-,6,12,Lbl,,,}
-...\marks4{b+,6,12,Lbl,,,}
-...\marks4{e-,6,12,}
-...\marks4{e+,6,12,}
-...\marks4{b-,7,11,text,,,}
-...\marks4{b+,7,11,text,,,}
-...\marks4{e-,7,11,}
-...\marks4{e+,7,11,}
-...\marks4{b-,8,11,text,,,}
-...\marks4{b+,8,11,text,,,}
-...\marks4{e-,8,11,}
-...\marks4{e+,8,11,}
-...\marks4{b-,9,11,text,,,}
-...\marks4{b+,9,11,text,,,}
-...\marks4{e-,9,11,}
-...\marks4{e+,9,11,}
+...\marks4{b-,5,10,text,,,}
+...\marks4{b+,5,10,text,,,}
+...\marks4{e-,5,10,}
+...\marks4{e+,5,10,}
+...\marks4{b-,6,11,Lbl,,,}
+...\marks4{b+,6,11,Lbl,,,}
+...\marks4{e-,6,11,}
+...\marks4{e+,6,11,}
+...\marks4{b-,7,10,text,,,}
+...\marks4{b+,7,10,text,,,}
+...\marks4{e-,7,10,}
+...\marks4{e+,7,10,}
+...\marks4{b-,8,10,text,,,}
+...\marks4{b+,8,10,text,,,}
+...\marks4{e-,8,10,}
+...\marks4{e+,8,10,}
+...\marks4{b-,9,10,text,,,}
+...\marks4{b+,9,10,text,,,}
+...\marks4{e-,9,10,}
+...\marks4{e+,9,10,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 320.98918fil
 ....\write1{\new@label@record{mcid-16}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{16}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -656,26 +656,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,16,22,text,,,}
-...\marks4{b+,16,22,text,,,}
-...\marks4{e-,16,22,}
-...\marks4{e+,16,22,}
-...\marks4{b-,17,23,Lbl,,,}
-...\marks4{b+,17,23,Lbl,,,}
-...\marks4{e-,17,23,}
-...\marks4{e+,17,23,}
-...\marks4{b-,18,22,text,,,}
-...\marks4{b+,18,22,text,,,}
-...\marks4{e-,18,22,}
-...\marks4{e+,18,22,}
-...\marks4{b-,19,22,text,,,}
-...\marks4{b+,19,22,text,,,}
-...\marks4{e-,19,22,}
-...\marks4{e+,19,22,}
-...\marks4{b-,20,22,text,,,}
-...\marks4{b+,20,22,text,,,}
-...\marks4{e-,20,22,}
-...\marks4{e+,20,22,}
+...\marks4{b-,16,20,text,,,}
+...\marks4{b+,16,20,text,,,}
+...\marks4{e-,16,20,}
+...\marks4{e+,16,20,}
+...\marks4{b-,17,21,Lbl,,,}
+...\marks4{b+,17,21,Lbl,,,}
+...\marks4{e-,17,21,}
+...\marks4{e+,17,21,}
+...\marks4{b-,18,20,text,,,}
+...\marks4{b+,18,20,text,,,}
+...\marks4{e-,18,20,}
+...\marks4{e+,18,20,}
+...\marks4{b-,19,20,text,,,}
+...\marks4{b+,19,20,text,,,}
+...\marks4{e-,19,20,}
+...\marks4{e+,19,20,}
+...\marks4{b-,20,20,text,,,}
+...\marks4{b+,20,20,text,,,}
+...\marks4{e-,20,20,}
+...\marks4{e+,20,20,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 320.86699fil
 ....\write1{\new@label@record{mcid-25}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{25}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -709,26 +709,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,25,30,text,,,}
-...\marks4{b+,25,30,text,,,}
-...\marks4{e-,25,30,}
-...\marks4{e+,25,30,}
-...\marks4{b-,26,31,Lbl,,,}
-...\marks4{b+,26,31,Lbl,,,}
-...\marks4{e-,26,31,}
-...\marks4{e+,26,31,}
-...\marks4{b-,27,30,text,,,}
-...\marks4{b+,27,30,text,,,}
-...\marks4{e-,27,30,}
-...\marks4{e+,27,30,}
-...\marks4{b-,28,30,text,,,}
-...\marks4{b+,28,30,text,,,}
-...\marks4{e-,28,30,}
-...\marks4{e+,28,30,}
-...\marks4{b-,29,30,text,,,}
-...\marks4{b+,29,30,text,,,}
-...\marks4{e-,29,30,}
-...\marks4{e+,29,30,}
+...\marks4{b-,25,27,text,,,}
+...\marks4{b+,25,27,text,,,}
+...\marks4{e-,25,27,}
+...\marks4{e+,25,27,}
+...\marks4{b-,26,28,Lbl,,,}
+...\marks4{b+,26,28,Lbl,,,}
+...\marks4{e-,26,28,}
+...\marks4{e+,26,28,}
+...\marks4{b-,27,27,text,,,}
+...\marks4{b+,27,27,text,,,}
+...\marks4{e-,27,27,}
+...\marks4{e+,27,27,}
+...\marks4{b-,28,27,text,,,}
+...\marks4{b+,28,27,text,,,}
+...\marks4{e-,28,27,}
+...\marks4{e+,28,27,}
+...\marks4{b-,29,27,text,,,}
+...\marks4{b+,29,27,text,,,}
+...\marks4{e-,29,27,}
+...\marks4{e+,29,27,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 216.28975fil
 ....\write1{\new@label@record{mcid-33}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{33}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -792,26 +792,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,33,36,text,,,}
-...\marks4{b+,33,36,text,,,}
-...\marks4{e-,33,36,}
-...\marks4{e+,33,36,}
-...\marks4{b-,34,37,Lbl,,,}
-...\marks4{b+,34,37,Lbl,,,}
-...\marks4{e-,34,37,}
-...\marks4{e+,34,37,}
-...\marks4{b-,35,36,text,,,}
-...\marks4{b+,35,36,text,,,}
-...\marks4{e-,35,36,}
-...\marks4{e+,35,36,}
-...\marks4{b-,36,36,text,,,}
-...\marks4{b+,36,36,text,,,}
-...\marks4{e-,36,36,}
-...\marks4{e+,36,36,}
-...\marks4{b-,37,36,text,,,}
-...\marks4{b+,37,36,text,,,}
-...\marks4{e-,37,36,}
-...\marks4{e+,37,36,}
+...\marks4{b-,33,32,text,,,}
+...\marks4{b+,33,32,text,,,}
+...\marks4{e-,33,32,}
+...\marks4{e+,33,32,}
+...\marks4{b-,34,33,Lbl,,,}
+...\marks4{b+,34,33,Lbl,,,}
+...\marks4{e-,34,33,}
+...\marks4{e+,34,33,}
+...\marks4{b-,35,32,text,,,}
+...\marks4{b+,35,32,text,,,}
+...\marks4{e-,35,32,}
+...\marks4{e+,35,32,}
+...\marks4{b-,36,32,text,,,}
+...\marks4{b+,36,32,text,,,}
+...\marks4{e-,36,32,}
+...\marks4{e+,36,32,}
+...\marks4{b-,37,32,text,,,}
+...\marks4{b+,37,32,text,,,}
+...\marks4{e-,37,32,}
+...\marks4{e+,37,32,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 175.68161fil
 ....\write1{\new@label@record{mcid-42}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{42}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -885,26 +885,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,42,44,text,,,}
-...\marks4{b+,42,44,text,,,}
-...\marks4{e-,42,44,}
-...\marks4{e+,42,44,}
-...\marks4{b-,43,45,Lbl,,,}
-...\marks4{b+,43,45,Lbl,,,}
-...\marks4{e-,43,45,}
-...\marks4{e+,43,45,}
-...\marks4{b-,44,44,text,,,}
-...\marks4{b+,44,44,text,,,}
-...\marks4{e-,44,44,}
-...\marks4{e+,44,44,}
-...\marks4{b-,45,44,text,,,}
-...\marks4{b+,45,44,text,,,}
-...\marks4{e-,45,44,}
-...\marks4{e+,45,44,}
-...\marks4{b-,46,44,text,,,}
-...\marks4{b+,46,44,text,,,}
-...\marks4{e-,46,44,}
-...\marks4{e+,46,44,}
+...\marks4{b-,42,39,text,,,}
+...\marks4{b+,42,39,text,,,}
+...\marks4{e-,42,39,}
+...\marks4{e+,42,39,}
+...\marks4{b-,43,40,Lbl,,,}
+...\marks4{b+,43,40,Lbl,,,}
+...\marks4{e-,43,40,}
+...\marks4{e+,43,40,}
+...\marks4{b-,44,39,text,,,}
+...\marks4{b+,44,39,text,,,}
+...\marks4{e-,44,39,}
+...\marks4{e+,44,39,}
+...\marks4{b-,45,39,text,,,}
+...\marks4{b+,45,39,text,,,}
+...\marks4{e-,45,39,}
+...\marks4{e+,45,39,}
+...\marks4{b-,46,39,text,,,}
+...\marks4{b+,46,39,text,,,}
+...\marks4{e-,46,39,}
+...\marks4{e+,46,39,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 161.5184fil
 ....\write1{\new@label@record{mcid-51}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{51}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -983,26 +983,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,51,52,text,,,}
-...\marks4{b+,51,52,text,,,}
-...\marks4{e-,51,52,}
-...\marks4{e+,51,52,}
-...\marks4{b-,52,53,Lbl,,,}
-...\marks4{b+,52,53,Lbl,,,}
-...\marks4{e-,52,53,}
-...\marks4{e+,52,53,}
-...\marks4{b-,53,52,text,,,}
-...\marks4{b+,53,52,text,,,}
-...\marks4{e-,53,52,}
-...\marks4{e+,53,52,}
-...\marks4{b-,54,52,text,,,}
-...\marks4{b+,54,52,text,,,}
-...\marks4{e-,54,52,}
-...\marks4{e+,54,52,}
-...\marks4{b-,55,52,text,,,}
-...\marks4{b+,55,52,text,,,}
-...\marks4{e-,55,52,}
-...\marks4{e+,55,52,}
+...\marks4{b-,51,46,text,,,}
+...\marks4{b+,51,46,text,,,}
+...\marks4{e-,51,46,}
+...\marks4{e+,51,46,}
+...\marks4{b-,52,47,Lbl,,,}
+...\marks4{b+,52,47,Lbl,,,}
+...\marks4{e-,52,47,}
+...\marks4{e+,52,47,}
+...\marks4{b-,53,46,text,,,}
+...\marks4{b+,53,46,text,,,}
+...\marks4{e-,53,46,}
+...\marks4{e+,53,46,}
+...\marks4{b-,54,46,text,,,}
+...\marks4{b+,54,46,text,,,}
+...\marks4{e-,54,46,}
+...\marks4{e+,54,46,}
+...\marks4{b-,55,46,text,,,}
+...\marks4{b+,55,46,text,,,}
+...\marks4{e-,55,46,}
+...\marks4{e+,55,46,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 320.51707fil
 ....\write1{\new@label@record{mcid-59}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{59}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -1036,26 +1036,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,59,58,text,,,}
-...\marks4{b+,59,58,text,,,}
-...\marks4{e-,59,58,}
-...\marks4{e+,59,58,}
-...\marks4{b-,60,59,Lbl,,,}
-...\marks4{b+,60,59,Lbl,,,}
-...\marks4{e-,60,59,}
-...\marks4{e+,60,59,}
-...\marks4{b-,61,58,text,,,}
-...\marks4{b+,61,58,text,,,}
-...\marks4{e-,61,58,}
-...\marks4{e+,61,58,}
-...\marks4{b-,62,58,text,,,}
-...\marks4{b+,62,58,text,,,}
-...\marks4{e-,62,58,}
-...\marks4{e+,62,58,}
-...\marks4{b-,63,58,text,,,}
-...\marks4{b+,63,58,text,,,}
-...\marks4{e-,63,58,}
-...\marks4{e+,63,58,}
+...\marks4{b-,59,51,text,,,}
+...\marks4{b+,59,51,text,,,}
+...\marks4{e-,59,51,}
+...\marks4{e+,59,51,}
+...\marks4{b-,60,52,Lbl,,,}
+...\marks4{b+,60,52,Lbl,,,}
+...\marks4{e-,60,52,}
+...\marks4{e+,60,52,}
+...\marks4{b-,61,51,text,,,}
+...\marks4{b+,61,51,text,,,}
+...\marks4{e-,61,51,}
+...\marks4{e+,61,51,}
+...\marks4{b-,62,51,text,,,}
+...\marks4{b+,62,51,text,,,}
+...\marks4{e-,62,51,}
+...\marks4{e+,62,51,}
+...\marks4{b-,63,51,text,,,}
+...\marks4{b+,63,51,text,,,}
+...\marks4{e-,63,51,}
+...\marks4{e+,63,51,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue -2.85002
@@ -1077,10 +1077,10 @@ Completed box being shipped out [1]
 .\kern 0.0
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 62) on line ...
+(tagpdf)                struct 55) on line ...
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 73) on line ...
+(tagpdf)                struct 65) on line ...
 Completed box being shipped out [2]
 \vbox(633.0+0.0)x407.0
 .\hbox(0.0+0.0)x0.0
@@ -1135,15 +1135,15 @@ Completed box being shipped out [2]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,67,61,text,,,}
-.....\marks4{b+,67,61,text,,,}
-.....\marks4{e-,67,61,}
-.....\marks4{e+,67,61,}
+.....\marks4{b-,67,54,text,,,}
+.....\marks4{b+,67,54,text,,,}
+.....\marks4{e-,67,54,}
+.....\marks4{e+,67,54,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-68}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{68}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,68,62,Caption,,,}
-.....\marks4{b+,68,62,Caption,,,}
+.....\marks4{b-,68,55,Caption,,,}
+.....\marks4{b+,68,55,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {2}{\ignorespaces B}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 147.07565fil
@@ -1164,8 +1164,8 @@ Completed box being shipped out [2]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,68,62,}
-.....\marks4{e+,68,62,}
+.....\marks4{e-,68,55,}
+.....\marks4{e+,68,55,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -1229,22 +1229,22 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,69,64,text,,,}
-...\marks4{b+,69,64,text,,,}
-...\marks4{e-,69,64,}
-...\marks4{e+,69,64,}
-...\marks4{b-,70,65,Lbl,,,}
-...\marks4{b+,70,65,Lbl,,,}
-...\marks4{e-,70,65,}
-...\marks4{e+,70,65,}
-...\marks4{b-,71,64,text,,,}
-...\marks4{b+,71,64,text,,,}
-...\marks4{e-,71,64,}
-...\marks4{e+,71,64,}
-...\marks4{b-,77,64,text,,,}
-...\marks4{b+,77,64,text,,,}
-...\marks4{e-,77,64,}
-...\marks4{e+,77,64,}
+...\marks4{b-,69,57,text,,,}
+...\marks4{b+,69,57,text,,,}
+...\marks4{e-,69,57,}
+...\marks4{e+,69,57,}
+...\marks4{b-,70,58,Lbl,,,}
+...\marks4{b+,70,58,Lbl,,,}
+...\marks4{e-,70,58,}
+...\marks4{e+,70,58,}
+...\marks4{b-,71,57,text,,,}
+...\marks4{b+,71,57,text,,,}
+...\marks4{e-,71,57,}
+...\marks4{e+,71,57,}
+...\marks4{b-,77,57,text,,,}
+...\marks4{b+,77,57,text,,,}
+...\marks4{e-,77,57,}
+...\marks4{e+,77,57,}
 ...\penalty 0
 ...\penalty 10000
 ...\glue 0.0
@@ -1280,15 +1280,15 @@ Completed box being shipped out [2]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,78,72,text,,,}
-.....\marks4{b+,78,72,text,,,}
-.....\marks4{e-,78,72,}
-.....\marks4{e+,78,72,}
+.....\marks4{b-,78,64,text,,,}
+.....\marks4{b+,78,64,text,,,}
+.....\marks4{e-,78,64,}
+.....\marks4{e+,78,64,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-79}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{79}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,79,73,Caption,,,}
-.....\marks4{b+,79,73,Caption,,,}
+.....\marks4{b-,79,65,Caption,,,}
+.....\marks4{b+,79,65,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {3}{\ignorespaces C}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 147.00623fil
@@ -1309,8 +1309,8 @@ Completed box being shipped out [2]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,79,73,}
-.....\marks4{e+,79,73,}
+.....\marks4{e-,79,65,}
+.....\marks4{e+,79,65,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -1352,26 +1352,26 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,72,69,text,,,}
-...\marks4{b+,72,69,text,,,}
-...\marks4{e-,72,69,}
-...\marks4{e+,72,69,}
-...\marks4{b-,73,70,Lbl,,,}
-...\marks4{b+,73,70,Lbl,,,}
-...\marks4{e-,73,70,}
-...\marks4{e+,73,70,}
-...\marks4{b-,74,69,text,,,}
-...\marks4{b+,74,69,text,,,}
-...\marks4{e-,74,69,}
-...\marks4{e+,74,69,}
-...\marks4{b-,75,69,text,,,}
-...\marks4{b+,75,69,text,,,}
-...\marks4{e-,75,69,}
-...\marks4{e+,75,69,}
-...\marks4{b-,76,69,text,,,}
-...\marks4{b+,76,69,text,,,}
-...\marks4{e-,76,69,}
-...\marks4{e+,76,69,}
+...\marks4{b-,72,61,text,,,}
+...\marks4{b+,72,61,text,,,}
+...\marks4{e-,72,61,}
+...\marks4{e+,72,61,}
+...\marks4{b-,73,62,Lbl,,,}
+...\marks4{b+,73,62,Lbl,,,}
+...\marks4{e-,73,62,}
+...\marks4{e+,73,62,}
+...\marks4{b-,74,61,text,,,}
+...\marks4{b+,74,61,text,,,}
+...\marks4{e-,74,61,}
+...\marks4{e+,74,61,}
+...\marks4{b-,75,61,text,,,}
+...\marks4{b+,75,61,text,,,}
+...\marks4{e-,75,61,}
+...\marks4{e+,75,61,}
+...\marks4{b-,76,61,text,,,}
+...\marks4{b+,76,61,text,,,}
+...\marks4{e-,76,61,}
+...\marks4{e+,76,61,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue -2.85002
@@ -1480,22 +1480,22 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,82,75,text,,,}
-...\marks4{b+,82,75,text,,,}
-...\marks4{e-,82,75,}
-...\marks4{e+,82,75,}
-...\marks4{b-,83,76,Lbl,,,}
-...\marks4{b+,83,76,Lbl,,,}
-...\marks4{e-,83,76,}
-...\marks4{e+,83,76,}
-...\marks4{b-,84,75,text,,,}
-...\marks4{b+,84,75,text,,,}
-...\marks4{e-,84,75,}
-...\marks4{e+,84,75,}
-...\marks4{b-,90,75,text,,,}
-...\marks4{b+,90,75,text,,,}
-...\marks4{e-,90,75,}
-...\marks4{e+,90,75,}
+...\marks4{b-,82,67,text,,,}
+...\marks4{b+,82,67,text,,,}
+...\marks4{e-,82,67,}
+...\marks4{e+,82,67,}
+...\marks4{b-,83,68,Lbl,,,}
+...\marks4{b+,83,68,Lbl,,,}
+...\marks4{e-,83,68,}
+...\marks4{e+,83,68,}
+...\marks4{b-,84,67,text,,,}
+...\marks4{b+,84,67,text,,,}
+...\marks4{e-,84,67,}
+...\marks4{e+,84,67,}
+...\marks4{b-,90,67,text,,,}
+...\marks4{b+,90,67,text,,,}
+...\marks4{e-,90,67,}
+...\marks4{e+,90,67,}
 ...\kern -1.94397
 ...\hbox(0.0+1.94397)x0.0
 ...\glue 9.0 plus 4.0 minus 2.0
@@ -1536,26 +1536,26 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,85,80,text,,,}
-...\marks4{b+,85,80,text,,,}
-...\marks4{e-,85,80,}
-...\marks4{e+,85,80,}
-...\marks4{b-,86,81,Lbl,,,}
-...\marks4{b+,86,81,Lbl,,,}
-...\marks4{e-,86,81,}
-...\marks4{e+,86,81,}
-...\marks4{b-,87,80,text,,,}
-...\marks4{b+,87,80,text,,,}
-...\marks4{e-,87,80,}
-...\marks4{e+,87,80,}
-...\marks4{b-,88,80,text,,,}
-...\marks4{b+,88,80,text,,,}
-...\marks4{e-,88,80,}
-...\marks4{e+,88,80,}
-...\marks4{b-,89,80,text,,,}
-...\marks4{b+,89,80,text,,,}
-...\marks4{e-,89,80,}
-...\marks4{e+,89,80,}
+...\marks4{b-,85,71,text,,,}
+...\marks4{b+,85,71,text,,,}
+...\marks4{e-,85,71,}
+...\marks4{e+,85,71,}
+...\marks4{b-,86,72,Lbl,,,}
+...\marks4{b+,86,72,Lbl,,,}
+...\marks4{e-,86,72,}
+...\marks4{e+,86,72,}
+...\marks4{b-,87,71,text,,,}
+...\marks4{b+,87,71,text,,,}
+...\marks4{e-,87,71,}
+...\marks4{e+,87,71,}
+...\marks4{b-,88,71,text,,,}
+...\marks4{b+,88,71,text,,,}
+...\marks4{e-,88,71,}
+...\marks4{e+,88,71,}
+...\marks4{b-,89,71,text,,,}
+...\marks4{b+,89,71,text,,,}
+...\marks4{e-,89,71,}
+...\marks4{e+,89,71,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue -2.85002
@@ -1663,22 +1663,22 @@ Completed box being shipped out [4]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,93,83,text,,,}
-...\marks4{b+,93,83,text,,,}
-...\marks4{e-,93,83,}
-...\marks4{e+,93,83,}
-...\marks4{b-,94,84,Lbl,,,}
-...\marks4{b+,94,84,Lbl,,,}
-...\marks4{e-,94,84,}
-...\marks4{e+,94,84,}
-...\marks4{b-,95,83,text,,,}
-...\marks4{b+,95,83,text,,,}
-...\marks4{e-,95,83,}
-...\marks4{e+,95,83,}
-...\marks4{b-,101,83,text,,,}
-...\marks4{b+,101,83,text,,,}
-...\marks4{e-,101,83,}
-...\marks4{e+,101,83,}
+...\marks4{b-,93,74,text,,,}
+...\marks4{b+,93,74,text,,,}
+...\marks4{e-,93,74,}
+...\marks4{e+,93,74,}
+...\marks4{b-,94,75,Lbl,,,}
+...\marks4{b+,94,75,Lbl,,,}
+...\marks4{e-,94,75,}
+...\marks4{e+,94,75,}
+...\marks4{b-,95,74,text,,,}
+...\marks4{b+,95,74,text,,,}
+...\marks4{e-,95,74,}
+...\marks4{e+,95,74,}
+...\marks4{b-,101,74,text,,,}
+...\marks4{b+,101,74,text,,,}
+...\marks4{e-,101,74,}
+...\marks4{e+,101,74,}
 ...\glue -1.94397
 ...\glue 0.0 plus 1.0fil
 ...\kern 0.0
@@ -1722,26 +1722,26 @@ Completed box being shipped out [4]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,96,88,text,,,}
-...\marks4{b+,96,88,text,,,}
-...\marks4{e-,96,88,}
-...\marks4{e+,96,88,}
-...\marks4{b-,97,89,Lbl,,,}
-...\marks4{b+,97,89,Lbl,,,}
-...\marks4{e-,97,89,}
-...\marks4{e+,97,89,}
-...\marks4{b-,98,88,text,,,}
-...\marks4{b+,98,88,text,,,}
-...\marks4{e-,98,88,}
-...\marks4{e+,98,88,}
-...\marks4{b-,99,88,text,,,}
-...\marks4{b+,99,88,text,,,}
-...\marks4{e-,99,88,}
-...\marks4{e+,99,88,}
-...\marks4{b-,100,88,text,,,}
-...\marks4{b+,100,88,text,,,}
-...\marks4{e-,100,88,}
-...\marks4{e+,100,88,}
+...\marks4{b-,96,78,text,,,}
+...\marks4{b+,96,78,text,,,}
+...\marks4{e-,96,78,}
+...\marks4{e+,96,78,}
+...\marks4{b-,97,79,Lbl,,,}
+...\marks4{b+,97,79,Lbl,,,}
+...\marks4{e-,97,79,}
+...\marks4{e+,97,79,}
+...\marks4{b-,98,78,text,,,}
+...\marks4{b+,98,78,text,,,}
+...\marks4{e-,98,78,}
+...\marks4{e+,98,78,}
+...\marks4{b-,99,78,text,,,}
+...\marks4{b+,99,78,text,,,}
+...\marks4{e-,99,78,}
+...\marks4{e+,99,78,}
+...\marks4{b-,100,78,text,,,}
+...\marks4{b+,100,78,text,,,}
+...\marks4{e-,100,78,}
+...\marks4{e+,100,78,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue -2.85002
@@ -1762,7 +1762,7 @@ Completed box being shipped out [4]
 .\kern 0.0
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 94) on line ...
+(tagpdf)                struct 84) on line ...
 Completed box being shipped out [5]
 \vbox(633.0+0.0)x407.0
 .\hbox(0.0+0.0)x0.0
@@ -1838,10 +1838,10 @@ Completed box being shipped out [5]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,104,91,text,,,}
-...\marks4{b+,104,91,text,,,}
-...\marks4{e-,104,91,}
-...\marks4{e+,104,91,}
+...\marks4{b-,104,81,text,,,}
+...\marks4{b+,104,81,text,,,}
+...\marks4{e-,104,81,}
+...\marks4{e+,104,81,}
 ...\penalty 0
 ...\penalty 10000
 ...\kern 0.0
@@ -1875,15 +1875,15 @@ Completed box being shipped out [5]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,105,93,text,,,}
-.....\marks4{b+,105,93,text,,,}
-.....\marks4{e-,105,93,}
-.....\marks4{e+,105,93,}
+.....\marks4{b-,105,83,text,,,}
+.....\marks4{b+,105,83,text,,,}
+.....\marks4{e-,105,83,}
+.....\marks4{e+,105,83,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-106}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{106}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,106,94,Caption,,,}
-.....\marks4{b+,106,94,Caption,,,}
+.....\marks4{b-,106,84,Caption,,,}
+.....\marks4{b+,106,84,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {4}{\ignorespaces D}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 146.79794fil
@@ -1904,8 +1904,8 @@ Completed box being shipped out [5]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,106,94,}
-.....\marks4{e+,106,94,}
+.....\marks4{e-,106,84,}
+.....\marks4{e+,106,84,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -1927,7 +1927,7 @@ Completed box being shipped out [5]
 .\kern 0.0
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 99) on line ...
+(tagpdf)                struct 89) on line ...
 Completed box being shipped out [6]
 \vbox(633.0+0.0)x407.0
 .\hbox(0.0+0.0)x0.0
@@ -2001,10 +2001,10 @@ Completed box being shipped out [6]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,109,96,text,,,}
-...\marks4{b+,109,96,text,,,}
-...\marks4{e-,109,96,}
-...\marks4{e+,109,96,}
+...\marks4{b-,109,86,text,,,}
+...\marks4{b+,109,86,text,,,}
+...\marks4{e-,109,86,}
+...\marks4{e+,109,86,}
 ...\penalty 0
 ...\penalty 10000
 ...\glue 0.0
@@ -2040,15 +2040,15 @@ Completed box being shipped out [6]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,110,98,text,,,}
-.....\marks4{b+,110,98,text,,,}
-.....\marks4{e-,110,98,}
-.....\marks4{e+,110,98,}
+.....\marks4{b-,110,88,text,,,}
+.....\marks4{b+,110,88,text,,,}
+.....\marks4{e-,110,88,}
+.....\marks4{e+,110,88,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-111}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{111}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,111,99,Caption,,,}
-.....\marks4{b+,111,99,Caption,,,}
+.....\marks4{b-,111,89,Caption,,,}
+.....\marks4{b+,111,89,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {5}{\ignorespaces E}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 147.21451fil
@@ -2069,8 +2069,8 @@ Completed box being shipped out [6]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,111,99,}
-.....\marks4{e+,111,99,}
+.....\marks4{e-,111,89,}
+.....\marks4{e+,111,89,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -2148,10 +2148,10 @@ Completed box being shipped out [7]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,114,101,text,,,}
-...\marks4{b+,114,101,text,,,}
-...\marks4{e-,114,101,}
-...\marks4{e+,114,101,}
+...\marks4{b-,114,91,text,,,}
+...\marks4{b+,114,91,text,,,}
+...\marks4{e-,114,91,}
+...\marks4{e+,114,91,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.16882
@@ -2181,10 +2181,10 @@ Completed box being shipped out [7]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,115,103,text,,,}
-...\marks4{b+,115,103,text,,,}
-...\marks4{e-,115,103,}
-...\marks4{e+,115,103,}
+...\marks4{b-,115,93,text,,,}
+...\marks4{b+,115,93,text,,,}
+...\marks4{e-,115,93,}
+...\marks4{e+,115,93,}
 ...\kern -1.94397
 ...\hbox(0.0+1.94397)x0.0
 ...\glue -1.94397
@@ -2259,10 +2259,10 @@ Completed box being shipped out [8]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,118,105,text,,,}
-...\marks4{b+,118,105,text,,,}
-...\marks4{e-,118,105,}
-...\marks4{e+,118,105,}
+...\marks4{b-,118,95,text,,,}
+...\marks4{b+,118,95,text,,,}
+...\marks4{e-,118,95,}
+...\marks4{e+,118,95,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.16882
@@ -2292,10 +2292,10 @@ Completed box being shipped out [8]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,119,107,text,,,}
-...\marks4{b+,119,107,text,,,}
-...\marks4{e-,119,107,}
-...\marks4{e+,119,107,}
+...\marks4{b-,119,97,text,,,}
+...\marks4{b+,119,97,text,,,}
+...\marks4{e-,119,97,}
+...\marks4{e+,119,97,}
 ...\glue -1.94397
 ...\glue 0.0 plus 1.0fil
 ...\kern 0.0

--- a/required/latex-lab/testfiles-OR/footmisc-floats-latex.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-floats-latex.tlg
@@ -55,7 +55,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -65,7 +65,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
@@ -98,7 +98,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 (Font)              <6> on input line ....
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 15) on line ...
+(tagpdf)                struct 14) on line ...
 Completed box being shipped out [1]
 \vbox(633.0+0.0)x407.0
 .\hbox(0.0+0.0)x0.0
@@ -279,22 +279,22 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,13,17,text,,,}
-...\marks4{b+,13,17,text,,,}
-...\marks4{e-,13,17,}
-...\marks4{e+,13,17,}
-...\marks4{b-,14,18,Lbl,,,}
-...\marks4{b+,14,18,Lbl,,,}
-...\marks4{e-,14,18,}
-...\marks4{e+,14,18,}
-...\marks4{b-,15,17,text,,,}
-...\marks4{b+,15,17,text,,,}
-...\marks4{e-,15,17,}
-...\marks4{e+,15,17,}
-...\marks4{b-,21,17,text,,,}
-...\marks4{b+,21,17,text,,,}
-...\marks4{e-,21,17,}
-...\marks4{e+,21,17,}
+...\marks4{b-,13,16,text,,,}
+...\marks4{b+,13,16,text,,,}
+...\marks4{e-,13,16,}
+...\marks4{e+,13,16,}
+...\marks4{b-,14,17,Lbl,,,}
+...\marks4{b+,14,17,Lbl,,,}
+...\marks4{e-,14,17,}
+...\marks4{e+,14,17,}
+...\marks4{b-,15,16,text,,,}
+...\marks4{b+,15,16,text,,,}
+...\marks4{e-,15,16,}
+...\marks4{e+,15,16,}
+...\marks4{b-,21,16,text,,,}
+...\marks4{b+,21,16,text,,,}
+...\marks4{e-,21,16,}
+...\marks4{e+,21,16,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.83885
@@ -341,34 +341,34 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,22,25,text,,,}
-...\marks4{b+,22,25,text,,,}
-...\marks4{e-,22,25,}
-...\marks4{e+,22,25,}
-...\marks4{b-,23,26,Lbl,,,}
-...\marks4{b+,23,26,Lbl,,,}
-...\marks4{e-,23,26,}
-...\marks4{e+,23,26,}
-...\marks4{b-,24,25,text,,,}
-...\marks4{b+,24,25,text,,,}
-...\marks4{e-,24,25,}
-...\marks4{e+,24,25,}
-...\marks4{b-,30,25,text,,,}
-...\marks4{b+,30,25,text,,,}
-...\marks4{e-,30,25,}
-...\marks4{e+,30,25,}
-...\marks4{b-,31,32,Lbl,,,}
-...\marks4{b+,31,32,Lbl,,,}
-...\marks4{e-,31,32,}
-...\marks4{e+,31,32,}
-...\marks4{b-,32,25,text,,,}
-...\marks4{b+,32,25,text,,,}
-...\marks4{e-,32,25,}
-...\marks4{e+,32,25,}
-...\marks4{b-,38,25,text,,,}
-...\marks4{b+,38,25,text,,,}
-...\marks4{e-,38,25,}
-...\marks4{e+,38,25,}
+...\marks4{b-,22,23,text,,,}
+...\marks4{b+,22,23,text,,,}
+...\marks4{e-,22,23,}
+...\marks4{e+,22,23,}
+...\marks4{b-,23,24,Lbl,,,}
+...\marks4{b+,23,24,Lbl,,,}
+...\marks4{e-,23,24,}
+...\marks4{e+,23,24,}
+...\marks4{b-,24,23,text,,,}
+...\marks4{b+,24,23,text,,,}
+...\marks4{e-,24,23,}
+...\marks4{e+,24,23,}
+...\marks4{b-,30,23,text,,,}
+...\marks4{b+,30,23,text,,,}
+...\marks4{e-,30,23,}
+...\marks4{e+,30,23,}
+...\marks4{b-,31,29,Lbl,,,}
+...\marks4{b+,31,29,Lbl,,,}
+...\marks4{e-,31,29,}
+...\marks4{e+,31,29,}
+...\marks4{b-,32,23,text,,,}
+...\marks4{b+,32,23,text,,,}
+...\marks4{e-,32,23,}
+...\marks4{e+,32,23,}
+...\marks4{b-,38,23,text,,,}
+...\marks4{b+,38,23,text,,,}
+...\marks4{e-,38,23,}
+...\marks4{e+,38,23,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.83885
@@ -400,22 +400,22 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,39,39,text,,,}
-...\marks4{b+,39,39,text,,,}
-...\marks4{e-,39,39,}
-...\marks4{e+,39,39,}
-...\marks4{b-,40,40,Lbl,,,}
-...\marks4{b+,40,40,Lbl,,,}
-...\marks4{e-,40,40,}
-...\marks4{e+,40,40,}
-...\marks4{b-,41,39,text,,,}
-...\marks4{b+,41,39,text,,,}
-...\marks4{e-,41,39,}
-...\marks4{e+,41,39,}
-...\marks4{b-,47,39,text,,,}
-...\marks4{b+,47,39,text,,,}
-...\marks4{e-,47,39,}
-...\marks4{e+,47,39,}
+...\marks4{b-,39,35,text,,,}
+...\marks4{b+,39,35,text,,,}
+...\marks4{e-,39,35,}
+...\marks4{e+,39,35,}
+...\marks4{b-,40,36,Lbl,,,}
+...\marks4{b+,40,36,Lbl,,,}
+...\marks4{e-,40,36,}
+...\marks4{e+,40,36,}
+...\marks4{b-,41,35,text,,,}
+...\marks4{b+,41,35,text,,,}
+...\marks4{e-,41,35,}
+...\marks4{e+,41,35,}
+...\marks4{b-,47,35,text,,,}
+...\marks4{b+,47,35,text,,,}
+...\marks4{e-,47,35,}
+...\marks4{e+,47,35,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.83885
@@ -467,34 +467,34 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,48,47,text,,,}
-...\marks4{b+,48,47,text,,,}
-...\marks4{e-,48,47,}
-...\marks4{e+,48,47,}
-...\marks4{b-,49,48,Lbl,,,}
-...\marks4{b+,49,48,Lbl,,,}
-...\marks4{e-,49,48,}
-...\marks4{e+,49,48,}
-...\marks4{b-,50,47,text,,,}
-...\marks4{b+,50,47,text,,,}
-...\marks4{e-,50,47,}
-...\marks4{e+,50,47,}
-...\marks4{b-,56,47,text,,,}
-...\marks4{b+,56,47,text,,,}
-...\marks4{e-,56,47,}
-...\marks4{e+,56,47,}
-...\marks4{b-,57,54,Lbl,,,}
-...\marks4{b+,57,54,Lbl,,,}
-...\marks4{e-,57,54,}
-...\marks4{e+,57,54,}
-...\marks4{b-,58,47,text,,,}
-...\marks4{b+,58,47,text,,,}
-...\marks4{e-,58,47,}
-...\marks4{e+,58,47,}
-...\marks4{b-,64,47,text,,,}
-...\marks4{b+,64,47,text,,,}
-...\marks4{e-,64,47,}
-...\marks4{e+,64,47,}
+...\marks4{b-,48,42,text,,,}
+...\marks4{b+,48,42,text,,,}
+...\marks4{e-,48,42,}
+...\marks4{e+,48,42,}
+...\marks4{b-,49,43,Lbl,,,}
+...\marks4{b+,49,43,Lbl,,,}
+...\marks4{e-,49,43,}
+...\marks4{e+,49,43,}
+...\marks4{b-,50,42,text,,,}
+...\marks4{b+,50,42,text,,,}
+...\marks4{e-,50,42,}
+...\marks4{e+,50,42,}
+...\marks4{b-,56,42,text,,,}
+...\marks4{b+,56,42,text,,,}
+...\marks4{e-,56,42,}
+...\marks4{e+,56,42,}
+...\marks4{b-,57,48,Lbl,,,}
+...\marks4{b+,57,48,Lbl,,,}
+...\marks4{e-,57,48,}
+...\marks4{e+,57,48,}
+...\marks4{b-,58,42,text,,,}
+...\marks4{b+,58,42,text,,,}
+...\marks4{e-,58,42,}
+...\marks4{e+,58,42,}
+...\marks4{b-,64,42,text,,,}
+...\marks4{b+,64,42,text,,,}
+...\marks4{e-,64,42,}
+...\marks4{e+,64,42,}
 ...\kern 0.0
 ...\hbox(0.0+0.0)x0.0
 ...\glue 9.0 plus 4.0 minus 2.0
@@ -535,26 +535,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,5,11,text,,,}
-...\marks4{b+,5,11,text,,,}
-...\marks4{e-,5,11,}
-...\marks4{e+,5,11,}
-...\marks4{b-,6,12,Lbl,,,}
-...\marks4{b+,6,12,Lbl,,,}
-...\marks4{e-,6,12,}
-...\marks4{e+,6,12,}
-...\marks4{b-,7,11,text,,,}
-...\marks4{b+,7,11,text,,,}
-...\marks4{e-,7,11,}
-...\marks4{e+,7,11,}
-...\marks4{b-,8,11,text,,,}
-...\marks4{b+,8,11,text,,,}
-...\marks4{e-,8,11,}
-...\marks4{e+,8,11,}
-...\marks4{b-,9,11,text,,,}
-...\marks4{b+,9,11,text,,,}
-...\marks4{e-,9,11,}
-...\marks4{e+,9,11,}
+...\marks4{b-,5,10,text,,,}
+...\marks4{b+,5,10,text,,,}
+...\marks4{e-,5,10,}
+...\marks4{e+,5,10,}
+...\marks4{b-,6,11,Lbl,,,}
+...\marks4{b+,6,11,Lbl,,,}
+...\marks4{e-,6,11,}
+...\marks4{e+,6,11,}
+...\marks4{b-,7,10,text,,,}
+...\marks4{b+,7,10,text,,,}
+...\marks4{e-,7,10,}
+...\marks4{e+,7,10,}
+...\marks4{b-,8,10,text,,,}
+...\marks4{b+,8,10,text,,,}
+...\marks4{e-,8,10,}
+...\marks4{e+,8,10,}
+...\marks4{b-,9,10,text,,,}
+...\marks4{b+,9,10,text,,,}
+...\marks4{e-,9,10,}
+...\marks4{e+,9,10,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 320.98918fil
 ....\write1{\new@label@record{mcid-16}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{16}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -588,26 +588,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,16,22,text,,,}
-...\marks4{b+,16,22,text,,,}
-...\marks4{e-,16,22,}
-...\marks4{e+,16,22,}
-...\marks4{b-,17,23,Lbl,,,}
-...\marks4{b+,17,23,Lbl,,,}
-...\marks4{e-,17,23,}
-...\marks4{e+,17,23,}
-...\marks4{b-,18,22,text,,,}
-...\marks4{b+,18,22,text,,,}
-...\marks4{e-,18,22,}
-...\marks4{e+,18,22,}
-...\marks4{b-,19,22,text,,,}
-...\marks4{b+,19,22,text,,,}
-...\marks4{e-,19,22,}
-...\marks4{e+,19,22,}
-...\marks4{b-,20,22,text,,,}
-...\marks4{b+,20,22,text,,,}
-...\marks4{e-,20,22,}
-...\marks4{e+,20,22,}
+...\marks4{b-,16,20,text,,,}
+...\marks4{b+,16,20,text,,,}
+...\marks4{e-,16,20,}
+...\marks4{e+,16,20,}
+...\marks4{b-,17,21,Lbl,,,}
+...\marks4{b+,17,21,Lbl,,,}
+...\marks4{e-,17,21,}
+...\marks4{e+,17,21,}
+...\marks4{b-,18,20,text,,,}
+...\marks4{b+,18,20,text,,,}
+...\marks4{e-,18,20,}
+...\marks4{e+,18,20,}
+...\marks4{b-,19,20,text,,,}
+...\marks4{b+,19,20,text,,,}
+...\marks4{e-,19,20,}
+...\marks4{e+,19,20,}
+...\marks4{b-,20,20,text,,,}
+...\marks4{b+,20,20,text,,,}
+...\marks4{e-,20,20,}
+...\marks4{e+,20,20,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 320.86699fil
 ....\write1{\new@label@record{mcid-25}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{25}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -641,26 +641,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,25,30,text,,,}
-...\marks4{b+,25,30,text,,,}
-...\marks4{e-,25,30,}
-...\marks4{e+,25,30,}
-...\marks4{b-,26,31,Lbl,,,}
-...\marks4{b+,26,31,Lbl,,,}
-...\marks4{e-,26,31,}
-...\marks4{e+,26,31,}
-...\marks4{b-,27,30,text,,,}
-...\marks4{b+,27,30,text,,,}
-...\marks4{e-,27,30,}
-...\marks4{e+,27,30,}
-...\marks4{b-,28,30,text,,,}
-...\marks4{b+,28,30,text,,,}
-...\marks4{e-,28,30,}
-...\marks4{e+,28,30,}
-...\marks4{b-,29,30,text,,,}
-...\marks4{b+,29,30,text,,,}
-...\marks4{e-,29,30,}
-...\marks4{e+,29,30,}
+...\marks4{b-,25,27,text,,,}
+...\marks4{b+,25,27,text,,,}
+...\marks4{e-,25,27,}
+...\marks4{e+,25,27,}
+...\marks4{b-,26,28,Lbl,,,}
+...\marks4{b+,26,28,Lbl,,,}
+...\marks4{e-,26,28,}
+...\marks4{e+,26,28,}
+...\marks4{b-,27,27,text,,,}
+...\marks4{b+,27,27,text,,,}
+...\marks4{e-,27,27,}
+...\marks4{e+,27,27,}
+...\marks4{b-,28,27,text,,,}
+...\marks4{b+,28,27,text,,,}
+...\marks4{e-,28,27,}
+...\marks4{e+,28,27,}
+...\marks4{b-,29,27,text,,,}
+...\marks4{b+,29,27,text,,,}
+...\marks4{e-,29,27,}
+...\marks4{e+,29,27,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 216.28975fil
 ....\write1{\new@label@record{mcid-33}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{33}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -724,26 +724,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,33,36,text,,,}
-...\marks4{b+,33,36,text,,,}
-...\marks4{e-,33,36,}
-...\marks4{e+,33,36,}
-...\marks4{b-,34,37,Lbl,,,}
-...\marks4{b+,34,37,Lbl,,,}
-...\marks4{e-,34,37,}
-...\marks4{e+,34,37,}
-...\marks4{b-,35,36,text,,,}
-...\marks4{b+,35,36,text,,,}
-...\marks4{e-,35,36,}
-...\marks4{e+,35,36,}
-...\marks4{b-,36,36,text,,,}
-...\marks4{b+,36,36,text,,,}
-...\marks4{e-,36,36,}
-...\marks4{e+,36,36,}
-...\marks4{b-,37,36,text,,,}
-...\marks4{b+,37,36,text,,,}
-...\marks4{e-,37,36,}
-...\marks4{e+,37,36,}
+...\marks4{b-,33,32,text,,,}
+...\marks4{b+,33,32,text,,,}
+...\marks4{e-,33,32,}
+...\marks4{e+,33,32,}
+...\marks4{b-,34,33,Lbl,,,}
+...\marks4{b+,34,33,Lbl,,,}
+...\marks4{e-,34,33,}
+...\marks4{e+,34,33,}
+...\marks4{b-,35,32,text,,,}
+...\marks4{b+,35,32,text,,,}
+...\marks4{e-,35,32,}
+...\marks4{e+,35,32,}
+...\marks4{b-,36,32,text,,,}
+...\marks4{b+,36,32,text,,,}
+...\marks4{e-,36,32,}
+...\marks4{e+,36,32,}
+...\marks4{b-,37,32,text,,,}
+...\marks4{b+,37,32,text,,,}
+...\marks4{e-,37,32,}
+...\marks4{e+,37,32,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 175.68161fil
 ....\write1{\new@label@record{mcid-42}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{42}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -817,26 +817,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,42,44,text,,,}
-...\marks4{b+,42,44,text,,,}
-...\marks4{e-,42,44,}
-...\marks4{e+,42,44,}
-...\marks4{b-,43,45,Lbl,,,}
-...\marks4{b+,43,45,Lbl,,,}
-...\marks4{e-,43,45,}
-...\marks4{e+,43,45,}
-...\marks4{b-,44,44,text,,,}
-...\marks4{b+,44,44,text,,,}
-...\marks4{e-,44,44,}
-...\marks4{e+,44,44,}
-...\marks4{b-,45,44,text,,,}
-...\marks4{b+,45,44,text,,,}
-...\marks4{e-,45,44,}
-...\marks4{e+,45,44,}
-...\marks4{b-,46,44,text,,,}
-...\marks4{b+,46,44,text,,,}
-...\marks4{e-,46,44,}
-...\marks4{e+,46,44,}
+...\marks4{b-,42,39,text,,,}
+...\marks4{b+,42,39,text,,,}
+...\marks4{e-,42,39,}
+...\marks4{e+,42,39,}
+...\marks4{b-,43,40,Lbl,,,}
+...\marks4{b+,43,40,Lbl,,,}
+...\marks4{e-,43,40,}
+...\marks4{e+,43,40,}
+...\marks4{b-,44,39,text,,,}
+...\marks4{b+,44,39,text,,,}
+...\marks4{e-,44,39,}
+...\marks4{e+,44,39,}
+...\marks4{b-,45,39,text,,,}
+...\marks4{b+,45,39,text,,,}
+...\marks4{e-,45,39,}
+...\marks4{e+,45,39,}
+...\marks4{b-,46,39,text,,,}
+...\marks4{b+,46,39,text,,,}
+...\marks4{e-,46,39,}
+...\marks4{e+,46,39,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 161.5184fil
 ....\write1{\new@label@record{mcid-51}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{51}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -915,26 +915,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,51,52,text,,,}
-...\marks4{b+,51,52,text,,,}
-...\marks4{e-,51,52,}
-...\marks4{e+,51,52,}
-...\marks4{b-,52,53,Lbl,,,}
-...\marks4{b+,52,53,Lbl,,,}
-...\marks4{e-,52,53,}
-...\marks4{e+,52,53,}
-...\marks4{b-,53,52,text,,,}
-...\marks4{b+,53,52,text,,,}
-...\marks4{e-,53,52,}
-...\marks4{e+,53,52,}
-...\marks4{b-,54,52,text,,,}
-...\marks4{b+,54,52,text,,,}
-...\marks4{e-,54,52,}
-...\marks4{e+,54,52,}
-...\marks4{b-,55,52,text,,,}
-...\marks4{b+,55,52,text,,,}
-...\marks4{e-,55,52,}
-...\marks4{e+,55,52,}
+...\marks4{b-,51,46,text,,,}
+...\marks4{b+,51,46,text,,,}
+...\marks4{e-,51,46,}
+...\marks4{e+,51,46,}
+...\marks4{b-,52,47,Lbl,,,}
+...\marks4{b+,52,47,Lbl,,,}
+...\marks4{e-,52,47,}
+...\marks4{e+,52,47,}
+...\marks4{b-,53,46,text,,,}
+...\marks4{b+,53,46,text,,,}
+...\marks4{e-,53,46,}
+...\marks4{e+,53,46,}
+...\marks4{b-,54,46,text,,,}
+...\marks4{b+,54,46,text,,,}
+...\marks4{e-,54,46,}
+...\marks4{e+,54,46,}
+...\marks4{b-,55,46,text,,,}
+...\marks4{b+,55,46,text,,,}
+...\marks4{e-,55,46,}
+...\marks4{e+,55,46,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 320.51707fil
 ....\write1{\new@label@record{mcid-59}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{59}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -968,26 +968,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,59,58,text,,,}
-...\marks4{b+,59,58,text,,,}
-...\marks4{e-,59,58,}
-...\marks4{e+,59,58,}
-...\marks4{b-,60,59,Lbl,,,}
-...\marks4{b+,60,59,Lbl,,,}
-...\marks4{e-,60,59,}
-...\marks4{e+,60,59,}
-...\marks4{b-,61,58,text,,,}
-...\marks4{b+,61,58,text,,,}
-...\marks4{e-,61,58,}
-...\marks4{e+,61,58,}
-...\marks4{b-,62,58,text,,,}
-...\marks4{b+,62,58,text,,,}
-...\marks4{e-,62,58,}
-...\marks4{e+,62,58,}
-...\marks4{b-,63,58,text,,,}
-...\marks4{b+,63,58,text,,,}
-...\marks4{e-,63,58,}
-...\marks4{e+,63,58,}
+...\marks4{b-,59,51,text,,,}
+...\marks4{b+,59,51,text,,,}
+...\marks4{e-,59,51,}
+...\marks4{e+,59,51,}
+...\marks4{b-,60,52,Lbl,,,}
+...\marks4{b+,60,52,Lbl,,,}
+...\marks4{e-,60,52,}
+...\marks4{e+,60,52,}
+...\marks4{b-,61,51,text,,,}
+...\marks4{b+,61,51,text,,,}
+...\marks4{e-,61,51,}
+...\marks4{e+,61,51,}
+...\marks4{b-,62,51,text,,,}
+...\marks4{b+,62,51,text,,,}
+...\marks4{e-,62,51,}
+...\marks4{e+,62,51,}
+...\marks4{b-,63,51,text,,,}
+...\marks4{b+,63,51,text,,,}
+...\marks4{e-,63,51,}
+...\marks4{e+,63,51,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue 20.0 plus 2.0 minus 4.0
@@ -1019,15 +1019,15 @@ Completed box being shipped out [1]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,11,14,text,,,}
-.....\marks4{b+,11,14,text,,,}
-.....\marks4{e-,11,14,}
-.....\marks4{e+,11,14,}
+.....\marks4{b-,11,13,text,,,}
+.....\marks4{b+,11,13,text,,,}
+.....\marks4{e-,11,13,}
+.....\marks4{e+,11,13,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-12}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{12}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,12,15,Caption,,,}
-.....\marks4{b+,12,15,Caption,,,}
+.....\marks4{b-,12,14,Caption,,,}
+.....\marks4{b+,12,14,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {1}{\ignorespaces A}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 146.86737fil
@@ -1048,8 +1048,8 @@ Completed box being shipped out [1]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,12,15,}
-.....\marks4{e+,12,15,}
+.....\marks4{e-,12,14,}
+.....\marks4{e+,12,14,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -1073,10 +1073,10 @@ Completed box being shipped out [1]
 .\kern 0.0
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 62) on line ...
+(tagpdf)                struct 55) on line ...
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 73) on line ...
+(tagpdf)                struct 65) on line ...
 Completed box being shipped out [2]
 \vbox(633.0+0.0)x407.0
 .\hbox(0.0+0.0)x0.0
@@ -1131,15 +1131,15 @@ Completed box being shipped out [2]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,67,61,text,,,}
-.....\marks4{b+,67,61,text,,,}
-.....\marks4{e-,67,61,}
-.....\marks4{e+,67,61,}
+.....\marks4{b-,67,54,text,,,}
+.....\marks4{b+,67,54,text,,,}
+.....\marks4{e-,67,54,}
+.....\marks4{e+,67,54,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-68}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{68}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,68,62,Caption,,,}
-.....\marks4{b+,68,62,Caption,,,}
+.....\marks4{b-,68,55,Caption,,,}
+.....\marks4{b+,68,55,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {2}{\ignorespaces B}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 147.07565fil
@@ -1160,8 +1160,8 @@ Completed box being shipped out [2]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,68,62,}
-.....\marks4{e+,68,62,}
+.....\marks4{e-,68,55,}
+.....\marks4{e+,68,55,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -1225,22 +1225,22 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,69,64,text,,,}
-...\marks4{b+,69,64,text,,,}
-...\marks4{e-,69,64,}
-...\marks4{e+,69,64,}
-...\marks4{b-,70,65,Lbl,,,}
-...\marks4{b+,70,65,Lbl,,,}
-...\marks4{e-,70,65,}
-...\marks4{e+,70,65,}
-...\marks4{b-,71,64,text,,,}
-...\marks4{b+,71,64,text,,,}
-...\marks4{e-,71,64,}
-...\marks4{e+,71,64,}
-...\marks4{b-,77,64,text,,,}
-...\marks4{b+,77,64,text,,,}
-...\marks4{e-,77,64,}
-...\marks4{e+,77,64,}
+...\marks4{b-,69,57,text,,,}
+...\marks4{b+,69,57,text,,,}
+...\marks4{e-,69,57,}
+...\marks4{e+,69,57,}
+...\marks4{b-,70,58,Lbl,,,}
+...\marks4{b+,70,58,Lbl,,,}
+...\marks4{e-,70,58,}
+...\marks4{e+,70,58,}
+...\marks4{b-,71,57,text,,,}
+...\marks4{b+,71,57,text,,,}
+...\marks4{e-,71,57,}
+...\marks4{e+,71,57,}
+...\marks4{b-,77,57,text,,,}
+...\marks4{b+,77,57,text,,,}
+...\marks4{e-,77,57,}
+...\marks4{e+,77,57,}
 ...\penalty 0
 ...\penalty 10000
 ...\glue 0.0
@@ -1286,26 +1286,26 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,72,69,text,,,}
-...\marks4{b+,72,69,text,,,}
-...\marks4{e-,72,69,}
-...\marks4{e+,72,69,}
-...\marks4{b-,73,70,Lbl,,,}
-...\marks4{b+,73,70,Lbl,,,}
-...\marks4{e-,73,70,}
-...\marks4{e+,73,70,}
-...\marks4{b-,74,69,text,,,}
-...\marks4{b+,74,69,text,,,}
-...\marks4{e-,74,69,}
-...\marks4{e+,74,69,}
-...\marks4{b-,75,69,text,,,}
-...\marks4{b+,75,69,text,,,}
-...\marks4{e-,75,69,}
-...\marks4{e+,75,69,}
-...\marks4{b-,76,69,text,,,}
-...\marks4{b+,76,69,text,,,}
-...\marks4{e-,76,69,}
-...\marks4{e+,76,69,}
+...\marks4{b-,72,61,text,,,}
+...\marks4{b+,72,61,text,,,}
+...\marks4{e-,72,61,}
+...\marks4{e+,72,61,}
+...\marks4{b-,73,62,Lbl,,,}
+...\marks4{b+,73,62,Lbl,,,}
+...\marks4{e-,73,62,}
+...\marks4{e+,73,62,}
+...\marks4{b-,74,61,text,,,}
+...\marks4{b+,74,61,text,,,}
+...\marks4{e-,74,61,}
+...\marks4{e+,74,61,}
+...\marks4{b-,75,61,text,,,}
+...\marks4{b+,75,61,text,,,}
+...\marks4{e-,75,61,}
+...\marks4{e+,75,61,}
+...\marks4{b-,76,61,text,,,}
+...\marks4{b+,76,61,text,,,}
+...\marks4{e-,76,61,}
+...\marks4{e+,76,61,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue 20.0 plus 2.0 minus 4.0
@@ -1337,15 +1337,15 @@ Completed box being shipped out [2]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,78,72,text,,,}
-.....\marks4{b+,78,72,text,,,}
-.....\marks4{e-,78,72,}
-.....\marks4{e+,78,72,}
+.....\marks4{b-,78,64,text,,,}
+.....\marks4{b+,78,64,text,,,}
+.....\marks4{e-,78,64,}
+.....\marks4{e+,78,64,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-79}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{79}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,79,73,Caption,,,}
-.....\marks4{b+,79,73,Caption,,,}
+.....\marks4{b-,79,65,Caption,,,}
+.....\marks4{b+,79,65,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {3}{\ignorespaces C}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 147.00623fil
@@ -1366,8 +1366,8 @@ Completed box being shipped out [2]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,79,73,}
-.....\marks4{e+,79,73,}
+.....\marks4{e-,79,65,}
+.....\marks4{e+,79,65,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -1479,22 +1479,22 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,82,75,text,,,}
-...\marks4{b+,82,75,text,,,}
-...\marks4{e-,82,75,}
-...\marks4{e+,82,75,}
-...\marks4{b-,83,76,Lbl,,,}
-...\marks4{b+,83,76,Lbl,,,}
-...\marks4{e-,83,76,}
-...\marks4{e+,83,76,}
-...\marks4{b-,84,75,text,,,}
-...\marks4{b+,84,75,text,,,}
-...\marks4{e-,84,75,}
-...\marks4{e+,84,75,}
-...\marks4{b-,90,75,text,,,}
-...\marks4{b+,90,75,text,,,}
-...\marks4{e-,90,75,}
-...\marks4{e+,90,75,}
+...\marks4{b-,82,67,text,,,}
+...\marks4{b+,82,67,text,,,}
+...\marks4{e-,82,67,}
+...\marks4{e+,82,67,}
+...\marks4{b-,83,68,Lbl,,,}
+...\marks4{b+,83,68,Lbl,,,}
+...\marks4{e-,83,68,}
+...\marks4{e+,83,68,}
+...\marks4{b-,84,67,text,,,}
+...\marks4{b+,84,67,text,,,}
+...\marks4{e-,84,67,}
+...\marks4{e+,84,67,}
+...\marks4{b-,90,67,text,,,}
+...\marks4{b+,90,67,text,,,}
+...\marks4{e-,90,67,}
+...\marks4{e+,90,67,}
 ...\kern -1.94397
 ...\hbox(0.0+1.94397)x0.0
 ...\glue 9.0 plus 4.0 minus 2.0
@@ -1535,26 +1535,26 @@ Completed box being shipped out [3]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,85,80,text,,,}
-...\marks4{b+,85,80,text,,,}
-...\marks4{e-,85,80,}
-...\marks4{e+,85,80,}
-...\marks4{b-,86,81,Lbl,,,}
-...\marks4{b+,86,81,Lbl,,,}
-...\marks4{e-,86,81,}
-...\marks4{e+,86,81,}
-...\marks4{b-,87,80,text,,,}
-...\marks4{b+,87,80,text,,,}
-...\marks4{e-,87,80,}
-...\marks4{e+,87,80,}
-...\marks4{b-,88,80,text,,,}
-...\marks4{b+,88,80,text,,,}
-...\marks4{e-,88,80,}
-...\marks4{e+,88,80,}
-...\marks4{b-,89,80,text,,,}
-...\marks4{b+,89,80,text,,,}
-...\marks4{e-,89,80,}
-...\marks4{e+,89,80,}
+...\marks4{b-,85,71,text,,,}
+...\marks4{b+,85,71,text,,,}
+...\marks4{e-,85,71,}
+...\marks4{e+,85,71,}
+...\marks4{b-,86,72,Lbl,,,}
+...\marks4{b+,86,72,Lbl,,,}
+...\marks4{e-,86,72,}
+...\marks4{e+,86,72,}
+...\marks4{b-,87,71,text,,,}
+...\marks4{b+,87,71,text,,,}
+...\marks4{e-,87,71,}
+...\marks4{e+,87,71,}
+...\marks4{b-,88,71,text,,,}
+...\marks4{b+,88,71,text,,,}
+...\marks4{e-,88,71,}
+...\marks4{e+,88,71,}
+...\marks4{b-,89,71,text,,,}
+...\marks4{b+,89,71,text,,,}
+...\marks4{e-,89,71,}
+...\marks4{e+,89,71,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue -2.85002
@@ -1663,22 +1663,22 @@ Completed box being shipped out [4]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,93,83,text,,,}
-...\marks4{b+,93,83,text,,,}
-...\marks4{e-,93,83,}
-...\marks4{e+,93,83,}
-...\marks4{b-,94,84,Lbl,,,}
-...\marks4{b+,94,84,Lbl,,,}
-...\marks4{e-,94,84,}
-...\marks4{e+,94,84,}
-...\marks4{b-,95,83,text,,,}
-...\marks4{b+,95,83,text,,,}
-...\marks4{e-,95,83,}
-...\marks4{e+,95,83,}
-...\marks4{b-,101,83,text,,,}
-...\marks4{b+,101,83,text,,,}
-...\marks4{e-,101,83,}
-...\marks4{e+,101,83,}
+...\marks4{b-,93,74,text,,,}
+...\marks4{b+,93,74,text,,,}
+...\marks4{e-,93,74,}
+...\marks4{e+,93,74,}
+...\marks4{b-,94,75,Lbl,,,}
+...\marks4{b+,94,75,Lbl,,,}
+...\marks4{e-,94,75,}
+...\marks4{e+,94,75,}
+...\marks4{b-,95,74,text,,,}
+...\marks4{b+,95,74,text,,,}
+...\marks4{e-,95,74,}
+...\marks4{e+,95,74,}
+...\marks4{b-,101,74,text,,,}
+...\marks4{b+,101,74,text,,,}
+...\marks4{e-,101,74,}
+...\marks4{e+,101,74,}
 ...\glue -1.94397
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0 plus -1.0fil
@@ -1723,26 +1723,26 @@ Completed box being shipped out [4]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,96,88,text,,,}
-...\marks4{b+,96,88,text,,,}
-...\marks4{e-,96,88,}
-...\marks4{e+,96,88,}
-...\marks4{b-,97,89,Lbl,,,}
-...\marks4{b+,97,89,Lbl,,,}
-...\marks4{e-,97,89,}
-...\marks4{e+,97,89,}
-...\marks4{b-,98,88,text,,,}
-...\marks4{b+,98,88,text,,,}
-...\marks4{e-,98,88,}
-...\marks4{e+,98,88,}
-...\marks4{b-,99,88,text,,,}
-...\marks4{b+,99,88,text,,,}
-...\marks4{e-,99,88,}
-...\marks4{e+,99,88,}
-...\marks4{b-,100,88,text,,,}
-...\marks4{b+,100,88,text,,,}
-...\marks4{e-,100,88,}
-...\marks4{e+,100,88,}
+...\marks4{b-,96,78,text,,,}
+...\marks4{b+,96,78,text,,,}
+...\marks4{e-,96,78,}
+...\marks4{e+,96,78,}
+...\marks4{b-,97,79,Lbl,,,}
+...\marks4{b+,97,79,Lbl,,,}
+...\marks4{e-,97,79,}
+...\marks4{e+,97,79,}
+...\marks4{b-,98,78,text,,,}
+...\marks4{b+,98,78,text,,,}
+...\marks4{e-,98,78,}
+...\marks4{e+,98,78,}
+...\marks4{b-,99,78,text,,,}
+...\marks4{b+,99,78,text,,,}
+...\marks4{e-,99,78,}
+...\marks4{e+,99,78,}
+...\marks4{b-,100,78,text,,,}
+...\marks4{b+,100,78,text,,,}
+...\marks4{e-,100,78,}
+...\marks4{e+,100,78,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue 0.0 plus 1.0fil
@@ -1765,7 +1765,7 @@ Completed box being shipped out [4]
 .\kern 0.0
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 94) on line ...
+(tagpdf)                struct 84) on line ...
 Completed box being shipped out [5]
 \vbox(633.0+0.0)x407.0
 .\hbox(0.0+0.0)x0.0
@@ -1841,10 +1841,10 @@ Completed box being shipped out [5]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,104,91,text,,,}
-...\marks4{b+,104,91,text,,,}
-...\marks4{e-,104,91,}
-...\marks4{e+,104,91,}
+...\marks4{b-,104,81,text,,,}
+...\marks4{b+,104,81,text,,,}
+...\marks4{e-,104,81,}
+...\marks4{e+,104,81,}
 ...\penalty 0
 ...\penalty 10000
 ...\kern -1.94397
@@ -1878,15 +1878,15 @@ Completed box being shipped out [5]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,105,93,text,,,}
-.....\marks4{b+,105,93,text,,,}
-.....\marks4{e-,105,93,}
-.....\marks4{e+,105,93,}
+.....\marks4{b-,105,83,text,,,}
+.....\marks4{b+,105,83,text,,,}
+.....\marks4{e-,105,83,}
+.....\marks4{e+,105,83,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-106}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{106}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,106,94,Caption,,,}
-.....\marks4{b+,106,94,Caption,,,}
+.....\marks4{b-,106,84,Caption,,,}
+.....\marks4{b+,106,84,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {4}{\ignorespaces D}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 146.79794fil
@@ -1907,8 +1907,8 @@ Completed box being shipped out [5]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,106,94,}
-.....\marks4{e+,106,94,}
+.....\marks4{e-,106,84,}
+.....\marks4{e+,106,84,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -1931,7 +1931,7 @@ Completed box being shipped out [5]
 .\kern 0.0
 Package tagpdf Warning: Parent-Child 'Document/' --> 'Caption/pdf2'.
 (tagpdf)                Relation is not allowed (struct 2, /Document -->
-(tagpdf)                struct 99) on line ...
+(tagpdf)                struct 89) on line ...
 Completed box being shipped out [6]
 \vbox(633.0+0.0)x407.0
 .\hbox(0.0+0.0)x0.0
@@ -2005,10 +2005,10 @@ Completed box being shipped out [6]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,109,96,text,,,}
-...\marks4{b+,109,96,text,,,}
-...\marks4{e-,109,96,}
-...\marks4{e+,109,96,}
+...\marks4{b-,109,86,text,,,}
+...\marks4{b+,109,86,text,,,}
+...\marks4{e-,109,86,}
+...\marks4{e+,109,86,}
 ...\penalty 0
 ...\penalty 10000
 ...\glue 0.0
@@ -2045,15 +2045,15 @@ Completed box being shipped out [6]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,110,98,text,,,}
-.....\marks4{b+,110,98,text,,,}
-.....\marks4{e-,110,98,}
-.....\marks4{e+,110,98,}
+.....\marks4{b-,110,88,text,,,}
+.....\marks4{b+,110,88,text,,,}
+.....\marks4{e-,110,88,}
+.....\marks4{e+,110,88,}
 .....\rule(0.4+0.0)x*
 .....\write1{\new@label@record{mcid-111}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{111}{tagmcid}{\__property_code_tagmcid: }}}
 .....\pdfliteral shipout page{/Caption <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.....\marks4{b-,111,99,Caption,,,}
-.....\marks4{b+,111,99,Caption,,,}
+.....\marks4{b-,111,89,Caption,,,}
+.....\marks4{b+,111,89,Caption,,,}
 .....\write1{\@writefile{lof}{\protect \contentsline {figure}{\protect \numberline {5}{\ignorespaces E}}{\thepage }{}\protected@file@percent }}
 .....\glue 10.0
 .....\hbox(6.8872+1.94397)x345.0, glue set 147.21451fil
@@ -2074,8 +2074,8 @@ Completed box being shipped out [6]
 ......\glue 0.0 plus 1.0fil
 .....\glue 0.0
 .....\pdfliteral page{EMC}
-.....\marks4{e-,111,99,}
-.....\marks4{e+,111,99,}
+.....\marks4{e-,111,89,}
+.....\marks4{e+,111,89,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -2155,10 +2155,10 @@ Completed box being shipped out [7]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,114,101,text,,,}
-...\marks4{b+,114,101,text,,,}
-...\marks4{e-,114,101,}
-...\marks4{e+,114,101,}
+...\marks4{b-,114,91,text,,,}
+...\marks4{b+,114,91,text,,,}
+...\marks4{e-,114,91,}
+...\marks4{e+,114,91,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.16882
@@ -2188,10 +2188,10 @@ Completed box being shipped out [7]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,115,103,text,,,}
-...\marks4{b+,115,103,text,,,}
-...\marks4{e-,115,103,}
-...\marks4{e+,115,103,}
+...\marks4{b-,115,93,text,,,}
+...\marks4{b+,115,93,text,,,}
+...\marks4{e-,115,93,}
+...\marks4{e+,115,93,}
 ...\kern -1.94397
 ...\hbox(0.0+1.94397)x0.0
 ...\glue -1.94397
@@ -2267,10 +2267,10 @@ Completed box being shipped out [8]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,118,105,text,,,}
-...\marks4{b+,118,105,text,,,}
-...\marks4{e-,118,105,}
-...\marks4{e+,118,105,}
+...\marks4{b-,118,95,text,,,}
+...\marks4{b+,118,95,text,,,}
+...\marks4{e-,118,95,}
+...\marks4{e+,118,95,}
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 3.16882
@@ -2300,10 +2300,10 @@ Completed box being shipped out [8]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,119,107,text,,,}
-...\marks4{b+,119,107,text,,,}
-...\marks4{e-,119,107,}
-...\marks4{e+,119,107,}
+...\marks4{b-,119,97,text,,,}
+...\marks4{b+,119,97,text,,,}
+...\marks4{e-,119,97,}
+...\marks4{e+,119,97,}
 ...\glue -1.94397
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0 plus -1.0fil

--- a/required/latex-lab/testfiles-OR/footnote-float-above.tlg
+++ b/required/latex-lab/testfiles-OR/footnote-float-above.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -63,7 +63,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
@@ -218,26 +218,26 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,4,9,text,,,}
-...\marks4{b+,4,9,text,,,}
-...\marks4{e-,4,9,}
-...\marks4{e+,4,9,}
-...\marks4{b-,5,10,Lbl,,,}
-...\marks4{b+,5,10,Lbl,,,}
-...\marks4{e-,5,10,}
-...\marks4{e+,5,10,}
-...\marks4{b-,6,9,text,,,}
-...\marks4{b+,6,9,text,,,}
-...\marks4{e-,6,9,}
-...\marks4{e+,6,9,}
-...\marks4{b-,7,9,text,,,}
-...\marks4{b+,7,9,text,,,}
-...\marks4{e-,7,9,}
-...\marks4{e+,7,9,}
-...\marks4{b-,8,9,text,,,}
-...\marks4{b+,8,9,text,,,}
-...\marks4{e-,8,9,}
-...\marks4{e+,8,9,}
+...\marks4{b-,4,8,text,,,}
+...\marks4{b+,4,8,text,,,}
+...\marks4{e-,4,8,}
+...\marks4{e+,4,8,}
+...\marks4{b-,5,9,Lbl,,,}
+...\marks4{b+,5,9,Lbl,,,}
+...\marks4{e-,5,9,}
+...\marks4{e+,5,9,}
+...\marks4{b-,6,8,text,,,}
+...\marks4{b+,6,8,text,,,}
+...\marks4{e-,6,8,}
+...\marks4{e+,6,8,}
+...\marks4{b-,7,8,text,,,}
+...\marks4{b+,7,8,text,,,}
+...\marks4{e-,7,8,}
+...\marks4{e+,7,8,}
+...\marks4{b-,8,8,text,,,}
+...\marks4{b+,8,8,text,,,}
+...\marks4{e-,8,8,}
+...\marks4{e+,8,8,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue 20.0 plus 2.0 minus 4.0
@@ -256,10 +256,10 @@ Completed box being shipped out [1]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,10,12,text,,,}
-.....\marks4{b+,10,12,text,,,}
-.....\marks4{e-,10,12,}
-.....\marks4{e+,10,12,}
+.....\marks4{b-,10,11,text,,,}
+.....\marks4{b+,10,11,text,,,}
+.....\marks4{e-,10,11,}
+.....\marks4{e+,10,11,}
 .....\glue 0.0
 ...\glue 12.0 plus 2.0 minus 2.0
 ...\glue -12.0 plus -2.0 minus -2.0
@@ -321,10 +321,10 @@ Completed box being shipped out [2]
 ....\penalty 10000
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
-...\marks4{b-,13,14,text,,,}
-...\marks4{b+,13,14,text,,,}
-...\marks4{e-,13,14,}
-...\marks4{e+,13,14,}
+...\marks4{b-,13,13,text,,,}
+...\marks4{b+,13,13,text,,,}
+...\marks4{e-,13,13,}
+...\marks4{e+,13,13,}
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0 plus -1.0fil
 ...\kern 0.0
@@ -352,7 +352,7 @@ Completed box being shipped out [2]
 .\kern 633.0
 (footnote-float-above.aux)
 Package tagpdf Info: Finalizing the tagging structure:
-(tagpdf)             Writing out ~14 structure objects
+(tagpdf)             Writing out ~13 structure objects
 (tagpdf)             with ~15 'MC' leaf nodes.
 (tagpdf)             Be patient if there are lots of objects!
 Package tagpdf Info: writing ParentTree

--- a/required/latex-lab/testfiles-OR/footnote-heading.tlg
+++ b/required/latex-lab/testfiles-OR/footnote-heading.tlg
@@ -13,7 +13,7 @@ LaTeX Font Info:    External font `cmex10' loaded for size
 [1
 ] (footnote-heading.aux)
 Package tagpdf Info: Finalizing the tagging structure:
-(tagpdf)             Writing out ~13 structure objects
+(tagpdf)             Writing out ~12 structure objects
 (tagpdf)             with ~12 'MC' leaf nodes.
 (tagpdf)             Be patient if there are lots of objects!
 Package tagpdf Info: writing ParentTree

--- a/required/latex-lab/testfiles-OR/footnote-hyperref-001.tlg
+++ b/required/latex-lab/testfiles-OR/footnote-hyperref-001.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -63,7 +63,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext

--- a/required/latex-lab/testfiles-OR/footnote-par.tlg
+++ b/required/latex-lab/testfiles-OR/footnote-par.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -63,7 +63,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext

--- a/required/latex-lab/testfiles-OR/memoir-001.tpf
+++ b/required/latex-lab/testfiles-OR/memoir-001.tpf
@@ -1,6 +1,6 @@
 %PDF-1.5
 %ÐÔÅØ
-55 0 obj
+45 0 obj
 <<
 /Type /Metadata /Subtype /XML
 /Length 11690     
@@ -237,7 +237,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-57 0 obj
+47 0 obj
 <<
 /Length 23118     
 >>
@@ -470,47 +470,47 @@ endobj
 12 0 obj
 <<
 /Type /Page
-/Contents 57 0 R
-/Resources 56 0 R
+/Contents 47 0 R
+/Resources 46 0 R
 /MediaBox [0 0 612 792]
 /Tabs /S /StructParents 0 
-/Parent 64 0 R
+/Parent 54 0 R
 >>
 endobj
-56 0 obj
+46 0 obj
 <<
 /ExtGState 1 0 R 
-/Font << /F39 58 0 R /F54 59 0 R /F51 60 0 R /F53 61 0 R /F52 62 0 R /F40 63 0 R >>
+/Font << /F39 48 0 R /F54 49 0 R /F51 50 0 R /F53 51 0 R /F52 52 0 R /F40 53 0 R >>
 /ProcSet [ /PDF /Text ]
 >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-65 0 obj
+55 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 11 0 R 13 0 R 11 0 R 11 0 R 17 0 R 11 0 R 11 0 R 21 0 R 11 0 R 11 0 R 25 0 R 11 0 R 11 0 R 29 0 R 11 0 R 11 0 R 33 0 R 11 0 R 11 0 R 37 0 R 11 0 R 11 0 R 41 0 R 11 0 R 11 0 R 11 0 R 46 0 R 47 0 R 46 0 R 46 0 R 51 0 R 46 0 R 46 0 R 16 0 R 14 0 R 20 0 R 18 0 R 24 0 R 22 0 R 28 0 R 26 0 R 32 0 R 30 0 R 36 0 R 34 0 R 40 0 R 38 0 R 44 0 R 42 0 R 50 0 R 48 0 R 54 0 R 52 0 R ]
+<< /Nums [0 [ 11 0 R 13 0 R 11 0 R 11 0 R 16 0 R 11 0 R 11 0 R 19 0 R 11 0 R 11 0 R 22 0 R 11 0 R 11 0 R 25 0 R 11 0 R 11 0 R 28 0 R 11 0 R 11 0 R 31 0 R 11 0 R 11 0 R 34 0 R 11 0 R 11 0 R 11 0 R 38 0 R 39 0 R 38 0 R 38 0 R 42 0 R 38 0 R 38 0 R 15 0 R 14 0 R 18 0 R 17 0 R 21 0 R 20 0 R 24 0 R 23 0 R 27 0 R 26 0 R 30 0 R 29 0 R 33 0 R 32 0 R 36 0 R 35 0 R 41 0 R 40 0 R 44 0 R 43 0 R ]
 ] >>
 endobj
-66 0 obj
-<< /Limits [(ID.002) (ID.046)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 13 0 R (ID.006) 14 0 R (ID.007) 15 0 R (ID.008) 16 0 R (ID.009) 17 0 R (ID.010) 18 0 R (ID.011) 19 0 R (ID.012) 20 0 R (ID.013) 21 0 R (ID.014) 22 0 R (ID.015) 23 0 R (ID.016) 24 0 R (ID.017) 25 0 R (ID.018) 26 0 R (ID.019) 27 0 R (ID.020) 28 0 R (ID.021) 29 0 R (ID.022) 30 0 R (ID.023) 31 0 R (ID.024) 32 0 R (ID.025) 33 0 R (ID.026) 34 0 R (ID.027) 35 0 R (ID.028) 36 0 R (ID.029) 37 0 R (ID.030) 38 0 R (ID.031) 39 0 R (ID.032) 40 0 R (ID.033) 41 0 R (ID.034) 42 0 R (ID.035) 43 0 R (ID.036) 44 0 R (ID.037) 45 0 R (ID.038) 46 0 R (ID.039) 47 0 R (ID.040) 48 0 R (ID.041) 49 0 R (ID.042) 50 0 R (ID.043) 51 0 R (ID.044) 52 0 R (ID.045) 53 0 R (ID.046) 54 0 R ] >>
+56 0 obj
+<< /Limits [(ID.002) (ID.036)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 13 0 R (ID.006) 14 0 R (ID.007) 15 0 R (ID.008) 16 0 R (ID.009) 17 0 R (ID.010) 18 0 R (ID.011) 19 0 R (ID.012) 20 0 R (ID.013) 21 0 R (ID.014) 22 0 R (ID.015) 23 0 R (ID.016) 24 0 R (ID.017) 25 0 R (ID.018) 26 0 R (ID.019) 27 0 R (ID.020) 28 0 R (ID.021) 29 0 R (ID.022) 30 0 R (ID.023) 31 0 R (ID.024) 32 0 R (ID.025) 33 0 R (ID.026) 34 0 R (ID.027) 35 0 R (ID.028) 36 0 R (ID.029) 37 0 R (ID.030) 38 0 R (ID.031) 39 0 R (ID.032) 40 0 R (ID.033) 41 0 R (ID.034) 42 0 R (ID.035) 43 0 R (ID.036) 44 0 R ] >>
 endobj
-67 0 obj
-<< /Kids [66 0 R] >>
+57 0 obj
+<< /Kids [56 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H2 /subsection /H3 /subsubsection /H4 /paragraph /H5 /subparagraph /H6 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect /chapter /H1  >>
 endobj
 9 0 obj
-<<  /Type /StructElem /S /Document /P 5 0 R /K [10 0 R 45 0 R] /ID (ID.002) >>
+<<  /Type /StructElem /S /Document /P 5 0 R /K [10 0 R 37 0 R] /ID (ID.002) >>
 endobj
 10 0 obj
 <<  /Type /StructElem /S /text-unit /P 9 0 R /K 11 0 R /ID (ID.003) >>
 endobj
 11 0 obj
-<<  /Type /StructElem /S /text /P 10 0 R /K [<</Type /MCR /Pg 12 0 R/MCID 0>> 13 0 R <</Type /MCR /Pg 12 0 R/MCID 2>> 14 0 R <</Type /MCR /Pg 12 0 R/MCID 3>> 17 0 R <</Type /MCR /Pg 12 0 R/MCID 5>> 18 0 R <</Type /MCR /Pg 12 0 R/MCID 6>> 21 0 R <</Type /MCR /Pg 12 0 R/MCID 8>> 22 0 R <</Type /MCR /Pg 12 0 R/MCID 9>> 25 0 R <</Type /MCR /Pg 12 0 R/MCID 11>> 26 0 R <</Type /MCR /Pg 12 0 R/MCID 12>> 29 0 R <</Type /MCR /Pg 12 0 R/MCID 14>> 30 0 R <</Type /MCR /Pg 12 0 R/MCID 15>> 33 0 R <</Type /MCR /Pg 12 0 R/MCID 17>> 34 0 R <</Type /MCR /Pg 12 0 R/MCID 18>> 37 0 R <</Type /MCR /Pg 12 0 R/MCID 20>> 38 0 R <</Type /MCR /Pg 12 0 R/MCID 21>> 41 0 R <</Type /MCR /Pg 12 0 R/MCID 23>> 42 0 R <</Type /MCR /Pg 12 0 R/MCID 24>> <</Type /MCR /Pg 12 0 R/MCID 25>>] /ID (ID.004) >>
+<<  /Type /StructElem /S /text /P 10 0 R /K [<</Type /MCR /Pg 12 0 R/MCID 0>> 13 0 R <</Type /MCR /Pg 12 0 R/MCID 2>> 14 0 R <</Type /MCR /Pg 12 0 R/MCID 3>> 16 0 R <</Type /MCR /Pg 12 0 R/MCID 5>> 17 0 R <</Type /MCR /Pg 12 0 R/MCID 6>> 19 0 R <</Type /MCR /Pg 12 0 R/MCID 8>> 20 0 R <</Type /MCR /Pg 12 0 R/MCID 9>> 22 0 R <</Type /MCR /Pg 12 0 R/MCID 11>> 23 0 R <</Type /MCR /Pg 12 0 R/MCID 12>> 25 0 R <</Type /MCR /Pg 12 0 R/MCID 14>> 26 0 R <</Type /MCR /Pg 12 0 R/MCID 15>> 28 0 R <</Type /MCR /Pg 12 0 R/MCID 17>> 29 0 R <</Type /MCR /Pg 12 0 R/MCID 18>> 31 0 R <</Type /MCR /Pg 12 0 R/MCID 20>> 32 0 R <</Type /MCR /Pg 12 0 R/MCID 21>> 34 0 R <</Type /MCR /Pg 12 0 R/MCID 23>> 35 0 R <</Type /MCR /Pg 12 0 R/MCID 24>> <</Type /MCR /Pg 12 0 R/MCID 25>>] /ID (ID.004) >>
 endobj
 13 0 obj
 <<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 14 0 R ] /K <</Type /MCR /Pg 12 0 R/MCID 1>> /ID (ID.005) >>
@@ -519,147 +519,117 @@ endobj
 <<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 13 0 R ] /K [15 0 R <</Type /MCR /Pg 12 0 R/MCID 34>>] /ID (ID.006) >>
 endobj
 15 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 14 0 R /K 16 0 R /ID (ID.007) >>
+<<  /Type /StructElem /S /footnotelabel /P 14 0 R /K <</Type /MCR /Pg 12 0 R/MCID 33>> /ID (ID.007) >>
 endobj
 16 0 obj
-<<  /Type /StructElem /S /NonStruct /P 15 0 R /K <</Type /MCR /Pg 12 0 R/MCID 33>> /ID (ID.008) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 17 0 R ] /K <</Type /MCR /Pg 12 0 R/MCID 4>> /ID (ID.008) >>
 endobj
 17 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 18 0 R ] /K <</Type /MCR /Pg 12 0 R/MCID 4>> /ID (ID.009) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 16 0 R ] /K [18 0 R <</Type /MCR /Pg 12 0 R/MCID 36>>] /ID (ID.009) >>
 endobj
 18 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 17 0 R ] /K [19 0 R <</Type /MCR /Pg 12 0 R/MCID 36>>] /ID (ID.010) >>
+<<  /Type /StructElem /S /footnotelabel /P 17 0 R /K <</Type /MCR /Pg 12 0 R/MCID 35>> /ID (ID.010) >>
 endobj
 19 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 18 0 R /K 20 0 R /ID (ID.011) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 20 0 R ] /K <</Type /MCR /Pg 12 0 R/MCID 7>> /ID (ID.011) >>
 endobj
 20 0 obj
-<<  /Type /StructElem /S /NonStruct /P 19 0 R /K <</Type /MCR /Pg 12 0 R/MCID 35>> /ID (ID.012) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 19 0 R ] /K [21 0 R <</Type /MCR /Pg 12 0 R/MCID 38>>] /ID (ID.012) >>
 endobj
 21 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 22 0 R ] /K <</Type /MCR /Pg 12 0 R/MCID 7>> /ID (ID.013) >>
+<<  /Type /StructElem /S /footnotelabel /P 20 0 R /K <</Type /MCR /Pg 12 0 R/MCID 37>> /ID (ID.013) >>
 endobj
 22 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 21 0 R ] /K [23 0 R <</Type /MCR /Pg 12 0 R/MCID 38>>] /ID (ID.014) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 23 0 R ] /K <</Type /MCR /Pg 12 0 R/MCID 10>> /ID (ID.014) >>
 endobj
 23 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 22 0 R /K 24 0 R /ID (ID.015) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 22 0 R ] /K [24 0 R <</Type /MCR /Pg 12 0 R/MCID 40>>] /ID (ID.015) >>
 endobj
 24 0 obj
-<<  /Type /StructElem /S /NonStruct /P 23 0 R /K <</Type /MCR /Pg 12 0 R/MCID 37>> /ID (ID.016) >>
+<<  /Type /StructElem /S /footnotelabel /P 23 0 R /K <</Type /MCR /Pg 12 0 R/MCID 39>> /ID (ID.016) >>
 endobj
 25 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 12 0 R/MCID 10>> /ID (ID.017) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 26 0 R ] /K <</Type /MCR /Pg 12 0 R/MCID 13>> /ID (ID.017) >>
 endobj
 26 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 25 0 R ] /K [27 0 R <</Type /MCR /Pg 12 0 R/MCID 40>>] /ID (ID.018) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 25 0 R ] /K [27 0 R <</Type /MCR /Pg 12 0 R/MCID 42>>] /ID (ID.018) >>
 endobj
 27 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 26 0 R /K 28 0 R /ID (ID.019) >>
+<<  /Type /StructElem /S /footnotelabel /P 26 0 R /K <</Type /MCR /Pg 12 0 R/MCID 41>> /ID (ID.019) >>
 endobj
 28 0 obj
-<<  /Type /StructElem /S /NonStruct /P 27 0 R /K <</Type /MCR /Pg 12 0 R/MCID 39>> /ID (ID.020) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 29 0 R ] /K <</Type /MCR /Pg 12 0 R/MCID 16>> /ID (ID.020) >>
 endobj
 29 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 30 0 R ] /K <</Type /MCR /Pg 12 0 R/MCID 13>> /ID (ID.021) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 28 0 R ] /K [30 0 R <</Type /MCR /Pg 12 0 R/MCID 44>>] /ID (ID.021) >>
 endobj
 30 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 29 0 R ] /K [31 0 R <</Type /MCR /Pg 12 0 R/MCID 42>>] /ID (ID.022) >>
+<<  /Type /StructElem /S /footnotelabel /P 29 0 R /K <</Type /MCR /Pg 12 0 R/MCID 43>> /ID (ID.022) >>
 endobj
 31 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 30 0 R /K 32 0 R /ID (ID.023) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 32 0 R ] /K <</Type /MCR /Pg 12 0 R/MCID 19>> /ID (ID.023) >>
 endobj
 32 0 obj
-<<  /Type /StructElem /S /NonStruct /P 31 0 R /K <</Type /MCR /Pg 12 0 R/MCID 41>> /ID (ID.024) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 31 0 R ] /K [33 0 R <</Type /MCR /Pg 12 0 R/MCID 46>>] /ID (ID.024) >>
 endobj
 33 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 34 0 R ] /K <</Type /MCR /Pg 12 0 R/MCID 16>> /ID (ID.025) >>
+<<  /Type /StructElem /S /footnotelabel /P 32 0 R /K <</Type /MCR /Pg 12 0 R/MCID 45>> /ID (ID.025) >>
 endobj
 34 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 33 0 R ] /K [35 0 R <</Type /MCR /Pg 12 0 R/MCID 44>>] /ID (ID.026) >>
+<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 35 0 R ] /K <</Type /MCR /Pg 12 0 R/MCID 22>> /ID (ID.026) >>
 endobj
 35 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 34 0 R /K 36 0 R /ID (ID.027) >>
+<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 34 0 R ] /K [36 0 R <</Type /MCR /Pg 12 0 R/MCID 48>>] /ID (ID.027) >>
 endobj
 36 0 obj
-<<  /Type /StructElem /S /NonStruct /P 35 0 R /K <</Type /MCR /Pg 12 0 R/MCID 43>> /ID (ID.028) >>
+<<  /Type /StructElem /S /footnotelabel /P 35 0 R /K <</Type /MCR /Pg 12 0 R/MCID 47>> /ID (ID.028) >>
 endobj
 37 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 38 0 R ] /K <</Type /MCR /Pg 12 0 R/MCID 19>> /ID (ID.029) >>
+<<  /Type /StructElem /S /text-unit /P 9 0 R /K 38 0 R /ID (ID.029) >>
 endobj
 38 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 37 0 R ] /K [39 0 R <</Type /MCR /Pg 12 0 R/MCID 46>>] /ID (ID.030) >>
+<<  /Type /StructElem /S /text /P 37 0 R /K [<</Type /MCR /Pg 12 0 R/MCID 26>> 39 0 R <</Type /MCR /Pg 12 0 R/MCID 28>> 40 0 R <</Type /MCR /Pg 12 0 R/MCID 29>> 42 0 R <</Type /MCR /Pg 12 0 R/MCID 31>> 43 0 R <</Type /MCR /Pg 12 0 R/MCID 32>>] /ID (ID.030) >>
 endobj
 39 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 38 0 R /K 40 0 R /ID (ID.031) >>
+<<  /Type /StructElem /S /footnotemark /P 38 0 R /Ref [ 40 0 R ] /K <</Type /MCR /Pg 12 0 R/MCID 27>> /ID (ID.031) >>
 endobj
 40 0 obj
-<<  /Type /StructElem /S /NonStruct /P 39 0 R /K <</Type /MCR /Pg 12 0 R/MCID 45>> /ID (ID.032) >>
+<<  /Type /StructElem /S /footnote /P 38 0 R /Ref [ 39 0 R ] /K [41 0 R <</Type /MCR /Pg 12 0 R/MCID 50>>] /ID (ID.032) >>
 endobj
 41 0 obj
-<<  /Type /StructElem /S /footnotemark /P 11 0 R /Ref [ 42 0 R ] /K <</Type /MCR /Pg 12 0 R/MCID 22>> /ID (ID.033) >>
+<<  /Type /StructElem /S /footnotelabel /P 40 0 R /K <</Type /MCR /Pg 12 0 R/MCID 49>> /ID (ID.033) >>
 endobj
 42 0 obj
-<<  /Type /StructElem /S /footnote /P 11 0 R /Ref [ 41 0 R ] /K [43 0 R <</Type /MCR /Pg 12 0 R/MCID 48>>] /ID (ID.034) >>
+<<  /Type /StructElem /S /footnotemark /P 38 0 R /Ref [ 43 0 R ] /K <</Type /MCR /Pg 12 0 R/MCID 30>> /ID (ID.034) >>
 endobj
 43 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 42 0 R /K 44 0 R /ID (ID.035) >>
+<<  /Type /StructElem /S /footnote /P 38 0 R /Ref [ 42 0 R ] /K [44 0 R <</Type /MCR /Pg 12 0 R/MCID 52>>] /ID (ID.035) >>
 endobj
 44 0 obj
-<<  /Type /StructElem /S /NonStruct /P 43 0 R /K <</Type /MCR /Pg 12 0 R/MCID 47>> /ID (ID.036) >>
-endobj
-45 0 obj
-<<  /Type /StructElem /S /text-unit /P 9 0 R /K 46 0 R /ID (ID.037) >>
-endobj
-46 0 obj
-<<  /Type /StructElem /S /text /P 45 0 R /K [<</Type /MCR /Pg 12 0 R/MCID 26>> 47 0 R <</Type /MCR /Pg 12 0 R/MCID 28>> 48 0 R <</Type /MCR /Pg 12 0 R/MCID 29>> 51 0 R <</Type /MCR /Pg 12 0 R/MCID 31>> 52 0 R <</Type /MCR /Pg 12 0 R/MCID 32>>] /ID (ID.038) >>
-endobj
-47 0 obj
-<<  /Type /StructElem /S /footnotemark /P 46 0 R /Ref [ 48 0 R ] /K <</Type /MCR /Pg 12 0 R/MCID 27>> /ID (ID.039) >>
-endobj
-48 0 obj
-<<  /Type /StructElem /S /footnote /P 46 0 R /Ref [ 47 0 R ] /K [49 0 R <</Type /MCR /Pg 12 0 R/MCID 50>>] /ID (ID.040) >>
-endobj
-49 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 48 0 R /K 50 0 R /ID (ID.041) >>
-endobj
-50 0 obj
-<<  /Type /StructElem /S /NonStruct /P 49 0 R /K <</Type /MCR /Pg 12 0 R/MCID 49>> /ID (ID.042) >>
-endobj
-51 0 obj
-<<  /Type /StructElem /S /footnotemark /P 46 0 R /Ref [ 52 0 R ] /K <</Type /MCR /Pg 12 0 R/MCID 30>> /ID (ID.043) >>
-endobj
-52 0 obj
-<<  /Type /StructElem /S /footnote /P 46 0 R /Ref [ 51 0 R ] /K [53 0 R <</Type /MCR /Pg 12 0 R/MCID 52>>] /ID (ID.044) >>
-endobj
-53 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 52 0 R /K 54 0 R /ID (ID.045) >>
-endobj
-54 0 obj
-<<  /Type /StructElem /S /NonStruct /P 53 0 R /K <</Type /MCR /Pg 12 0 R/MCID 51>> /ID (ID.046) >>
+<<  /Type /StructElem /S /footnotelabel /P 43 0 R /K <</Type /MCR /Pg 12 0 R/MCID 51>> /ID (ID.036) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 67 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
+<<  /Type /StructTreeRoot /IDTree 57 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
 endobj
-69 0 obj
+59 0 obj
 [555.4 444.3 555.4 444.3 305.5 499.9 555.4 277.7 305.5 527.7 277.7 833.1 555.4 499.9 555.4 527.7 391.6 394.3 388.8 555.4 527.7 722 527.7]
 endobj
-70 0 obj
+60 0 obj
 [569.3 569.3 569.3 569.3 569.3 569.3 569.3 569.3 569.3 569.3]
 endobj
-71 0 obj
+61 0 obj
 [351.8]
 endobj
-72 0 obj
+62 0 obj
 [531.1 531.1 531.1 531.1 531.1 531.1 531.1 531.1 531.1 531.1]
 endobj
-73 0 obj
+63 0 obj
 [333]
 endobj
-74 0 obj
+64 0 obj
 [271.9 326.3 271.9 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 271.9 271.9 761.4 761.4 761.4 462.3 761.4 733.8 693.2 707 747.6 666 638.8 768.1 733.8 353.2 502.9 761 611.7 897 733.8 761.4 666 761.4 720.4 543.8 707 733.8 733.8 1005.8 733.8 733.8 598.2 271.9 489.5 271.9 598.2 761.4 271.9 489.5 543.8 435.1 543.8 435.1 299.1 489.5 543.8 271.9 299.1 516.7 271.9 815.8 543.8 489.5 543.8 516.7 380.7 386.1 380.7 543.8 516.7 707 516.7 516.7]
 endobj
-75 0 obj
+65 0 obj
 <<
 /Length1 1144
 /Length2 1422
@@ -668,7 +638,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-76 0 obj
+66 0 obj
 <<
 /Type /FontDescriptor
 /FontName /MUQHVU+PdfTeX-Space
@@ -681,10 +651,10 @@ endobj
 /StemV 0
 /XHeight 500
 /CharSet (/space)
-/FontFile 75 0 R
+/FontFile 65 0 R
 >>
 endobj
-77 0 obj
+67 0 obj
 <<
 /Length1 721
 /Length2 9483
@@ -693,7 +663,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-78 0 obj
+68 0 obj
 <<
 /Type /FontDescriptor
 /FontName /ZJJLVC+SFRM0600
@@ -706,10 +676,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/comma)
-/FontFile 77 0 R
+/FontFile 67 0 R
 >>
 endobj
-79 0 obj
+69 0 obj
 <<
 /Length1 721
 /Length2 14917
@@ -718,7 +688,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-80 0 obj
+70 0 obj
 <<
 /Type /FontDescriptor
 /FontName /HDSTHE+SFRM0700
@@ -731,10 +701,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/eight/five/four/nine/one/seven/six/three/two/zero)
-/FontFile 79 0 R
+/FontFile 69 0 R
 >>
 endobj
-81 0 obj
+71 0 obj
 <<
 /Length1 721
 /Length2 18057
@@ -743,7 +713,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-82 0 obj
+72 0 obj
 <<
 /Type /FontDescriptor
 /FontName /XXBBCR+SFRM0800
@@ -756,10 +726,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/eight/five/four/nine/one/seven/six/three/two/zero)
-/FontFile 81 0 R
+/FontFile 71 0 R
 >>
 endobj
-83 0 obj
+73 0 obj
 <<
 /Length1 721
 /Length2 9909
@@ -768,7 +738,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-84 0 obj
+74 0 obj
 <<
 /Type /FontDescriptor
 /FontName /IIWMFL+SFRM1000
@@ -781,10 +751,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/b/e/l/s/t/u/x)
-/FontFile 83 0 R
+/FontFile 73 0 R
 >>
 endobj
-85 0 obj
+75 0 obj
 <<
 /Length1 721
 /Length2 14593
@@ -793,7 +763,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-86 0 obj
+76 0 obj
 <<
 /Type /FontDescriptor
 /FontName /ZPLGSF+SFRM1200
@@ -806,16 +776,16 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/A/C/D/I/L/M/N/P/S/U/a/b/c/comma/d/e/f/g/h/hyphen/i/j/l/m/n/o/one/p/period/q/r/s/t/u/v/w/y)
-/FontFile 85 0 R
+/FontFile 75 0 R
 >>
 endobj
-68 0 obj
+58 0 obj
 <<
 /Type /Encoding
 /Differences [44/comma/hyphen/period 48/zero/one/two/three/four/five/six/seven/eight/nine 65/A 67/C/D 73/I 76/L/M/N 80/P 83/S 85/U 97/a/b/c/d/e/f/g/h/i/j 108/l/m/n/o/p/q/r/s/t/u/v/w/x/y]
 >>
 endobj
-87 0 obj
+77 0 obj
 <<
 /Length 2030      
 >>
@@ -959,20 +929,20 @@ end
 %%EOF
 endstream
 endobj
-61 0 obj
+51 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /ZJJLVC+SFRM0600
-/FontDescriptor 78 0 R
+/FontDescriptor 68 0 R
 /FirstChar 44
 /LastChar 44
-/Widths 71 0 R
-/Encoding 68 0 R
-/ToUnicode 87 0 R
+/Widths 61 0 R
+/Encoding 58 0 R
+/ToUnicode 77 0 R
 >>
 endobj
-88 0 obj
+78 0 obj
 <<
 /Length 2030      
 >>
@@ -1116,20 +1086,20 @@ end
 %%EOF
 endstream
 endobj
-62 0 obj
+52 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /HDSTHE+SFRM0700
-/FontDescriptor 80 0 R
+/FontDescriptor 70 0 R
 /FirstChar 48
 /LastChar 57
-/Widths 70 0 R
-/Encoding 68 0 R
-/ToUnicode 88 0 R
+/Widths 60 0 R
+/Encoding 58 0 R
+/ToUnicode 78 0 R
 >>
 endobj
-89 0 obj
+79 0 obj
 <<
 /Length 2030      
 >>
@@ -1273,20 +1243,20 @@ end
 %%EOF
 endstream
 endobj
-60 0 obj
+50 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /XXBBCR+SFRM0800
-/FontDescriptor 82 0 R
+/FontDescriptor 72 0 R
 /FirstChar 48
 /LastChar 57
-/Widths 72 0 R
-/Encoding 68 0 R
-/ToUnicode 89 0 R
+/Widths 62 0 R
+/Encoding 58 0 R
+/ToUnicode 79 0 R
 >>
 endobj
-90 0 obj
+80 0 obj
 <<
 /Length 2030      
 >>
@@ -1430,20 +1400,20 @@ end
 %%EOF
 endstream
 endobj
-63 0 obj
+53 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /IIWMFL+SFRM1000
-/FontDescriptor 84 0 R
+/FontDescriptor 74 0 R
 /FirstChar 98
 /LastChar 120
-/Widths 69 0 R
-/Encoding 68 0 R
-/ToUnicode 90 0 R
+/Widths 59 0 R
+/Encoding 58 0 R
+/ToUnicode 80 0 R
 >>
 endobj
-91 0 obj
+81 0 obj
 <<
 /Length 2030      
 >>
@@ -1587,20 +1557,20 @@ end
 %%EOF
 endstream
 endobj
-58 0 obj
+48 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /ZPLGSF+SFRM1200
-/FontDescriptor 86 0 R
+/FontDescriptor 76 0 R
 /FirstChar 44
 /LastChar 121
-/Widths 74 0 R
-/Encoding 68 0 R
-/ToUnicode 91 0 R
+/Widths 64 0 R
+/Encoding 58 0 R
+/ToUnicode 81 0 R
 >>
 endobj
-92 0 obj
+82 0 obj
 <<
 /Length 654       
 >>
@@ -1638,140 +1608,130 @@ end
 %%EOF
 endstream
 endobj
-59 0 obj
+49 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /MUQHVU+PdfTeX-Space
-/FontDescriptor 76 0 R
+/FontDescriptor 66 0 R
 /FirstChar 32
 /LastChar 32
-/Widths 73 0 R
-/ToUnicode 92 0 R
+/Widths 63 0 R
+/ToUnicode 82 0 R
 >>
 endobj
-64 0 obj
+54 0 obj
 <<
 /Type /Pages
 /Count 1
 /Kids [12 0 R]
 >>
 endobj
-93 0 obj
+83 0 obj
 <<
 /Type /Catalog
-/Pages 64 0 R
-/MarkInfo 65 0 R/Lang (en)/Metadata 55 0 R/StructTreeRoot 5 0 R
+/Pages 54 0 R
+/MarkInfo 55 0 R/Lang (en)/Metadata 45 0 R/StructTreeRoot 5 0 R
 >>
 endobj
-94 0 obj
+84 0 obj
 <<
 /Producer (pdfTeX)/Creator (TeX)/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z)
 /Trapped /False
 >>
 endobj
 xref
-0 95
+0 85
 0000000002 65535 f 
 0000035254 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000043287 00000 n 
+0000042247 00000 n 
 0000035337 00000 n 
-0000036559 00000 n 
+0000036399 00000 n 
 0000000000 00000 f 
-0000037151 00000 n 
-0000037245 00000 n 
-0000037332 00000 n 
+0000036991 00000 n 
+0000037085 00000 n 
+0000037172 00000 n 
 0000034971 00000 n 
-0000038127 00000 n 
-0000038260 00000 n 
-0000038399 00000 n 
+0000037967 00000 n 
+0000038100 00000 n 
+0000038239 00000 n 
+0000038358 00000 n 
 0000038491 00000 n 
-0000038606 00000 n 
-0000038739 00000 n 
-0000038878 00000 n 
-0000038970 00000 n 
-0000039085 00000 n 
-0000039218 00000 n 
-0000039357 00000 n 
-0000039449 00000 n 
-0000039564 00000 n 
-0000039698 00000 n 
-0000039837 00000 n 
-0000039929 00000 n 
-0000040044 00000 n 
-0000040178 00000 n 
-0000040317 00000 n 
-0000040409 00000 n 
-0000040524 00000 n 
-0000040658 00000 n 
-0000040797 00000 n 
-0000040889 00000 n 
-0000041004 00000 n 
-0000041138 00000 n 
-0000041277 00000 n 
-0000041369 00000 n 
-0000041484 00000 n 
-0000041618 00000 n 
-0000041757 00000 n 
-0000041849 00000 n 
-0000041964 00000 n 
-0000042051 00000 n 
-0000042327 00000 n 
-0000042461 00000 n 
-0000042600 00000 n 
-0000042692 00000 n 
-0000042807 00000 n 
-0000042941 00000 n 
-0000043080 00000 n 
-0000043172 00000 n 
+0000038630 00000 n 
+0000038749 00000 n 
+0000038882 00000 n 
+0000039021 00000 n 
+0000039140 00000 n 
+0000039274 00000 n 
+0000039413 00000 n 
+0000039532 00000 n 
+0000039666 00000 n 
+0000039805 00000 n 
+0000039924 00000 n 
+0000040058 00000 n 
+0000040197 00000 n 
+0000040316 00000 n 
+0000040450 00000 n 
+0000040589 00000 n 
+0000040708 00000 n 
+0000040842 00000 n 
+0000040981 00000 n 
+0000041100 00000 n 
+0000041187 00000 n 
+0000041463 00000 n 
+0000041597 00000 n 
+0000041736 00000 n 
+0000041855 00000 n 
+0000041989 00000 n 
+0000042128 00000 n 
 0000000015 00000 n 
 0000035106 00000 n 
 0000011794 00000 n 
-0000130835 00000 n 
-0000131726 00000 n 
-0000126302 00000 n 
-0000121770 00000 n 
-0000124036 00000 n 
-0000128568 00000 n 
-0000131890 00000 n 
+0000129795 00000 n 
+0000130686 00000 n 
+0000125262 00000 n 
+0000120730 00000 n 
+0000122996 00000 n 
+0000127528 00000 n 
+0000130850 00000 n 
 0000035301 00000 n 
 0000035744 00000 n 
-0000036522 00000 n 
-0000119456 00000 n 
-0000043388 00000 n 
-0000043542 00000 n 
-0000043620 00000 n 
-0000043644 00000 n 
-0000043722 00000 n 
-0000043744 00000 n 
-0000044217 00000 n 
-0000046881 00000 n 
-0000047099 00000 n 
-0000057400 00000 n 
-0000057625 00000 n 
-0000073361 00000 n 
-0000073630 00000 n 
-0000092506 00000 n 
-0000092775 00000 n 
-0000103502 00000 n 
-0000103735 00000 n 
-0000119147 00000 n 
-0000119681 00000 n 
-0000121947 00000 n 
-0000124213 00000 n 
-0000126479 00000 n 
-0000128746 00000 n 
-0000131013 00000 n 
-0000131949 00000 n 
-0000132064 00000 n 
+0000036362 00000 n 
+0000118416 00000 n 
+0000042348 00000 n 
+0000042502 00000 n 
+0000042580 00000 n 
+0000042604 00000 n 
+0000042682 00000 n 
+0000042704 00000 n 
+0000043177 00000 n 
+0000045841 00000 n 
+0000046059 00000 n 
+0000056360 00000 n 
+0000056585 00000 n 
+0000072321 00000 n 
+0000072590 00000 n 
+0000091466 00000 n 
+0000091735 00000 n 
+0000102462 00000 n 
+0000102695 00000 n 
+0000118107 00000 n 
+0000118641 00000 n 
+0000120907 00000 n 
+0000123173 00000 n 
+0000125439 00000 n 
+0000127706 00000 n 
+0000129973 00000 n 
+0000130909 00000 n 
+0000131024 00000 n 
 trailer
-<< /Size 95
-/Root 93 0 R
-/Info 94 0 R
+<< /Size 85
+/Root 83 0 R
+/Info 84 0 R
 /ID [<9BD18DF3359C1216B83ADB4AA401CC9A> <9BD18DF3359C1216B83ADB4AA401CC9A>] >>
 startxref
-132196
+131156
 %%EOF

--- a/required/latex-lab/testfiles-OR/scrartcl-001.tpf
+++ b/required/latex-lab/testfiles-OR/scrartcl-001.tpf
@@ -3,13 +3,13 @@
 16 0 obj
 << /Type/OBJR/Obj 15 0 R/Pg 9 0 R >>
 endobj
-25 0 obj
-<< /Type/OBJR/Obj 24 0 R/Pg 9 0 R >>
+24 0 obj
+<< /Type/OBJR/Obj 23 0 R/Pg 9 0 R >>
 endobj
-34 0 obj
-<< /Type/OBJR/Obj 33 0 R/Pg 9 0 R >>
+32 0 obj
+<< /Type/OBJR/Obj 31 0 R/Pg 9 0 R >>
 endobj
-40 0 obj
+37 0 obj
 <<
 /Type /Metadata /Subtype /XML
 /Length 11706     
@@ -246,7 +246,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-42 0 obj
+39 0 obj
 <<
 /Length 1662      
 >>
@@ -366,12 +366,12 @@ endobj
 9 0 obj
 <<
 /Type /Page
-/Contents 42 0 R
-/Resources 41 0 R
+/Contents 39 0 R
+/Resources 38 0 R
 /MediaBox [0 0 595.276 841.89]
 /Tabs /S /StructParents 0 
-/Parent 63 0 R
-/Annots [ 15 0 R 24 0 R 33 0 R ]
+/Parent 60 0 R
+/Annots [ 15 0 R 23 0 R 31 0 R ]
 >>
 endobj
 15 0 obj
@@ -380,116 +380,116 @@ endobj
 /Subtype /Link
 /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 1 
 /Rect [91.293 758.781 120.934 771.088]
-/A << /S /GoTo /D (footnote*.5) /SD 50 0 R >>
+/A << /S /GoTo /D (footnote*.5) /SD 47 0 R >>
 >>
 endobj
-24 0 obj
+23 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 2 
 /Rect [129.019 758.781 158.659 771.088]
-/A << /S /GoTo /D (footnote*.12) /SD 56 0 R >>
+/A << /S /GoTo /D (footnote*.11) /SD 53 0 R >>
 >>
 endobj
-33 0 obj
+31 0 obj
 <<
 /Type /Annot
 /Subtype /Link
 /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 3 
 /Rect [166.745 758.781 196.385 771.088]
-/A << /S /GoTo /D (footnote*.19) /SD 60 0 R >>
+/A << /S /GoTo /D (footnote*.17) /SD 57 0 R >>
 >>
 endobj
-43 0 obj
+40 0 obj
 <<
 /D [9 0 R /XYZ 73.409 812.458 null]
 >>
 endobj
-44 0 obj
+41 0 obj
 [10 0 R /XYZ 73.409 812.458 null]
 endobj
-45 0 obj
+42 0 obj
 <<
 /D [9 0 R /XYZ 74.409 771.732 null]
 >>
 endobj
-46 0 obj
+43 0 obj
 [10 0 R /XYZ 74.409 771.732 null]
 endobj
+46 0 obj
+<<
+/D [9 0 R /XYZ 134.171 724.838 null]
+>>
+endobj
+47 0 obj
+[19 0 R /XYZ 134.171 724.838 null]
+endobj
+48 0 obj
+<<
+/D [9 0 R /XYZ 134.171 724.838 null]
+>>
+endobj
 49 0 obj
-<<
-/D [9 0 R /XYZ 134.171 724.838 null]
->>
-endobj
-50 0 obj
-[20 0 R /XYZ 134.171 724.838 null]
-endobj
-51 0 obj
-<<
-/D [9 0 R /XYZ 134.171 724.838 null]
->>
+[19 0 R /XYZ 134.171 724.838 null]
 endobj
 52 0 obj
-[20 0 R /XYZ 134.171 724.838 null]
+<<
+/D [9 0 R /XYZ 134.171 712.407 null]
+>>
+endobj
+53 0 obj
+[27 0 R /XYZ 134.171 712.407 null]
+endobj
+54 0 obj
+<<
+/D [9 0 R /XYZ 134.171 712.407 null]
+>>
 endobj
 55 0 obj
-<<
-/D [9 0 R /XYZ 134.171 712.407 null]
->>
+[27 0 R /XYZ 134.171 712.407 null]
 endobj
 56 0 obj
-[29 0 R /XYZ 134.171 712.407 null]
+<<
+/D [9 0 R /XYZ 134.171 699.976 null]
+>>
 endobj
 57 0 obj
-<<
-/D [9 0 R /XYZ 134.171 712.407 null]
->>
+[35 0 R /XYZ 134.171 699.976 null]
 endobj
 58 0 obj
-[29 0 R /XYZ 134.171 712.407 null]
+<<
+/D [9 0 R /XYZ 134.171 699.976 null]
+>>
 endobj
 59 0 obj
-<<
-/D [9 0 R /XYZ 134.171 699.976 null]
->>
+[35 0 R /XYZ 134.171 699.976 null]
 endobj
-60 0 obj
-[38 0 R /XYZ 134.171 699.976 null]
-endobj
-61 0 obj
-<<
-/D [9 0 R /XYZ 134.171 699.976 null]
->>
-endobj
-62 0 obj
-[38 0 R /XYZ 134.171 699.976 null]
-endobj
-41 0 obj
+38 0 obj
 <<
 /ExtGState 1 0 R 
-/Font << /F39 47 0 R /F49 48 0 R /F51 53 0 R /F50 54 0 R >>
+/Font << /F39 44 0 R /F49 45 0 R /F51 50 0 R /F50 51 0 R >>
 /ProcSet [ /PDF /Text ]
 >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-64 0 obj
+61 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 12 0 R 13 0 R 14 0 R 13 0 R 12 0 R 12 0 R 22 0 R 23 0 R 22 0 R 12 0 R 12 0 R 31 0 R 32 0 R 31 0 R 12 0 R 12 0 R 20 0 R 21 0 R 20 0 R 20 0 R 20 0 R 29 0 R 30 0 R 29 0 R 29 0 R 29 0 R 38 0 R 39 0 R 38 0 R 38 0 R 38 0 R ]
+<< /Nums [0 [ 12 0 R 13 0 R 14 0 R 13 0 R 12 0 R 12 0 R 21 0 R 22 0 R 21 0 R 12 0 R 12 0 R 29 0 R 30 0 R 29 0 R 12 0 R 12 0 R 19 0 R 20 0 R 19 0 R 19 0 R 19 0 R 27 0 R 28 0 R 27 0 R 27 0 R 27 0 R 35 0 R 36 0 R 35 0 R 35 0 R 35 0 R ]
 1 14 0 R
-2 23 0 R
-3 32 0 R
+2 22 0 R
+3 30 0 R
 ] >>
 endobj
-65 0 obj
-<< /Limits [(ID.002) (ID.025)]/Names [(ID.002) 10 0 R (ID.003) 11 0 R (ID.004) 12 0 R (ID.005) 13 0 R (ID.006) 14 0 R (ID.007) 17 0 R (ID.008) 18 0 R (ID.009) 19 0 R (ID.010) 20 0 R (ID.011) 21 0 R (ID.012) 22 0 R (ID.013) 23 0 R (ID.014) 26 0 R (ID.015) 27 0 R (ID.016) 28 0 R (ID.017) 29 0 R (ID.018) 30 0 R (ID.019) 31 0 R (ID.020) 32 0 R (ID.021) 35 0 R (ID.022) 36 0 R (ID.023) 37 0 R (ID.024) 38 0 R (ID.025) 39 0 R ] >>
+62 0 obj
+<< /Limits [(ID.002) (ID.022)]/Names [(ID.002) 10 0 R (ID.003) 11 0 R (ID.004) 12 0 R (ID.005) 13 0 R (ID.006) 14 0 R (ID.007) 17 0 R (ID.008) 18 0 R (ID.009) 19 0 R (ID.010) 20 0 R (ID.011) 21 0 R (ID.012) 22 0 R (ID.013) 25 0 R (ID.014) 26 0 R (ID.015) 27 0 R (ID.016) 28 0 R (ID.017) 29 0 R (ID.018) 30 0 R (ID.019) 33 0 R (ID.020) 34 0 R (ID.021) 35 0 R (ID.022) 36 0 R ] >>
 endobj
-66 0 obj
-<< /Kids [65 0 R] >>
+63 0 obj
+<< /Kids [62 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
@@ -501,7 +501,7 @@ endobj
 <<  /Type /StructElem /S /text-unit /P 10 0 R /K 12 0 R /ID (ID.003) >>
 endobj
 12 0 obj
-<<  /Type /StructElem /S /text /P 11 0 R /K [<</Type /MCR /Pg 9 0 R/MCID 0>> 13 0 R <</Type /MCR /Pg 9 0 R/MCID 4>> 17 0 R <</Type /MCR /Pg 9 0 R/MCID 5>> 22 0 R <</Type /MCR /Pg 9 0 R/MCID 9>> 26 0 R <</Type /MCR /Pg 9 0 R/MCID 10>> 31 0 R <</Type /MCR /Pg 9 0 R/MCID 14>> 35 0 R <</Type /MCR /Pg 9 0 R/MCID 15>>] /ID (ID.004) >>
+<<  /Type /StructElem /S /text /P 11 0 R /K [<</Type /MCR /Pg 9 0 R/MCID 0>> 13 0 R <</Type /MCR /Pg 9 0 R/MCID 4>> 17 0 R <</Type /MCR /Pg 9 0 R/MCID 5>> 21 0 R <</Type /MCR /Pg 9 0 R/MCID 9>> 25 0 R <</Type /MCR /Pg 9 0 R/MCID 10>> 29 0 R <</Type /MCR /Pg 9 0 R/MCID 14>> 33 0 R <</Type /MCR /Pg 9 0 R/MCID 15>>] /ID (ID.004) >>
 endobj
 13 0 obj
 <<  /Type /StructElem /S /footnotemark /P 12 0 R /Ref [ 17 0 R ] /K [<</Type /MCR /Pg 9 0 R/MCID 1>> 14 0 R <</Type /MCR /Pg 9 0 R/MCID 3>>] /ID (ID.005) >>
@@ -510,78 +510,69 @@ endobj
 <<  /Type /StructElem /S /Link /P 13 0 R /K [<</Type /MCR /Pg 9 0 R/MCID 2>> 16 0 R] /ID (ID.006) >>
 endobj
 17 0 obj
-<<  /Type /StructElem /S /footnote /P 12 0 R /Ref [ 13 0 R ] /K [18 0 R 19 0 R] /ID (ID.007) >>
+<<  /Type /StructElem /S /footnote /P 12 0 R /Ref [ 13 0 R ] /K [20 0 R 18 0 R] /ID (ID.007) >>
 endobj
 18 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 17 0 R /K 21 0 R /ID (ID.008) >>
+<<  /Type /StructElem /S /text-unit /P 17 0 R /K 19 0 R /ID (ID.008) >>
 endobj
 19 0 obj
-<<  /Type /StructElem /S /text-unit /P 17 0 R /K 20 0 R /ID (ID.009) >>
+<<  /Type /StructElem /S /text /P 18 0 R /K [<</Type /MCR /Pg 9 0 R/MCID 16>> <</Type /MCR /Pg 9 0 R/MCID 18>> <</Type /MCR /Pg 9 0 R/MCID 19>> <</Type /MCR /Pg 9 0 R/MCID 20>>] /ID (ID.009) >>
 endobj
 20 0 obj
-<<  /Type /StructElem /S /text /P 19 0 R /K [<</Type /MCR /Pg 9 0 R/MCID 16>> <</Type /MCR /Pg 9 0 R/MCID 18>> <</Type /MCR /Pg 9 0 R/MCID 19>> <</Type /MCR /Pg 9 0 R/MCID 20>>] /ID (ID.010) >>
+<<  /Type /StructElem /S /footnotelabel /P 17 0 R /K <</Type /MCR /Pg 9 0 R/MCID 17>> /ID (ID.010) >>
 endobj
 21 0 obj
-<<  /Type /StructElem /S /NonStruct /P 18 0 R /K <</Type /MCR /Pg 9 0 R/MCID 17>> /ID (ID.011) >>
+<<  /Type /StructElem /S /footnotemark /P 12 0 R /Ref [ 25 0 R ] /K [<</Type /MCR /Pg 9 0 R/MCID 6>> 22 0 R <</Type /MCR /Pg 9 0 R/MCID 8>>] /ID (ID.011) >>
 endobj
 22 0 obj
-<<  /Type /StructElem /S /footnotemark /P 12 0 R /Ref [ 26 0 R ] /K [<</Type /MCR /Pg 9 0 R/MCID 6>> 23 0 R <</Type /MCR /Pg 9 0 R/MCID 8>>] /ID (ID.012) >>
+<<  /Type /StructElem /S /Link /P 21 0 R /K [<</Type /MCR /Pg 9 0 R/MCID 7>> 24 0 R] /ID (ID.012) >>
 endobj
-23 0 obj
-<<  /Type /StructElem /S /Link /P 22 0 R /K [<</Type /MCR /Pg 9 0 R/MCID 7>> 25 0 R] /ID (ID.013) >>
+25 0 obj
+<<  /Type /StructElem /S /footnote /P 12 0 R /Ref [ 21 0 R ] /K [28 0 R 26 0 R] /ID (ID.013) >>
 endobj
 26 0 obj
-<<  /Type /StructElem /S /footnote /P 12 0 R /Ref [ 22 0 R ] /K [27 0 R 28 0 R] /ID (ID.014) >>
+<<  /Type /StructElem /S /text-unit /P 25 0 R /K 27 0 R /ID (ID.014) >>
 endobj
 27 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 26 0 R /K 30 0 R /ID (ID.015) >>
+<<  /Type /StructElem /S /text /P 26 0 R /K [<</Type /MCR /Pg 9 0 R/MCID 21>> <</Type /MCR /Pg 9 0 R/MCID 23>> <</Type /MCR /Pg 9 0 R/MCID 24>> <</Type /MCR /Pg 9 0 R/MCID 25>>] /ID (ID.015) >>
 endobj
 28 0 obj
-<<  /Type /StructElem /S /text-unit /P 26 0 R /K 29 0 R /ID (ID.016) >>
+<<  /Type /StructElem /S /footnotelabel /P 25 0 R /K <</Type /MCR /Pg 9 0 R/MCID 22>> /ID (ID.016) >>
 endobj
 29 0 obj
-<<  /Type /StructElem /S /text /P 28 0 R /K [<</Type /MCR /Pg 9 0 R/MCID 21>> <</Type /MCR /Pg 9 0 R/MCID 23>> <</Type /MCR /Pg 9 0 R/MCID 24>> <</Type /MCR /Pg 9 0 R/MCID 25>>] /ID (ID.017) >>
+<<  /Type /StructElem /S /footnotemark /P 12 0 R /Ref [ 33 0 R ] /K [<</Type /MCR /Pg 9 0 R/MCID 11>> 30 0 R <</Type /MCR /Pg 9 0 R/MCID 13>>] /ID (ID.017) >>
 endobj
 30 0 obj
-<<  /Type /StructElem /S /NonStruct /P 27 0 R /K <</Type /MCR /Pg 9 0 R/MCID 22>> /ID (ID.018) >>
+<<  /Type /StructElem /S /Link /P 29 0 R /K [<</Type /MCR /Pg 9 0 R/MCID 12>> 32 0 R] /ID (ID.018) >>
 endobj
-31 0 obj
-<<  /Type /StructElem /S /footnotemark /P 12 0 R /Ref [ 35 0 R ] /K [<</Type /MCR /Pg 9 0 R/MCID 11>> 32 0 R <</Type /MCR /Pg 9 0 R/MCID 13>>] /ID (ID.019) >>
+33 0 obj
+<<  /Type /StructElem /S /footnote /P 12 0 R /Ref [ 29 0 R ] /K [36 0 R 34 0 R] /ID (ID.019) >>
 endobj
-32 0 obj
-<<  /Type /StructElem /S /Link /P 31 0 R /K [<</Type /MCR /Pg 9 0 R/MCID 12>> 34 0 R] /ID (ID.020) >>
+34 0 obj
+<<  /Type /StructElem /S /text-unit /P 33 0 R /K 35 0 R /ID (ID.020) >>
 endobj
 35 0 obj
-<<  /Type /StructElem /S /footnote /P 12 0 R /Ref [ 31 0 R ] /K [36 0 R 37 0 R] /ID (ID.021) >>
+<<  /Type /StructElem /S /text /P 34 0 R /K [<</Type /MCR /Pg 9 0 R/MCID 26>> <</Type /MCR /Pg 9 0 R/MCID 28>> <</Type /MCR /Pg 9 0 R/MCID 29>> <</Type /MCR /Pg 9 0 R/MCID 30>>] /ID (ID.021) >>
 endobj
 36 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 35 0 R /K 39 0 R /ID (ID.022) >>
-endobj
-37 0 obj
-<<  /Type /StructElem /S /text-unit /P 35 0 R /K 38 0 R /ID (ID.023) >>
-endobj
-38 0 obj
-<<  /Type /StructElem /S /text /P 37 0 R /K [<</Type /MCR /Pg 9 0 R/MCID 26>> <</Type /MCR /Pg 9 0 R/MCID 28>> <</Type /MCR /Pg 9 0 R/MCID 29>> <</Type /MCR /Pg 9 0 R/MCID 30>>] /ID (ID.024) >>
-endobj
-39 0 obj
-<<  /Type /StructElem /S /NonStruct /P 36 0 R /K <</Type /MCR /Pg 9 0 R/MCID 27>> /ID (ID.025) >>
+<<  /Type /StructElem /S /footnotelabel /P 33 0 R /K <</Type /MCR /Pg 9 0 R/MCID 27>> /ID (ID.022) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 66 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 10 0 R >>
+<<  /Type /StructTreeRoot /IDTree 63 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 10 0 R >>
 endobj
-68 0 obj
+65 0 obj
 [444.3 305.5 499.9 555.4 277.7 305.5 527.7 277.7 833.1 555.4 499.9 555.4 527.7 391.6 394.3 388.8]
 endobj
-69 0 obj
+66 0 obj
 [446.3 446.3 569.3 876.8 323.3 384.8 323.3 569.3 569.3 569.3 569.3 569.3 569.3 569.3 569.3 569.3 569.3 569.3 323.3 323.3 876.8 876.8 876.8 538.6 876.8 843.1 798.4 815.3 859.9 767.7 736.9 883.7 843.1 412.6 583.2 873.8 706.2 1027.5 843.1]
 endobj
-70 0 obj
+67 0 obj
 [413.1 413.1 531.1 826.2 295.1 354.1 295.1 531.1 531.1 531.1 531.1 531.1 531.1 531.1 531.1 531.1 531.1 531.1 295.1 295.1 826.2 826.2 826.2 501.6 826.2 795.6 751.9 767.2 810.9 722.4 692.9 833.3 795.6 382.5 545.4 825.1 663.4 972.7 795.6 826.2 722.4 826.2 781.4 590.1 767.2 795.6 795.6 1090.7 795.6 795.6 649.1 295.1 531.1 295.1 649.1 826.2 295.1 531.1 590.1 472.1 590.1 472.1 324.6 531.1 590.1 295.1 324.6 560.6 295.1 885.2 590.1 531.1 590.1 560.6 414 419 413.1 590.1 560.6 767.2 560.6 560.6]
 endobj
-71 0 obj
+68 0 obj
 [489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 271.9 271.9 761.4 761.4 761.4 462.3 761.4 733.8 693.2 707 747.6 666 638.8 768.1 733.8 353.2 502.9 761 611.7 897 733.8 761.4 666 761.4 720.4 543.8 707 733.8 733.8 1005.8 733.8 733.8 598.2 271.9 489.5 271.9 598.2 761.4 271.9 489.5 543.8 435.1 543.8 435.1 299.1 489.5 543.8 271.9 299.1 516.7 271.9 815.8 543.8 489.5 543.8 516.7 380.7 386.1 380.7 543.8 516.7 707 516.7]
 endobj
-72 0 obj
+69 0 obj
 <<
 /Length1 721
 /Length2 14106
@@ -590,7 +581,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-73 0 obj
+70 0 obj
 <<
 /Type /FontDescriptor
 /FontName /FFNBVP+SFRM0700
@@ -603,10 +594,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/F/N/one/parenleft/parenright/three/two)
-/FontFile 72 0 R
+/FontFile 69 0 R
 >>
 endobj
-74 0 obj
+71 0 obj
 <<
 /Length1 721
 /Length2 22350
@@ -615,7 +606,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-75 0 obj
+72 0 obj
 <<
 /Type /FontDescriptor
 /FontName /NQUESM+SFRM0800
@@ -628,10 +619,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/F/N/one/parenleft/parenright/three/two/y)
-/FontFile 74 0 R
+/FontFile 71 0 R
 >>
 endobj
-76 0 obj
+73 0 obj
 <<
 /Length1 721
 /Length2 8782
@@ -640,7 +631,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-77 0 obj
+74 0 obj
 <<
 /Type /FontDescriptor
 /FontName /GCSERG+SFRM1000
@@ -653,10 +644,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/e/s/t)
-/FontFile 76 0 R
+/FontFile 73 0 R
 >>
 endobj
-78 0 obj
+75 0 obj
 <<
 /Length1 721
 /Length2 1200
@@ -665,7 +656,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-79 0 obj
+76 0 obj
 <<
 /Type /FontDescriptor
 /FontName /LUUETJ+SFRM1200
@@ -678,16 +669,16 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/one/x)
-/FontFile 78 0 R
+/FontFile 75 0 R
 >>
 endobj
-67 0 obj
+64 0 obj
 <<
 /Type /Encoding
 /Differences [40/parenleft/parenright 49/one/two/three 70/F 78/N 101/e 115/s/t 120/x/y]
 >>
 endobj
-80 0 obj
+77 0 obj
 <<
 /Length 2030      
 >>
@@ -831,20 +822,20 @@ end
 %%EOF
 endstream
 endobj
-53 0 obj
+50 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /FFNBVP+SFRM0700
-/FontDescriptor 73 0 R
+/FontDescriptor 70 0 R
 /FirstChar 40
 /LastChar 78
-/Widths 69 0 R
-/Encoding 67 0 R
-/ToUnicode 80 0 R
+/Widths 66 0 R
+/Encoding 64 0 R
+/ToUnicode 77 0 R
 >>
 endobj
-81 0 obj
+78 0 obj
 <<
 /Length 2030      
 >>
@@ -988,20 +979,20 @@ end
 %%EOF
 endstream
 endobj
-48 0 obj
+45 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /NQUESM+SFRM0800
-/FontDescriptor 75 0 R
+/FontDescriptor 72 0 R
 /FirstChar 40
 /LastChar 121
-/Widths 70 0 R
-/Encoding 67 0 R
-/ToUnicode 81 0 R
+/Widths 67 0 R
+/Encoding 64 0 R
+/ToUnicode 78 0 R
 >>
 endobj
-82 0 obj
+79 0 obj
 <<
 /Length 2030      
 >>
@@ -1145,20 +1136,20 @@ end
 %%EOF
 endstream
 endobj
-54 0 obj
+51 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /GCSERG+SFRM1000
-/FontDescriptor 77 0 R
+/FontDescriptor 74 0 R
 /FirstChar 101
 /LastChar 116
-/Widths 68 0 R
-/Encoding 67 0 R
-/ToUnicode 82 0 R
+/Widths 65 0 R
+/Encoding 64 0 R
+/ToUnicode 79 0 R
 >>
 endobj
-83 0 obj
+80 0 obj
 <<
 /Length 2030      
 >>
@@ -1302,105 +1293,102 @@ end
 %%EOF
 endstream
 endobj
-47 0 obj
+44 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /LUUETJ+SFRM1200
-/FontDescriptor 79 0 R
+/FontDescriptor 76 0 R
 /FirstChar 49
 /LastChar 120
-/Widths 71 0 R
-/Encoding 67 0 R
-/ToUnicode 83 0 R
+/Widths 68 0 R
+/Encoding 64 0 R
+/ToUnicode 80 0 R
 >>
 endobj
-63 0 obj
+60 0 obj
 <<
 /Type /Pages
 /Count 1
 /Kids [9 0 R]
 >>
 endobj
+81 0 obj
+<<
+/Names [(Doc-Start) 42 0 R (footnote*.11) 52 0 R (footnote*.13) 54 0 R (footnote*.17) 56 0 R (footnote*.19) 58 0 R (footnote*.5) 46 0 R]
+/Limits [(Doc-Start) (footnote*.5)]
+>>
+endobj
+82 0 obj
+<<
+/Names [(footnote*.7) 48 0 R (page.1) 40 0 R]
+/Limits [(footnote*.7) (page.1)]
+>>
+endobj
+83 0 obj
+<<
+/Kids [81 0 R 82 0 R]
+/Limits [(Doc-Start) (page.1)]
+>>
+endobj
 84 0 obj
 <<
-/Names [(Doc-Start) 45 0 R (footnote*.12) 55 0 R (footnote*.14) 57 0 R (footnote*.19) 59 0 R (footnote*.21) 61 0 R (footnote*.5) 49 0 R]
-/Limits [(Doc-Start) (footnote*.5)]
+/Dests 83 0 R
 >>
 endobj
 85 0 obj
 <<
-/Names [(footnote*.7) 51 0 R (page.1) 43 0 R]
-/Limits [(footnote*.7) (page.1)]
+/Type /Catalog
+/Pages 60 0 R
+/Names 84 0 R
+/MarkInfo 61 0 R/PageMode /UseOutlines/OpenAction <</S/GoTo /D [9 0 R /Fit] /SD [10 0 R/Fit]>>/Lang (en)/PageLabels <</Nums[0<</S/D>>]>>/Metadata 37 0 R/StructTreeRoot 5 0 R
 >>
 endobj
 86 0 obj
-<<
-/Kids [84 0 R 85 0 R]
-/Limits [(Doc-Start) (page.1)]
->>
-endobj
-87 0 obj
-<<
-/Dests 86 0 R
->>
-endobj
-88 0 obj
-<<
-/Type /Catalog
-/Pages 63 0 R
-/Names 87 0 R
-/MarkInfo 64 0 R/PageMode /UseOutlines/OpenAction <</S/GoTo /D [9 0 R /Fit] /SD [10 0 R/Fit]>>/Lang (en)/PageLabels <</Nums[0<</S/D>>]>>/Metadata 40 0 R/StructTreeRoot 5 0 R
->>
-endobj
-89 0 obj
 <<
 /Producer (pdfTeX)/Creator <FEFF004C006100540065005800200077006900740068002000680079007000650072007200650066>/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z)
 /Trapped /False
 >>
 endobj
 xref
-0 90
+0 87
 0000000002 65535 f 
 0000015519 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000020183 00000 n 
+0000019871 00000 n 
 0000015602 00000 n 
-0000016362 00000 n 
+0000016314 00000 n 
 0000000000 00000 f 
 0000013690 00000 n 
-0000016941 00000 n 
-0000017027 00000 n 
-0000017115 00000 n 
-0000017462 00000 n 
-0000017635 00000 n 
+0000016893 00000 n 
+0000016979 00000 n 
+0000017067 00000 n 
+0000017414 00000 n 
+0000017587 00000 n 
 0000013864 00000 n 
 0000000015 00000 n 
-0000017752 00000 n 
-0000017864 00000 n 
-0000017956 00000 n 
-0000018044 00000 n 
-0000018254 00000 n 
-0000018368 00000 n 
-0000018541 00000 n 
+0000017704 00000 n 
+0000017816 00000 n 
+0000017904 00000 n 
+0000018114 00000 n 
+0000018232 00000 n 
+0000018405 00000 n 
 0000014081 00000 n 
 0000000068 00000 n 
-0000018658 00000 n 
-0000018770 00000 n 
-0000018862 00000 n 
-0000018950 00000 n 
-0000019160 00000 n 
-0000019274 00000 n 
-0000019449 00000 n 
+0000018522 00000 n 
+0000018634 00000 n 
+0000018722 00000 n 
+0000018932 00000 n 
+0000019050 00000 n 
+0000019225 00000 n 
 0000014300 00000 n 
 0000000121 00000 n 
-0000019567 00000 n 
-0000019679 00000 n 
-0000019771 00000 n 
-0000019859 00000 n 
-0000020069 00000 n 
+0000019343 00000 n 
+0000019455 00000 n 
+0000019543 00000 n 
+0000019753 00000 n 
 0000000174 00000 n 
 0000015395 00000 n 
 0000011969 00000 n 
@@ -1408,14 +1396,14 @@ xref
 0000014577 00000 n 
 0000014627 00000 n 
 0000014685 00000 n 
-0000081292 00000 n 
-0000076757 00000 n 
+0000080980 00000 n 
+0000076445 00000 n 
 0000014735 00000 n 
 0000014794 00000 n 
 0000014845 00000 n 
 0000014904 00000 n 
-0000074491 00000 n 
-0000079024 00000 n 
+0000074179 00000 n 
+0000078712 00000 n 
 0000014955 00000 n 
 0000015014 00000 n 
 0000015065 00000 n 
@@ -1424,38 +1412,38 @@ xref
 0000015234 00000 n 
 0000015285 00000 n 
 0000015344 00000 n 
-0000081470 00000 n 
+0000081158 00000 n 
 0000015566 00000 n 
 0000015882 00000 n 
-0000016325 00000 n 
-0000072276 00000 n 
-0000020285 00000 n 
-0000020399 00000 n 
-0000020652 00000 n 
-0000021159 00000 n 
-0000021596 00000 n 
-0000036521 00000 n 
-0000036779 00000 n 
-0000059948 00000 n 
-0000060208 00000 n 
-0000069808 00000 n 
-0000070033 00000 n 
-0000072051 00000 n 
-0000072402 00000 n 
-0000074668 00000 n 
-0000076935 00000 n 
-0000079203 00000 n 
-0000081528 00000 n 
-0000081723 00000 n 
-0000081824 00000 n 
-0000081899 00000 n 
-0000081935 00000 n 
-0000082174 00000 n 
+0000016277 00000 n 
+0000071964 00000 n 
+0000019973 00000 n 
+0000020087 00000 n 
+0000020340 00000 n 
+0000020847 00000 n 
+0000021284 00000 n 
+0000036209 00000 n 
+0000036467 00000 n 
+0000059636 00000 n 
+0000059896 00000 n 
+0000069496 00000 n 
+0000069721 00000 n 
+0000071739 00000 n 
+0000072090 00000 n 
+0000074356 00000 n 
+0000076623 00000 n 
+0000078891 00000 n 
+0000081216 00000 n 
+0000081411 00000 n 
+0000081512 00000 n 
+0000081587 00000 n 
+0000081623 00000 n 
+0000081862 00000 n 
 trailer
-<< /Size 90
-/Root 88 0 R
-/Info 89 0 R
+<< /Size 87
+/Root 85 0 R
+/Info 86 0 R
 /ID [<9BD18DF3359C1216B83ADB4AA401CC9A> <9BD18DF3359C1216B83ADB4AA401CC9A>] >>
 startxref
-82383
+82071
 %%EOF

--- a/required/latex-lab/testfiles-OR/tagging-001.tlg
+++ b/required/latex-lab/testfiles-OR/tagging-001.tlg
@@ -53,7 +53,7 @@ Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\tag_struct_begin:n {tag=footnotelabel}\tag_struct_end: \bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
@@ -63,7 +63,7 @@ Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=NonStruct,parent=\l__fnote_currentstruct_tl +1}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
@@ -205,10 +205,10 @@ Completed box being shipped out [1]
 ...\marks4{b+,12,4,text,,,}
 ...\marks4{e-,12,4,}
 ...\marks4{e+,12,4,}
-...\marks4{b-,13,11,Lbl,,,}
-...\marks4{b+,13,11,Lbl,,,}
-...\marks4{e-,13,11,}
-...\marks4{e+,13,11,}
+...\marks4{b-,13,10,Lbl,,,}
+...\marks4{b+,13,10,Lbl,,,}
+...\marks4{e-,13,10,}
+...\marks4{e+,13,10,}
 ...\marks4{b-,14,4,text,,,}
 ...\marks4{b+,14,4,text,,,}
 ...\marks4{e-,14,4,}
@@ -281,32 +281,32 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\marks4{b-,5,-1,}
 ...\marks4{b+,5,-1,}
-...\marks4{e-,5,9,}
-...\marks4{e+,5,9,}
-...\marks4{b-,6,9,text,,,}
-...\marks4{b+,6,9,text,,,}
-...\marks4{e-,6,9,}
-...\marks4{e+,6,9,}
-...\marks4{b-,7,10,Lbl,,,}
-...\marks4{b+,7,10,Lbl,,,}
-...\marks4{e-,7,10,}
-...\marks4{e+,7,10,}
-...\marks4{b-,8,9,text,,,}
-...\marks4{b+,8,9,text,,,}
-...\marks4{e-,8,9,}
-...\marks4{e+,8,9,}
-...\marks4{b-,9,9,text,,,}
-...\marks4{b+,9,9,text,,,}
-...\marks4{e-,9,9,}
-...\marks4{e+,9,9,}
-...\marks4{b-,10,9,text,,,}
-...\marks4{b+,10,9,text,,,}
-...\marks4{e-,10,9,}
-...\marks4{e+,10,9,}
+...\marks4{e-,5,8,}
+...\marks4{e+,5,8,}
+...\marks4{b-,6,8,text,,,}
+...\marks4{b+,6,8,text,,,}
+...\marks4{e-,6,8,}
+...\marks4{e+,6,8,}
+...\marks4{b-,7,9,Lbl,,,}
+...\marks4{b+,7,9,Lbl,,,}
+...\marks4{e-,7,9,}
+...\marks4{e+,7,9,}
+...\marks4{b-,8,8,text,,,}
+...\marks4{b+,8,8,text,,,}
+...\marks4{e-,8,8,}
+...\marks4{e+,8,8,}
+...\marks4{b-,9,8,text,,,}
+...\marks4{b+,9,8,text,,,}
+...\marks4{e-,9,8,}
+...\marks4{e+,9,8,}
+...\marks4{b-,10,8,text,,,}
+...\marks4{b+,10,8,text,,,}
+...\marks4{e-,10,8,}
+...\marks4{e+,10,8,}
 ...\marks4{b-,11,-1,}
 ...\marks4{b+,11,-1,}
-...\marks4{e-,11,9,}
-...\marks4{e+,11,9,}
+...\marks4{e-,11,8,}
+...\marks4{e+,11,8,}
 ...\hbox(6.6724+2.85002)x345.0, glue set 308.59221fil
 ....\pdfliteral page{/Artifact BMC}
 ....\hbox(3.22144+0.0)x0.0, glue set - 5.76248fil
@@ -363,32 +363,32 @@ Completed box being shipped out [1]
 ....\glue(\rightskip) 0.0
 ...\marks4{b-,16,-1,}
 ...\marks4{b+,16,-1,}
-...\marks4{e-,16,15,}
-...\marks4{e+,16,15,}
-...\marks4{b-,17,15,text,,,}
-...\marks4{b+,17,15,text,,,}
-...\marks4{e-,17,15,}
-...\marks4{e+,17,15,}
-...\marks4{b-,18,16,Lbl,,,}
-...\marks4{b+,18,16,Lbl,,,}
-...\marks4{e-,18,16,}
-...\marks4{e+,18,16,}
-...\marks4{b-,19,15,text,,,}
-...\marks4{b+,19,15,text,,,}
-...\marks4{e-,19,15,}
-...\marks4{e+,19,15,}
-...\marks4{b-,20,15,text,,,}
-...\marks4{b+,20,15,text,,,}
-...\marks4{e-,20,15,}
-...\marks4{e+,20,15,}
-...\marks4{b-,21,15,text,,,}
-...\marks4{b+,21,15,text,,,}
-...\marks4{e-,21,15,}
-...\marks4{e+,21,15,}
+...\marks4{e-,16,13,}
+...\marks4{e+,16,13,}
+...\marks4{b-,17,13,text,,,}
+...\marks4{b+,17,13,text,,,}
+...\marks4{e-,17,13,}
+...\marks4{e+,17,13,}
+...\marks4{b-,18,14,Lbl,,,}
+...\marks4{b+,18,14,Lbl,,,}
+...\marks4{e-,18,14,}
+...\marks4{e+,18,14,}
+...\marks4{b-,19,13,text,,,}
+...\marks4{b+,19,13,text,,,}
+...\marks4{e-,19,13,}
+...\marks4{e+,19,13,}
+...\marks4{b-,20,13,text,,,}
+...\marks4{b+,20,13,text,,,}
+...\marks4{e-,20,13,}
+...\marks4{e+,20,13,}
+...\marks4{b-,21,13,text,,,}
+...\marks4{b+,21,13,text,,,}
+...\marks4{e-,21,13,}
+...\marks4{e+,21,13,}
 ...\marks4{b-,22,-1,}
 ...\marks4{b+,22,-1,}
-...\marks4{e-,22,15,}
-...\marks4{e+,22,15,}
+...\marks4{e-,22,13,}
+...\marks4{e+,22,13,}
 ...\kern -2.85002
 ...\hbox(0.0+2.85002)x0.0
 ...\glue 0.0 plus 1.0fil

--- a/required/latex-lab/testfiles-OR/tagging-002-longtable.tpf
+++ b/required/latex-lab/testfiles-OR/tagging-002-longtable.tpf
@@ -1,6 +1,6 @@
 %PDF-1.5
 %ÐÔÅØ
-41 0 obj
+39 0 obj
 <<
 /Type /Metadata /Subtype /XML
 /Length 11701     
@@ -237,7 +237,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-43 0 obj
+41 0 obj
 <<
 /Length 1408      
 >>
@@ -343,40 +343,40 @@ endobj
 15 0 obj
 <<
 /Type /Page
-/Contents 43 0 R
-/Resources 42 0 R
+/Contents 41 0 R
+/Resources 40 0 R
 /MediaBox [0 0 612 792]
 /Tabs /S /StructParents 0 
-/Parent 50 0 R
+/Parent 48 0 R
 >>
 endobj
-42 0 obj
+40 0 obj
 <<
 /ExtGState 1 0 R 
-/Font << /F41 44 0 R /F39 45 0 R /F42 46 0 R /F52 47 0 R /F50 48 0 R /F43 49 0 R >>
+/Font << /F41 42 0 R /F39 43 0 R /F42 44 0 R /F52 45 0 R /F50 46 0 R /F43 47 0 R >>
 /ProcSet [ /PDF /Text ]
 >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-51 0 obj
+49 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 14 0 R 13 0 R 20 0 R 21 0 R 20 0 R 29 0 R 28 0 R 34 0 R 35 0 R 34 0 R 25 0 R 26 0 R 25 0 R 25 0 R 25 0 R 39 0 R 40 0 R 39 0 R 39 0 R 39 0 R ]
+<< /Nums [0 [ 14 0 R 13 0 R 20 0 R 21 0 R 20 0 R 28 0 R 27 0 R 33 0 R 34 0 R 33 0 R 24 0 R 25 0 R 24 0 R 24 0 R 24 0 R 37 0 R 38 0 R 37 0 R 37 0 R 37 0 R ]
 ] >>
 endobj
-52 0 obj
-<< /Limits [(ID.002) (ID.032)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 16 0 R (ID.009) 17 0 R (ID.010) 18 0 R (ID.011) 19 0 R (ID.012) 20 0 R (ID.013) 21 0 R (ID.014) 22 0 R (ID.015) 23 0 R (ID.016) 24 0 R (ID.017) 25 0 R (ID.018) 26 0 R (ID.019) 27 0 R (ID.020) 28 0 R (ID.021) 29 0 R (ID.022) 30 0 R (ID.023) 31 0 R (ID.024) 32 0 R (ID.025) 33 0 R (ID.026) 34 0 R (ID.027) 35 0 R (ID.028) 36 0 R (ID.029) 37 0 R (ID.030) 38 0 R (ID.031) 39 0 R (ID.032) 40 0 R ] >>
+50 0 obj
+<< /Limits [(ID.002) (ID.030)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 16 0 R (ID.009) 17 0 R (ID.010) 18 0 R (ID.011) 19 0 R (ID.012) 20 0 R (ID.013) 21 0 R (ID.014) 22 0 R (ID.015) 23 0 R (ID.016) 24 0 R (ID.017) 25 0 R (ID.018) 26 0 R (ID.019) 27 0 R (ID.020) 28 0 R (ID.021) 29 0 R (ID.022) 30 0 R (ID.023) 31 0 R (ID.024) 32 0 R (ID.025) 33 0 R (ID.026) 34 0 R (ID.027) 35 0 R (ID.028) 36 0 R (ID.029) 37 0 R (ID.030) 38 0 R ] >>
 endobj
-53 0 obj
-<< /Kids [52 0 R] >>
+51 0 obj
+<< /Kids [50 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
 endobj
-54 0 obj
+52 0 obj
 << /justify <</O/Layout/TextAlign/Justify>>
 /TH-both <</O/Table/Scope/Both>>
 /TH-row <</O/Table/Scope/Row>>
@@ -393,7 +393,7 @@ endobj
 <<  /Type /StructElem /S /Artifact /P 5 0 R /ID (ID.004) >>
 endobj
 12 0 obj
-<<  /Type /StructElem /S /Sect /P 9 0 R /K [13 0 R 16 0 R 22 0 R 27 0 R] /ID (ID.005) >>
+<<  /Type /StructElem /S /Sect /P 9 0 R /K [13 0 R 16 0 R 22 0 R 26 0 R] /ID (ID.005) >>
 endobj
 13 0 obj
 <<  /Type /StructElem /S /section /P 12 0 R /K [14 0 R <</Type /MCR /Pg 15 0 R/MCID 1>>] /ID (ID.006) >>
@@ -420,84 +420,78 @@ endobj
 <<  /Type /StructElem /S /footnotemark /P 20 0 R /Ref [ 22 0 R ] /K <</Type /MCR /Pg 15 0 R/MCID 3>> /ID (ID.013) >>
 endobj
 22 0 obj
-<<  /Type /StructElem /S /footnote /P 12 0 R /Ref [ 21 0 R ] /K [23 0 R 24 0 R] /ID (ID.014) >>
+<<  /Type /StructElem /S /footnote /P 12 0 R /Ref [ 21 0 R ] /K [25 0 R 23 0 R] /ID (ID.014) >>
 endobj
 23 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 22 0 R /K 26 0 R /ID (ID.015) >>
+<<  /Type /StructElem /S /Div /P 22 0 R /K 24 0 R /ID (ID.015) >>
 endobj
 24 0 obj
-<<  /Type /StructElem /S /Div /P 22 0 R /K 25 0 R /ID (ID.016) >>
+<<  /Type /StructElem /C /justify /S /text /P 23 0 R /K [<</Type /MCR /Pg 15 0 R/MCID 10>> <</Type /MCR /Pg 15 0 R/MCID 12>> <</Type /MCR /Pg 15 0 R/MCID 13>> <</Type /MCR /Pg 15 0 R/MCID 14>>] /ID (ID.016) >>
 endobj
 25 0 obj
-<<  /Type /StructElem /C /justify /S /text /P 24 0 R /K [<</Type /MCR /Pg 15 0 R/MCID 10>> <</Type /MCR /Pg 15 0 R/MCID 12>> <</Type /MCR /Pg 15 0 R/MCID 13>> <</Type /MCR /Pg 15 0 R/MCID 14>>] /ID (ID.017) >>
+<<  /Type /StructElem /S /footnotelabel /P 22 0 R /K <</Type /MCR /Pg 15 0 R/MCID 11>> /ID (ID.017) >>
 endobj
 26 0 obj
-<<  /Type /StructElem /S /NonStruct /P 23 0 R /K <</Type /MCR /Pg 15 0 R/MCID 11>> /ID (ID.018) >>
+<<  /Type /StructElem /S /Sect /P 12 0 R /K [27 0 R 29 0 R 35 0 R] /ID (ID.018) >>
 endobj
 27 0 obj
-<<  /Type /StructElem /S /Sect /P 12 0 R /K [28 0 R 30 0 R 36 0 R] /ID (ID.019) >>
+<<  /Type /StructElem /S /subsection /P 26 0 R /K [28 0 R <</Type /MCR /Pg 15 0 R/MCID 6>>] /ID (ID.019) >>
 endobj
 28 0 obj
-<<  /Type /StructElem /S /subsection /P 27 0 R /K [29 0 R <</Type /MCR /Pg 15 0 R/MCID 6>>] /ID (ID.020) >>
+<<  /Type /StructElem /S /Lbl /P 27 0 R /K <</Type /MCR /Pg 15 0 R/MCID 5>> /ID (ID.020) >>
 endobj
 29 0 obj
-<<  /Type /StructElem /S /Lbl /P 28 0 R /K <</Type /MCR /Pg 15 0 R/MCID 5>> /ID (ID.021) >>
+<<  /Type /StructElem /S /Table /P 26 0 R /K 30 0 R /ID (ID.021) >>
 endobj
 30 0 obj
-<<  /Type /StructElem /S /Table /P 27 0 R /K 31 0 R /ID (ID.022) >>
+<<  /Type /StructElem /S /TR /P 29 0 R /K 31 0 R /ID (ID.022) >>
 endobj
 31 0 obj
-<<  /Type /StructElem /S /TR /P 30 0 R /K 32 0 R /ID (ID.023) >>
+<<  /Type /StructElem /S /TD /P 30 0 R /K 32 0 R /ID (ID.023) >>
 endobj
 32 0 obj
-<<  /Type /StructElem /S /TD /P 31 0 R /K 33 0 R /ID (ID.024) >>
+<<  /Type /StructElem /S /Div /P 31 0 R /K 33 0 R /ID (ID.024) >>
 endobj
 33 0 obj
-<<  /Type /StructElem /S /Div /P 32 0 R /K 34 0 R /ID (ID.025) >>
+<<  /Type /StructElem /C /justify /S /text /P 32 0 R /K [<</Type /MCR /Pg 15 0 R/MCID 7>> 34 0 R <</Type /MCR /Pg 15 0 R/MCID 9>>] /ID (ID.025) >>
 endobj
 34 0 obj
-<<  /Type /StructElem /C /justify /S /text /P 33 0 R /K [<</Type /MCR /Pg 15 0 R/MCID 7>> 35 0 R <</Type /MCR /Pg 15 0 R/MCID 9>>] /ID (ID.026) >>
+<<  /Type /StructElem /S /footnotemark /P 33 0 R /Ref [ 35 0 R ] /K <</Type /MCR /Pg 15 0 R/MCID 8>> /ID (ID.026) >>
 endobj
 35 0 obj
-<<  /Type /StructElem /S /footnotemark /P 34 0 R /Ref [ 36 0 R ] /K <</Type /MCR /Pg 15 0 R/MCID 8>> /ID (ID.027) >>
+<<  /Type /StructElem /S /footnote /P 26 0 R /Ref [ 34 0 R ] /K [38 0 R 36 0 R] /ID (ID.027) >>
 endobj
 36 0 obj
-<<  /Type /StructElem /S /footnote /P 27 0 R /Ref [ 35 0 R ] /K [37 0 R 38 0 R] /ID (ID.028) >>
+<<  /Type /StructElem /S /Div /P 35 0 R /K 37 0 R /ID (ID.028) >>
 endobj
 37 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 36 0 R /K 40 0 R /ID (ID.029) >>
+<<  /Type /StructElem /C /justify /S /text /P 36 0 R /K [<</Type /MCR /Pg 15 0 R/MCID 15>> <</Type /MCR /Pg 15 0 R/MCID 17>> <</Type /MCR /Pg 15 0 R/MCID 18>> <</Type /MCR /Pg 15 0 R/MCID 19>>] /ID (ID.029) >>
 endobj
 38 0 obj
-<<  /Type /StructElem /S /Div /P 36 0 R /K 39 0 R /ID (ID.030) >>
-endobj
-39 0 obj
-<<  /Type /StructElem /C /justify /S /text /P 38 0 R /K [<</Type /MCR /Pg 15 0 R/MCID 15>> <</Type /MCR /Pg 15 0 R/MCID 17>> <</Type /MCR /Pg 15 0 R/MCID 18>> <</Type /MCR /Pg 15 0 R/MCID 19>>] /ID (ID.031) >>
-endobj
-40 0 obj
-<<  /Type /StructElem /S /NonStruct /P 37 0 R /K <</Type /MCR /Pg 15 0 R/MCID 16>> /ID (ID.032) >>
+<<  /Type /StructElem /S /footnotelabel /P 35 0 R /K <</Type /MCR /Pg 15 0 R/MCID 16>> /ID (ID.030) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 53 0 R /ClassMap 54 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
+<<  /Type /StructTreeRoot /IDTree 51 0 R /ClassMap 52 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
 endobj
-56 0 obj
+54 0 obj
 [531.1 590.1 472.1]
 endobj
-57 0 obj
+55 0 obj
 [611 611]
 endobj
-58 0 obj
+56 0 obj
 [312.4 562.4 562.4 562.4 562.4 562.4 562.4 562.4 562.4 562.4 562.4 562.4 312.4 312.4 874.8 874.8 874.8 531.1 874.8 849.3 799.6 812.3 862.1 738.2 707 884 879.4 418.9 580.9 880.6 675.8 1066.9 879.4 844.7 768.3 844.7 838.9 624.8 782.2 864.4 849.3 1161.8 849.3 849.3 687.3 312.4 562.4 312.4 687.3 874.8 312.4 546.7 624.8 499.9 624.8 513.2 343.7 562.4 624.8 312.4 343.7 593.6 312.4]
 endobj
-59 0 obj
+57 0 obj
 [569.3 569.3]
 endobj
-60 0 obj
+58 0 obj
 [499.9 499.9 499.9 499.9 499.9 499.9 499.9 499.9 499.9 277.7 277.7 777.6 777.6 777.6 472.1 777.6 749.8 708.2 722 763.7 680.4 652.6 784.5 749.8 361 513.8 777.6 624.8 916.4 749.8 777.6 680.4 777.6 735.9 555.4 722 749.8 749.8 1027.5 749.8 749.8 611 277.7 499.9 277.7 611 777.6 277.7 499.9 555.4 444.3 555.4 444.3 305.5 499.9 555.4 277.7 305.5 527.7 277.7 833.1 555.4 499.9 555.4 527.7 391.6 394.3 388.8]
 endobj
-61 0 obj
+59 0 obj
 [549.9 549.9 549.9 549.9 549.9 549.9 549.9 549.9 549.9 305.5 305.5 855.4 855.4 855.4 519.3 855.4 830.2 781.7 794.3 842.8 721.6 691 864.3 859.8 404.9 567.8 860.8 660.5 1043 859.8 825.8 751.1 825.8 817.3 611 764.7 845 830.2 1135.7 830.2 830.2 672.1 305.5 549.9 305.5 672.1 855.4 305.5 549.9 611 488.8]
 endobj
-62 0 obj
+60 0 obj
 <<
 /Length1 727
 /Length2 7574
@@ -506,7 +500,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-63 0 obj
+61 0 obj
 <<
 /Type /FontDescriptor
 /FontName /AZUAYJ+SFBX1200
@@ -519,10 +513,10 @@ endobj
 /StemV 50
 /XHeight 444
 /CharSet (/a/b/l/one/period)
-/FontFile 62 0 R
+/FontFile 60 0 R
 >>
 endobj
-64 0 obj
+62 0 obj
 <<
 /Length1 727
 /Length2 2916
@@ -531,7 +525,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-65 0 obj
+63 0 obj
 <<
 /Type /FontDescriptor
 /FontName /AAUTQH+SFBX1440
@@ -544,10 +538,10 @@ endobj
 /StemV 50
 /XHeight 444
 /CharSet (/a/b/c/one)
-/FontFile 64 0 R
+/FontFile 62 0 R
 >>
 endobj
-66 0 obj
+64 0 obj
 <<
 /Length1 721
 /Length2 14010
@@ -556,7 +550,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-67 0 obj
+65 0 obj
 <<
 /Type /FontDescriptor
 /FontName /QNUIBG+SFRM0600
@@ -569,10 +563,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/one/two)
-/FontFile 66 0 R
+/FontFile 64 0 R
 >>
 endobj
-68 0 obj
+66 0 obj
 <<
 /Length1 721
 /Length2 1158
@@ -581,7 +575,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-69 0 obj
+67 0 obj
 <<
 /Type /FontDescriptor
 /FontName /JDSMEO+SFRM0700
@@ -594,10 +588,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/one/two)
-/FontFile 68 0 R
+/FontFile 66 0 R
 >>
 endobj
-70 0 obj
+68 0 obj
 <<
 /Length1 721
 /Length2 9381
@@ -606,7 +600,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-71 0 obj
+69 0 obj
 <<
 /Type /FontDescriptor
 /FontName /WOWNJR+SFRM0800
@@ -619,10 +613,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/a/b/c)
-/FontFile 70 0 R
+/FontFile 68 0 R
 >>
 endobj
-72 0 obj
+70 0 obj
 <<
 /Length1 721
 /Length2 9015
@@ -631,7 +625,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-73 0 obj
+71 0 obj
 <<
 /Type /FontDescriptor
 /FontName /SSKXDU+SFRM1000
@@ -644,16 +638,16 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/T/e/one/s/t)
-/FontFile 72 0 R
+/FontFile 70 0 R
 >>
 endobj
-55 0 obj
+53 0 obj
 <<
 /Type /Encoding
 /Differences [46/period 49/one/two 84/T 97/a/b/c 101/e 108/l 115/s/t]
 >>
 endobj
-74 0 obj
+72 0 obj
 <<
 /Length 2030      
 >>
@@ -797,20 +791,20 @@ end
 %%EOF
 endstream
 endobj
-47 0 obj
+45 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /AZUAYJ+SFBX1200
-/FontDescriptor 63 0 R
+/FontDescriptor 61 0 R
 /FirstChar 46
 /LastChar 108
-/Widths 58 0 R
-/Encoding 55 0 R
-/ToUnicode 74 0 R
+/Widths 56 0 R
+/Encoding 53 0 R
+/ToUnicode 72 0 R
 >>
 endobj
-75 0 obj
+73 0 obj
 <<
 /Length 2030      
 >>
@@ -954,20 +948,20 @@ end
 %%EOF
 endstream
 endobj
-44 0 obj
+42 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /AAUTQH+SFBX1440
-/FontDescriptor 65 0 R
+/FontDescriptor 63 0 R
 /FirstChar 49
 /LastChar 99
-/Widths 61 0 R
-/Encoding 55 0 R
-/ToUnicode 75 0 R
+/Widths 59 0 R
+/Encoding 53 0 R
+/ToUnicode 73 0 R
 >>
 endobj
-76 0 obj
+74 0 obj
 <<
 /Length 2030      
 >>
@@ -1111,20 +1105,20 @@ end
 %%EOF
 endstream
 endobj
-48 0 obj
+46 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /QNUIBG+SFRM0600
-/FontDescriptor 67 0 R
+/FontDescriptor 65 0 R
 /FirstChar 49
 /LastChar 50
-/Widths 57 0 R
-/Encoding 55 0 R
-/ToUnicode 76 0 R
+/Widths 55 0 R
+/Encoding 53 0 R
+/ToUnicode 74 0 R
 >>
 endobj
-77 0 obj
+75 0 obj
 <<
 /Length 2030      
 >>
@@ -1268,20 +1262,20 @@ end
 %%EOF
 endstream
 endobj
-46 0 obj
+44 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /JDSMEO+SFRM0700
-/FontDescriptor 69 0 R
+/FontDescriptor 67 0 R
 /FirstChar 49
 /LastChar 50
-/Widths 59 0 R
-/Encoding 55 0 R
-/ToUnicode 77 0 R
+/Widths 57 0 R
+/Encoding 53 0 R
+/ToUnicode 75 0 R
 >>
 endobj
-78 0 obj
+76 0 obj
 <<
 /Length 2030      
 >>
@@ -1425,20 +1419,20 @@ end
 %%EOF
 endstream
 endobj
-49 0 obj
+47 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /WOWNJR+SFRM0800
-/FontDescriptor 71 0 R
+/FontDescriptor 69 0 R
 /FirstChar 97
 /LastChar 99
-/Widths 56 0 R
-/Encoding 55 0 R
-/ToUnicode 78 0 R
+/Widths 54 0 R
+/Encoding 53 0 R
+/ToUnicode 76 0 R
 >>
 endobj
-79 0 obj
+77 0 obj
 <<
 /Length 2030      
 >>
@@ -1582,128 +1576,126 @@ end
 %%EOF
 endstream
 endobj
-45 0 obj
+43 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /SSKXDU+SFRM1000
-/FontDescriptor 73 0 R
+/FontDescriptor 71 0 R
 /FirstChar 49
 /LastChar 116
-/Widths 60 0 R
-/Encoding 55 0 R
-/ToUnicode 79 0 R
+/Widths 58 0 R
+/Encoding 53 0 R
+/ToUnicode 77 0 R
 >>
 endobj
-50 0 obj
+48 0 obj
 <<
 /Type /Pages
 /Count 1
 /Kids [15 0 R]
 >>
 endobj
-80 0 obj
+78 0 obj
 <<
 /Type /Catalog
-/Pages 50 0 R
-/MarkInfo 51 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 41 0 R
+/Pages 48 0 R
+/MarkInfo 49 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 39 0 R
 >>
 endobj
-81 0 obj
+79 0 obj
 <<
 /Producer (pdfTeX)/Creator (TeX)/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z)
 /Trapped /False
 >>
 endobj
 xref
-0 82
+0 80
 0000000002 65535 f 
 0000013555 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000018550 00000 n 
+0000018342 00000 n 
 0000013638 00000 n 
-0000014405 00000 n 
+0000014373 00000 n 
 0000000000 00000 f 
-0000015146 00000 n 
-0000015231 00000 n 
-0000015307 00000 n 
-0000015383 00000 n 
-0000015488 00000 n 
-0000015609 00000 n 
+0000015114 00000 n 
+0000015199 00000 n 
+0000015275 00000 n 
+0000015351 00000 n 
+0000015456 00000 n 
+0000015577 00000 n 
 0000013272 00000 n 
-0000015717 00000 n 
-0000015801 00000 n 
-0000015882 00000 n 
-0000015963 00000 n 
-0000016045 00000 n 
-0000016208 00000 n 
-0000016341 00000 n 
-0000016453 00000 n 
-0000016545 00000 n 
-0000016627 00000 n 
-0000016853 00000 n 
-0000016968 00000 n 
-0000017067 00000 n 
-0000017191 00000 n 
-0000017299 00000 n 
-0000017383 00000 n 
-0000017464 00000 n 
-0000017545 00000 n 
-0000017627 00000 n 
-0000017790 00000 n 
-0000017923 00000 n 
-0000018035 00000 n 
-0000018127 00000 n 
-0000018209 00000 n 
-0000018435 00000 n 
+0000015685 00000 n 
+0000015769 00000 n 
+0000015850 00000 n 
+0000015931 00000 n 
+0000016013 00000 n 
+0000016176 00000 n 
+0000016309 00000 n 
+0000016421 00000 n 
+0000016503 00000 n 
+0000016729 00000 n 
+0000016848 00000 n 
+0000016947 00000 n 
+0000017071 00000 n 
+0000017179 00000 n 
+0000017263 00000 n 
+0000017344 00000 n 
+0000017425 00000 n 
+0000017507 00000 n 
+0000017670 00000 n 
+0000017803 00000 n 
+0000017915 00000 n 
+0000017997 00000 n 
+0000018223 00000 n 
 0000000015 00000 n 
 0000013407 00000 n 
 0000011805 00000 n 
-0000074701 00000 n 
-0000083765 00000 n 
-0000079233 00000 n 
-0000072434 00000 n 
-0000076967 00000 n 
-0000081499 00000 n 
-0000083943 00000 n 
+0000074493 00000 n 
+0000083557 00000 n 
+0000079025 00000 n 
+0000072226 00000 n 
+0000076759 00000 n 
+0000081291 00000 n 
+0000083735 00000 n 
 0000013602 00000 n 
 0000013814 00000 n 
-0000014368 00000 n 
-0000014984 00000 n 
-0000070237 00000 n 
-0000018668 00000 n 
-0000018704 00000 n 
-0000018730 00000 n 
-0000019124 00000 n 
-0000019154 00000 n 
-0000019571 00000 n 
-0000019887 00000 n 
-0000028285 00000 n 
-0000028521 00000 n 
-0000032261 00000 n 
-0000032490 00000 n 
-0000047319 00000 n 
-0000047546 00000 n 
-0000049522 00000 n 
-0000049749 00000 n 
-0000059948 00000 n 
-0000060173 00000 n 
-0000070006 00000 n 
-0000070345 00000 n 
-0000072612 00000 n 
-0000074878 00000 n 
-0000077144 00000 n 
-0000079410 00000 n 
-0000081676 00000 n 
-0000084002 00000 n 
-0000084117 00000 n 
+0000014336 00000 n 
+0000014952 00000 n 
+0000070029 00000 n 
+0000018460 00000 n 
+0000018496 00000 n 
+0000018522 00000 n 
+0000018916 00000 n 
+0000018946 00000 n 
+0000019363 00000 n 
+0000019679 00000 n 
+0000028077 00000 n 
+0000028313 00000 n 
+0000032053 00000 n 
+0000032282 00000 n 
+0000047111 00000 n 
+0000047338 00000 n 
+0000049314 00000 n 
+0000049541 00000 n 
+0000059740 00000 n 
+0000059965 00000 n 
+0000069798 00000 n 
+0000070137 00000 n 
+0000072404 00000 n 
+0000074670 00000 n 
+0000076936 00000 n 
+0000079202 00000 n 
+0000081468 00000 n 
+0000083794 00000 n 
+0000083909 00000 n 
 trailer
-<< /Size 82
-/Root 80 0 R
-/Info 81 0 R
+<< /Size 80
+/Root 78 0 R
+/Info 79 0 R
 /ID [<9BD18DF3359C1216B83ADB4AA401CC9A> <9BD18DF3359C1216B83ADB4AA401CC9A>] >>
 startxref
-84249
+84041
 %%EOF

--- a/required/latex-lab/testfiles-minipage/minipage-005-footnote.luatex.tlg
+++ b/required/latex-lab/testfiles-minipage/minipage-005-footnote.luatex.tlg
@@ -145,7 +145,7 @@ Completed box being shipped out [1]
 .\pdfliteral page <lua data reference ...>
 (minipage-005-footnote.aux)
 Package tagpdf Info: Finalizing the tagging structure:
-(tagpdf)             Writing out ~16 structure objects
+(tagpdf)             Writing out ~15 structure objects
 (tagpdf)             with ~13 'MC' leaf nodes.
 (tagpdf)             Be patient if there are lots of objects!
 Package tagpdf Info: writing ParentTree

--- a/required/latex-lab/testfiles-minipage/minipage-005-footnote.tlg
+++ b/required/latex-lab/testfiles-minipage/minipage-005-footnote.tlg
@@ -133,26 +133,26 @@ Completed box being shipped out [1]
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0 plus 1.0fil
 ......\glue(\rightskip) 0.0
-.....\marks4{b-,5,14,text,,,}
-.....\marks4{b+,5,14,text,,,}
-.....\marks4{e-,5,14,}
-.....\marks4{e+,5,14,}
-.....\marks4{b-,6,15,Lbl,,,}
-.....\marks4{b+,6,15,Lbl,,,}
-.....\marks4{e-,6,15,}
-.....\marks4{e+,6,15,}
-.....\marks4{b-,7,14,text,,,}
-.....\marks4{b+,7,14,text,,,}
-.....\marks4{e-,7,14,}
-.....\marks4{e+,7,14,}
-.....\marks4{b-,8,14,text,,,}
-.....\marks4{b+,8,14,text,,,}
-.....\marks4{e-,8,14,}
-.....\marks4{e+,8,14,}
-.....\marks4{b-,9,14,text,,,}
-.....\marks4{b+,9,14,text,,,}
-.....\marks4{e-,9,14,}
-.....\marks4{e+,9,14,}
+.....\marks4{b-,5,13,text,,,}
+.....\marks4{b+,5,13,text,,,}
+.....\marks4{e-,5,13,}
+.....\marks4{e+,5,13,}
+.....\marks4{b-,6,14,Lbl,,,}
+.....\marks4{b+,6,14,Lbl,,,}
+.....\marks4{e-,6,14,}
+.....\marks4{e+,6,14,}
+.....\marks4{b-,7,13,text,,,}
+.....\marks4{b+,7,13,text,,,}
+.....\marks4{e-,7,13,}
+.....\marks4{e+,7,13,}
+.....\marks4{b-,8,13,text,,,}
+.....\marks4{b+,8,13,text,,,}
+.....\marks4{e-,8,13,}
+.....\marks4{e+,8,13,}
+.....\marks4{b-,9,13,text,,,}
+.....\marks4{b+,9,13,text,,,}
+.....\marks4{e-,9,13,}
+.....\marks4{e+,9,13,}
 ....\mathoff
 ....\write1{\new@label@record{mcid-11}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{11}{tagmcid}{\__property_code_tagmcid: }}}
 ....\pdfliteral shipout page{/text <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -164,10 +164,10 @@ Completed box being shipped out [1]
 ...\marks4{b+,1,6,text,,,}
 ...\marks4{e-,1,6,}
 ...\marks4{e+,1,6,}
-...\marks4{b-,11,16,text,,,}
-...\marks4{b+,11,16,text,,,}
-...\marks4{e-,11,16,}
-...\marks4{e+,11,16,}
+...\marks4{b-,11,15,text,,,}
+...\marks4{b+,11,15,text,,,}
+...\marks4{e-,11,15,}
+...\marks4{e+,11,15,}
 ...\glue -5.0
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0 plus -1.0fil
@@ -197,7 +197,7 @@ Completed box being shipped out [1]
 .\kern 633.0
 (minipage-005-footnote.aux)
 Package tagpdf Info: Finalizing the tagging structure:
-(tagpdf)             Writing out ~16 structure objects
+(tagpdf)             Writing out ~15 structure objects
 (tagpdf)             with ~13 'MC' leaf nodes.
 (tagpdf)             Be patient if there are lots of objects!
 Package tagpdf Info: writing ParentTree

--- a/required/latex-lab/testfiles-title/title-002.luatex.tpf
+++ b/required/latex-lab/testfiles-title/title-002.luatex.tpf
@@ -1,6 +1,6 @@
 %PDF-1.5
 %Ã’¡‘≈ÿ–ƒ∆
-23 0 obj
+22 0 obj
 << /Type /Metadata /Subtype /XML /Length 11987 >>      
 stream
 <?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
@@ -245,7 +245,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-26 0 obj
+25 0 obj
 << /Length 1736 >>       
 stream
 /opacity1 gs
@@ -345,32 +345,32 @@ EMC
 EMC
 endstream
 endobj
-25 0 obj
-<< /Type /Page /Contents 26 0 R /Resources 24 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 35 0 R >>
-endobj
 24 0 obj
-<< /ExtGState 1 0 R /Font << /F17 27 0 R /F15 28 0 R /F28 29 0 R /F29 30 0 R /F18 31 0 R /F42 32 0 R /F30 33 0 R /F16 34 0 R >> /ProcSet [ /PDF /Text ] >>
+<< /Type /Page /Contents 25 0 R /Resources 23 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 34 0 R >>
+endobj
+23 0 obj
+<< /ExtGState 1 0 R /Font << /F17 26 0 R /F15 27 0 R /F28 28 0 R /F29 29 0 R /F18 30 0 R /F42 31 0 R /F30 32 0 R /F16 33 0 R >> /ProcSet [ /PDF /Text ] >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-36 0 obj
+35 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 22 0 R 21 0 R] 
+<< /Nums [0 [ 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 21 0 R 20 0 R] 
 ] >>
 endobj
-37 0 obj
-<< /Limits [(ID.002) (ID.015)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 15 0 R (ID.009) 16 0 R (ID.010) 17 0 R (ID.011) 18 0 R (ID.012) 19 0 R (ID.013) 20 0 R (ID.014) 21 0 R (ID.015) 22 0 R ] >>
+36 0 obj
+<< /Limits [(ID.002) (ID.014)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 15 0 R (ID.009) 16 0 R (ID.010) 17 0 R (ID.011) 18 0 R (ID.012) 19 0 R (ID.013) 20 0 R (ID.014) 21 0 R ] >>
 endobj
-38 0 obj
-<< /Kids [37 0 R] >>
+37 0 obj
+<< /Kids [36 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
 endobj
-39 0 obj
+38 0 obj
 << /center <</O/Layout/TextAlign/Center>>
 /justify <</O/Layout/TextAlign/Justify>>
 /TH-both <</O/Table/Scope/Both>>
@@ -391,71 +391,68 @@ endobj
 <<  /Type /StructElem /S /text-unit /P 9 0 R /K [13 0 R 15 0 R 16 0 R 17 0 R] /ID (ID.005) >>
 endobj
 13 0 obj
-<<  /Type /StructElem /C /center /S /Title /P 12 0 R /K [<</Type /MCR /Pg 25 0 R /MCID 0>>  14 0 R ] /ID (ID.006) >>
+<<  /Type /StructElem /C /center /S /Title /P 12 0 R /K [<</Type /MCR /Pg 24 0 R /MCID 0>>  14 0 R ] /ID (ID.006) >>
 endobj
 14 0 obj
-<<  /Type /StructElem /S /footnotemark /P 13 0 R /Ref [ 18 0 R ] /K <</Type /MCR /Pg 25 0 R /MCID 1>>  /ID (ID.007) >>
+<<  /Type /StructElem /S /footnotemark /P 13 0 R /Ref [ 18 0 R ] /K <</Type /MCR /Pg 24 0 R /MCID 1>>  /ID (ID.007) >>
 endobj
 15 0 obj
-<<  /Type /StructElem /C /center /S /Title /P 12 0 R /K <</Type /MCR /Pg 25 0 R /MCID 2>>  /ID (ID.008) >>
+<<  /Type /StructElem /C /center /S /Title /P 12 0 R /K <</Type /MCR /Pg 24 0 R /MCID 2>>  /ID (ID.008) >>
 endobj
 16 0 obj
-<<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 25 0 R /MCID 3>>  /ID (ID.009) >>
+<<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 24 0 R /MCID 3>>  /ID (ID.009) >>
 endobj
 17 0 obj
-<<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 25 0 R /MCID 4>>  /ID (ID.010) >>
+<<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 24 0 R /MCID 4>>  /ID (ID.010) >>
 endobj
 18 0 obj
-<<  /Type /StructElem /S /footnote /P 9 0 R /Ref [ 14 0 R ] /K [19 0 R 20 0 R] /ID (ID.011) >>
+<<  /Type /StructElem /S /footnote /P 9 0 R /Ref [ 14 0 R ] /K [21 0 R 19 0 R] /ID (ID.011) >>
 endobj
 19 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 18 0 R /K 22 0 R /ID (ID.012) >>
+<<  /Type /StructElem /S /text-unit /P 18 0 R /K 20 0 R /ID (ID.012) >>
 endobj
 20 0 obj
-<<  /Type /StructElem /S /text-unit /P 18 0 R /K 21 0 R /ID (ID.013) >>
+<<  /Type /StructElem /C /justify /S /text /P 19 0 R /K [  <</Type /MCR /Pg 24 0 R /MCID 6>>  ] /ID (ID.013) >>
 endobj
 21 0 obj
-<<  /Type /StructElem /C /justify /S /text /P 20 0 R /K [  <</Type /MCR /Pg 25 0 R /MCID 6>>  ] /ID (ID.014) >>
-endobj
-22 0 obj
-<<  /Type /StructElem /S /NonStruct /P 19 0 R /K <</Type /MCR /Pg 25 0 R /MCID 5>>  /ID (ID.015) >>
+<<  /Type /StructElem /S /footnotelabel /P 18 0 R /K <</Type /MCR /Pg 24 0 R /MCID 5>>  /ID (ID.014) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 38 0 R /ClassMap 39 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
+<<  /Type /StructTreeRoot /IDTree 37 0 R /ClassMap 38 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
 endobj
-40 0 obj
+39 0 obj
 [500 ]
 endobj
-41 0 obj
+40 0 obj
 [795.8 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 472.2 0 0 0 0 0 0 0 0 0 531.3 0 0 0 0 413.2 ]
 endobj
-43 0 obj
+42 0 obj
 [611 ]
 endobj
-44 0 obj
+43 0 obj
 [272 0 0 0 489.6 489.6 489.6 0 0 0 489.6 0 0 0 0 0 0 0 0 0 0 734 693.4 0 0 0 0 0 0 0 0 0 0 897.2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 489.6 0 0 0 0 0 0 544 0 0 0 0 0 0 489.6 0 0 380.8 0 380.8 544 0 0 0 516.8 ]
 endobj
-45 0 obj
+44 0 obj
 [513.9 571 0 0 457.2 0 0 571 285.5 0 0 285.5 0 0 0 0 0 0 405.4 399.7 571 0 742.3 ]
 endobj
-46 0 obj
+45 0 obj
 [489.5 ]
 endobj
-47 0 obj
+46 0 obj
 [ 103 [ 333 ] ]
 endobj
-49 0 obj
+48 0 obj
 << /Length 13 >>         
 [BINARY STREAM]
 endobj
-50 0 obj
+49 0 obj
 << /Subtype /CIDFontType0C /Length 506 >>        
 [BINARY STREAM]
 endobj
-48 0 obj
-<< /Type /FontDescriptor /FontName /XVZVYO+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 50 0 R /CIDSet 49 0 R >>
+47 0 obj
+<< /Type /FontDescriptor /FontName /XVZVYO+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 49 0 R /CIDSet 48 0 R >>
 endobj
-51 0 obj
+50 0 obj
 << /Length 692 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -491,68 +488,68 @@ end
 %%EOF
 endstream
 endobj
-28 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /XVZVYO+LMRoman10-Regular /DescendantFonts [ 52 0 R ] /ToUnicode 51 0 R >>
+27 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /XVZVYO+LMRoman10-Regular /DescendantFonts [ 51 0 R ] /ToUnicode 50 0 R >>
+endobj
+51 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /XVZVYO+LMRoman10-Regular /FontDescriptor 47 0 R /W 46 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 52 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /XVZVYO+LMRoman10-Regular /FontDescriptor 48 0 R /W 47 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-53 0 obj
 [693.3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 406.4 0 0 0 249.6 0 0 249.6 0 0 0 0 0 0 0 354.1 ]
 endobj
-55 0 obj
+54 0 obj
 << /Length1 1387 /Length2 5943 /Length3 0 /Length 7330 >>       
 [BINARY STREAM]
 endobj
-54 0 obj
-<< /Type /FontDescriptor /FontName /SDXKYB+CMR10 /Flags 4 /FontBBox [ -40 -250 1009 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 69 /XHeight 431 /CharSet( /one) /FontFile 55 0 R >>
+53 0 obj
+<< /Type /FontDescriptor /FontName /SDXKYB+CMR10 /Flags 4 /FontBBox [ -40 -250 1009 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 69 /XHeight 431 /CharSet( /one) /FontFile 54 0 R >>
 endobj
-57 0 obj
+56 0 obj
 << /Length1 1599 /Length2 8302 /Length3 0 /Length 9901 >>       
 [BINARY STREAM]
 endobj
-56 0 obj
-<< /Type /FontDescriptor /FontName /VBFROV+CMR12 /Flags 4 /FontBBox [ -34 -251 988 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 65 /XHeight 431 /CharSet( /A /B /M /a /comma /h /o /one /r /six /t /two /u /y /zero) /FontFile 57 0 R >>
+55 0 obj
+<< /Type /FontDescriptor /FontName /VBFROV+CMR12 /Flags 4 /FontBBox [ -34 -251 988 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 65 /XHeight 431 /CharSet( /A /B /M /a /comma /h /o /one /r /six /t /two /u /y /zero) /FontFile 56 0 R >>
 endobj
-59 0 obj
+58 0 obj
 << /Length1 1444 /Length2 6633 /Length3 0 /Length 8077 >>       
 [BINARY STREAM]
 endobj
-58 0 obj
-<< /Type /FontDescriptor /FontName /PXLAWO+CMR17 /Flags 4 /FontBBox [ -33 -250 945 749 ] /Ascent 694 /CapHeight 683 /Descent -195 /ItalicAngle 0 /StemV 53 /XHeight 430 /CharSet( /A /e /i /l /t) /FontFile 59 0 R >>
+57 0 obj
+<< /Type /FontDescriptor /FontName /PXLAWO+CMR17 /Flags 4 /FontBBox [ -33 -250 945 749 ] /Ascent 694 /CapHeight 683 /Descent -195 /ItalicAngle 0 /StemV 53 /XHeight 430 /CharSet( /A /e /i /l /t) /FontFile 58 0 R >>
 endobj
-61 0 obj
+60 0 obj
 << /Length1 1422 /Length2 6395 /Length3 0 /Length 7817 >>       
 [BINARY STREAM]
 endobj
-60 0 obj
-<< /Type /FontDescriptor /FontName /FRWMVG+CMR8 /Flags 4 /FontBBox [ -36 -250 1070 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 76 /XHeight 431 /CharSet( /N /e /o /t) /FontFile 61 0 R >>
+59 0 obj
+<< /Type /FontDescriptor /FontName /FRWMVG+CMR8 /Flags 4 /FontBBox [ -36 -250 1070 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 76 /XHeight 431 /CharSet( /N /e /o /t) /FontFile 60 0 R >>
 endobj
-63 0 obj
+62 0 obj
 << /Length1 1511 /Length2 8440 /Length3 0 /Length 9951 >>       
 [BINARY STREAM]
 endobj
-62 0 obj
-<< /Type /FontDescriptor /FontName /BSXKTW+CMR9 /Flags 4 /FontBBox [ -39 -250 1036 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 74 /XHeight 431 /CharSet( /a /b /e /h /i /l /s /t /u /w) /FontFile 63 0 R >>
+61 0 obj
+<< /Type /FontDescriptor /FontName /BSXKTW+CMR9 /Flags 4 /FontBBox [ -39 -250 1036 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 74 /XHeight 431 /CharSet( /a /b /e /h /i /l /s /t /u /w) /FontFile 62 0 R >>
 endobj
-65 0 obj
+64 0 obj
 << /Length1 721 /Length2 1124 /Length3 0 /Length 1845 >>       
 [BINARY STREAM]
 endobj
-64 0 obj
-<< /Type /FontDescriptor /FontName /YIGRIT+SFRM0600 /Flags 4 /FontBBox [ -210 -320 1719 944 ] /Ascent 0 /CapHeight 0 /Descent 0 /ItalicAngle 0 /StemV 50 /XHeight 430 /CharSet( /asteriskmath) /FontFile 65 0 R >>
+63 0 obj
+<< /Type /FontDescriptor /FontName /YIGRIT+SFRM0600 /Flags 4 /FontBBox [ -210 -320 1719 944 ] /Ascent 0 /CapHeight 0 /Descent 0 /ItalicAngle 0 /StemV 50 /XHeight 430 /CharSet( /asteriskmath) /FontFile 64 0 R >>
 endobj
-67 0 obj
+66 0 obj
 << /Length1 721 /Length2 5420 /Length3 0 /Length 6141 >>       
 [BINARY STREAM]
 endobj
-66 0 obj
-<< /Type /FontDescriptor /FontName /RYQARY+SFRM1200 /Flags 4 /FontBBox [ -185 -320 1420 942 ] /Ascent 0 /CapHeight 0 /Descent 0 /ItalicAngle 0 /StemV 50 /XHeight 430 /CharSet( /asteriskmath) /FontFile 67 0 R >>
+65 0 obj
+<< /Type /FontDescriptor /FontName /RYQARY+SFRM1200 /Flags 4 /FontBBox [ -185 -320 1420 942 ] /Ascent 0 /CapHeight 0 /Descent 0 /ItalicAngle 0 /StemV 50 /XHeight 430 /CharSet( /asteriskmath) /FontFile 66 0 R >>
 endobj
-42 0 obj
+41 0 obj
 << /Type /Encoding /Differences [ 42 /asteriskmath ] >>
 endobj
-68 0 obj
+67 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -672,10 +669,10 @@ end
 %%EOF
 endstream
 endobj
-34 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /SDXKYB+CMR10 /FontDescriptor 54 0 R /FirstChar 49 /LastChar 49 /Widths 40 0 R /ToUnicode 68 0 R >>
+33 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /SDXKYB+CMR10 /FontDescriptor 53 0 R /FirstChar 49 /LastChar 49 /Widths 39 0 R /ToUnicode 67 0 R >>
 endobj
-69 0 obj
+68 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -795,10 +792,10 @@ end
 %%EOF
 endstream
 endobj
-31 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /VBFROV+CMR12 /FontDescriptor 56 0 R /FirstChar 44 /LastChar 121 /Widths 44 0 R /ToUnicode 69 0 R >>
+30 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /VBFROV+CMR12 /FontDescriptor 55 0 R /FirstChar 44 /LastChar 121 /Widths 43 0 R /ToUnicode 68 0 R >>
 endobj
-70 0 obj
+69 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -918,10 +915,10 @@ end
 %%EOF
 endstream
 endobj
-27 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /PXLAWO+CMR17 /FontDescriptor 58 0 R /FirstChar 65 /LastChar 116 /Widths 53 0 R /ToUnicode 70 0 R >>
+26 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /PXLAWO+CMR17 /FontDescriptor 57 0 R /FirstChar 65 /LastChar 116 /Widths 52 0 R /ToUnicode 69 0 R >>
 endobj
-71 0 obj
+70 0 obj
 << /Length 1719 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -1041,10 +1038,10 @@ end
 %%EOF
 endstream
 endobj
-33 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /FRWMVG+CMR8 /FontDescriptor 60 0 R /FirstChar 78 /LastChar 116 /Widths 41 0 R /ToUnicode 71 0 R >>
+32 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /FRWMVG+CMR8 /FontDescriptor 59 0 R /FirstChar 78 /LastChar 116 /Widths 40 0 R /ToUnicode 70 0 R >>
 endobj
-72 0 obj
+71 0 obj
 << /Length 1719 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -1164,8 +1161,119 @@ end
 %%EOF
 endstream
 endobj
-30 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /BSXKTW+CMR9 /FontDescriptor 62 0 R /FirstChar 97 /LastChar 119 /Widths 45 0 R /ToUnicode 72 0 R >>
+29 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /BSXKTW+CMR9 /FontDescriptor 61 0 R /FirstChar 97 /LastChar 119 /Widths 44 0 R /ToUnicode 71 0 R >>
+endobj
+72 0 obj
+<< /Length 1523 >>       
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: ProcSet (CIDInit)
+%%IncludeResource: ProcSet (CIDInit)
+%%BeginResource: CMap (TeX-cm-super-ts1-0)
+%%Title: (TeX-cm-super-ts1-0 TeX cm-super-ts1 0)
+%%Version: 1.000
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<< /Registry (TeX)
+/Ordering (cm-super-ts1)
+/Supplement 0
+>> def
+/CMapName /TeX-cm-super-ts1-0 def
+/CMapType 2 def
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+7 beginbfrange
+<30> <39> <0030>
+<84> <85> <2020>
+<A0> <A1> <2045>
+<A2> <AA> <00A2>
+<AE> <B7> <00AE>
+<B9> <BA> <00B9>
+<BC> <BE> <00BC>
+endbfrange
+66 beginbfchar
+<00> <0060>
+<01> <00B4>
+<04> <00A8>
+<05> <02DD>
+<07> <02C7>
+<09> <00AF>
+<0B> <00B8>
+<0C> <02DB>
+<0D> <201A>
+<12> <201E>
+<16> <F6DE>
+<17> <200C>
+<18> <2190>
+<19> <2192>
+<1F> <200C>
+<20> <2422>
+<24> <0024>
+<27> <0027>
+<2A> <2217>
+<2C> <002C>
+<2E> <002E>
+<2F> <2044>
+<3C> <2329>
+<3D> <2212>
+<3E> <232A>
+<4D> <2127>
+<4F> <25CB>
+<57> <2126>
+<5B> <301A>
+<5D> <301B>
+<5E> <2191>
+<5F> <2193>
+<60> <0060>
+<6E> <266A>
+<80> <02D8>
+<81> <02C7>
+<82> <02DD>
+<83> <00A0030F>
+<86> <2016>
+<87> <2030>
+<88> <2022>
+<89> <2103>
+<8A> <0024>
+<8B> <00A2>
+<8C> <0192>
+<8D> <20A1>
+<8E> <20A9>
+<8F> <20A6>
+<92> <20A4>
+<94> <203D>
+<96> <20AB>
+<97> <2122>
+<98> <2031>
+<99> <00B6>
+<9A> <0E3F>
+<9B> <2116>
+<9D> <212E>
+<9E> <25E6>
+<9F> <2120>
+<AC> <00AC>
+<AD> <2117>
+<B8> <203B>
+<BB> <221A>
+<BF> <20AC>
+<D6> <00D7>
+<F6> <00F7>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+31 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /YIGRIT+SFRM0600 /FontDescriptor 63 0 R /FirstChar 42 /LastChar 42 /Widths 42 0 R /Encoding 41 0 R /ToUnicode 72 0 R >>
 endobj
 73 0 obj
 << /Length 1523 >>       
@@ -1275,210 +1383,98 @@ end
 %%EOF
 endstream
 endobj
-32 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /YIGRIT+SFRM0600 /FontDescriptor 64 0 R /FirstChar 42 /LastChar 42 /Widths 43 0 R /Encoding 42 0 R /ToUnicode 73 0 R >>
+28 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /RYQARY+SFRM1200 /FontDescriptor 65 0 R /FirstChar 42 /LastChar 42 /Widths 45 0 R /Encoding 41 0 R /ToUnicode 73 0 R >>
+endobj
+34 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 24 0 R ] >>
 endobj
 74 0 obj
-<< /Length 1523 >>       
-stream
-%!PS-Adobe-3.0 Resource-CMap
-%%DocumentNeededResources: ProcSet (CIDInit)
-%%IncludeResource: ProcSet (CIDInit)
-%%BeginResource: CMap (TeX-cm-super-ts1-0)
-%%Title: (TeX-cm-super-ts1-0 TeX cm-super-ts1 0)
-%%Version: 1.000
-%%EndComments
-/CIDInit /ProcSet findresource begin
-12 dict begin
-begincmap
-/CIDSystemInfo
-<< /Registry (TeX)
-/Ordering (cm-super-ts1)
-/Supplement 0
->> def
-/CMapName /TeX-cm-super-ts1-0 def
-/CMapType 2 def
-1 begincodespacerange
-<00> <FF>
-endcodespacerange
-7 beginbfrange
-<30> <39> <0030>
-<84> <85> <2020>
-<A0> <A1> <2045>
-<A2> <AA> <00A2>
-<AE> <B7> <00AE>
-<B9> <BA> <00B9>
-<BC> <BE> <00BC>
-endbfrange
-66 beginbfchar
-<00> <0060>
-<01> <00B4>
-<04> <00A8>
-<05> <02DD>
-<07> <02C7>
-<09> <00AF>
-<0B> <00B8>
-<0C> <02DB>
-<0D> <201A>
-<12> <201E>
-<16> <F6DE>
-<17> <200C>
-<18> <2190>
-<19> <2192>
-<1F> <200C>
-<20> <2422>
-<24> <0024>
-<27> <0027>
-<2A> <2217>
-<2C> <002C>
-<2E> <002E>
-<2F> <2044>
-<3C> <2329>
-<3D> <2212>
-<3E> <232A>
-<4D> <2127>
-<4F> <25CB>
-<57> <2126>
-<5B> <301A>
-<5D> <301B>
-<5E> <2191>
-<5F> <2193>
-<60> <0060>
-<6E> <266A>
-<80> <02D8>
-<81> <02C7>
-<82> <02DD>
-<83> <00A0030F>
-<86> <2016>
-<87> <2030>
-<88> <2022>
-<89> <2103>
-<8A> <0024>
-<8B> <00A2>
-<8C> <0192>
-<8D> <20A1>
-<8E> <20A9>
-<8F> <20A6>
-<92> <20A4>
-<94> <203D>
-<96> <20AB>
-<97> <2122>
-<98> <2031>
-<99> <00B6>
-<9A> <0E3F>
-<9B> <2116>
-<9D> <212E>
-<9E> <25E6>
-<9F> <2120>
-<AC> <00AC>
-<AD> <2117>
-<B8> <203B>
-<BB> <221A>
-<BF> <20AC>
-<D6> <00D7>
-<F6> <00F7>
-endbfchar
-endcmap
-CMapName currentdict /CMap defineresource pop
-end
-end
-%%EndResource
-%%EOF
-endstream
-endobj
-29 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /RYQARY+SFRM1200 /FontDescriptor 66 0 R /FirstChar 42 /LastChar 42 /Widths 46 0 R /Encoding 42 0 R /ToUnicode 74 0 R >>
-endobj
-35 0 obj
-<< /Type /Pages  /Count 1 /Kids [ 25 0 R ] >>
+<< /Type /Catalog /Pages 34 0 R /MarkInfo 35 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 22 0 R >>
 endobj
 75 0 obj
-<< /Type /Catalog /Pages 35 0 R /MarkInfo 36 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 23 0 R >>
-endobj
-76 0 obj
 << /Producer (LuaTeX)/Creator (TeX)/Title <FEFF00410020007400690074006C0065005B00310063006D005D00200077006900740068002000610020007300750062007400690074006C0065>/Author <FEFF0061007500740068006F0072002000410020002C0061007500740068006F007200200042>/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 77
+0 76
 0000000002 65535 f 
 0000014199 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000016992 00000 n 
+0000016888 00000 n 
 0000014282 00000 n 
-0000014686 00000 n 
+0000014670 00000 n 
 0000000000 00000 f 
-0000015466 00000 n 
-0000015560 00000 n 
-0000015636 00000 n 
-0000015712 00000 n 
-0000015822 00000 n 
-0000015955 00000 n 
-0000016090 00000 n 
-0000016213 00000 n 
-0000016335 00000 n 
-0000016457 00000 n 
-0000016568 00000 n 
-0000016660 00000 n 
-0000016748 00000 n 
-0000016876 00000 n 
+0000015450 00000 n 
+0000015544 00000 n 
+0000015620 00000 n 
+0000015696 00000 n 
+0000015806 00000 n 
+0000015939 00000 n 
+0000016074 00000 n 
+0000016197 00000 n 
+0000016319 00000 n 
+0000016441 00000 n 
+0000016552 00000 n 
+0000016640 00000 n 
+0000016768 00000 n 
 0000000020 00000 n 
 0000014028 00000 n 
 0000013893 00000 n 
 0000012097 00000 n 
-0000078942 00000 n 
-0000019303 00000 n 
-0000086315 00000 n 
-0000082815 00000 n 
-0000077000 00000 n 
-0000084555 00000 n 
-0000080879 00000 n 
-0000075059 00000 n 
-0000086492 00000 n 
+0000078838 00000 n 
+0000019199 00000 n 
+0000086211 00000 n 
+0000082711 00000 n 
+0000076896 00000 n 
+0000084451 00000 n 
+0000080775 00000 n 
+0000074955 00000 n 
+0000086388 00000 n 
 0000014246 00000 n 
 0000014367 00000 n 
-0000014649 00000 n 
-0000015265 00000 n 
-0000017110 00000 n 
-0000017133 00000 n 
-0000073203 00000 n 
-0000017246 00000 n 
-0000017269 00000 n 
-0000017496 00000 n 
-0000017595 00000 n 
-0000017620 00000 n 
-0000018315 00000 n 
-0000017652 00000 n 
-0000017725 00000 n 
-0000018551 00000 n 
-0000019457 00000 n 
-0000019657 00000 n 
-0000027229 00000 n 
-0000019800 00000 n 
-0000037450 00000 n 
-0000027450 00000 n 
-0000045899 00000 n 
-0000037723 00000 n 
-0000054045 00000 n 
-0000046129 00000 n 
-0000064322 00000 n 
-0000054272 00000 n 
-0000066510 00000 n 
-0000064567 00000 n 
-0000072976 00000 n 
-0000066737 00000 n 
-0000073275 00000 n 
-0000075216 00000 n 
-0000077158 00000 n 
-0000079100 00000 n 
-0000081036 00000 n 
-0000082972 00000 n 
-0000084732 00000 n 
-0000086554 00000 n 
-0000086669 00000 n 
+0000014633 00000 n 
+0000015249 00000 n 
+0000017006 00000 n 
+0000017029 00000 n 
+0000073099 00000 n 
+0000017142 00000 n 
+0000017165 00000 n 
+0000017392 00000 n 
+0000017491 00000 n 
+0000017516 00000 n 
+0000018211 00000 n 
+0000017548 00000 n 
+0000017621 00000 n 
+0000018447 00000 n 
+0000019353 00000 n 
+0000019553 00000 n 
+0000027125 00000 n 
+0000019696 00000 n 
+0000037346 00000 n 
+0000027346 00000 n 
+0000045795 00000 n 
+0000037619 00000 n 
+0000053941 00000 n 
+0000046025 00000 n 
+0000064218 00000 n 
+0000054168 00000 n 
+0000066406 00000 n 
+0000064463 00000 n 
+0000072872 00000 n 
+0000066633 00000 n 
+0000073171 00000 n 
+0000075112 00000 n 
+0000077054 00000 n 
+0000078996 00000 n 
+0000080932 00000 n 
+0000082868 00000 n 
+0000084628 00000 n 
+0000086450 00000 n 
+0000086565 00000 n 
 trailer
-<< /Size 77 /Root 75 0 R /Info 76 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 76 /Root 74 0 R /Info 75 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-87012
+86908
 %%EOF

--- a/required/latex-lab/testfiles-title/title-002.tpf
+++ b/required/latex-lab/testfiles-title/title-002.tpf
@@ -1,6 +1,6 @@
 %PDF-1.5
 %ÐÔÅØ
-24 0 obj
+23 0 obj
 <<
 /Type /Metadata /Subtype /XML
 /Length 11985     
@@ -248,7 +248,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-26 0 obj
+25 0 obj
 <<
 /Length 1269      
 >>
@@ -313,40 +313,40 @@ endobj
 14 0 obj
 <<
 /Type /Page
-/Contents 26 0 R
-/Resources 25 0 R
+/Contents 25 0 R
+/Resources 24 0 R
 /MediaBox [0 0 612 792]
 /Tabs /S /StructParents 0 
-/Parent 35 0 R
+/Parent 34 0 R
 >>
 endobj
-25 0 obj
+24 0 obj
 <<
 /ExtGState 1 0 R 
-/Font << /F40 27 0 R /F64 28 0 R /F50 29 0 R /F51 30 0 R /F49 31 0 R /F63 32 0 R /F60 33 0 R /F39 34 0 R >>
+/Font << /F40 26 0 R /F64 27 0 R /F50 28 0 R /F51 29 0 R /F49 30 0 R /F63 31 0 R /F60 32 0 R /F39 33 0 R >>
 /ProcSet [ /PDF /Text ]
 >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-36 0 obj
+35 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 13 0 R 15 0 R 13 0 R 16 0 R 17 0 R 18 0 R 22 0 R 23 0 R 22 0 R 22 0 R 22 0 R ]
+<< /Nums [0 [ 13 0 R 15 0 R 13 0 R 16 0 R 17 0 R 18 0 R 21 0 R 22 0 R 21 0 R 21 0 R 21 0 R ]
 ] >>
 endobj
-37 0 obj
-<< /Limits [(ID.002) (ID.015)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 15 0 R (ID.008) 16 0 R (ID.009) 17 0 R (ID.010) 18 0 R (ID.011) 19 0 R (ID.012) 20 0 R (ID.013) 21 0 R (ID.014) 22 0 R (ID.015) 23 0 R ] >>
+36 0 obj
+<< /Limits [(ID.002) (ID.014)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 15 0 R (ID.008) 16 0 R (ID.009) 17 0 R (ID.010) 18 0 R (ID.011) 19 0 R (ID.012) 20 0 R (ID.013) 21 0 R (ID.014) 22 0 R ] >>
 endobj
-38 0 obj
-<< /Kids [37 0 R] >>
+37 0 obj
+<< /Kids [36 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
 endobj
-39 0 obj
+38 0 obj
 << /center <</O/Layout/TextAlign/Center>>
 /justify <</O/Layout/TextAlign/Justify>>
 /TH-both <</O/Table/Scope/Both>>
@@ -382,48 +382,45 @@ endobj
 <<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 14 0 R/MCID 5>> /ID (ID.010) >>
 endobj
 19 0 obj
-<<  /Type /StructElem /S /footnote /P 9 0 R /Ref [ 15 0 R ] /K [20 0 R 21 0 R] /ID (ID.011) >>
+<<  /Type /StructElem /S /footnote /P 9 0 R /Ref [ 15 0 R ] /K [22 0 R 20 0 R] /ID (ID.011) >>
 endobj
 20 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 19 0 R /K 23 0 R /ID (ID.012) >>
+<<  /Type /StructElem /S /text-unit /P 19 0 R /K 21 0 R /ID (ID.012) >>
 endobj
 21 0 obj
-<<  /Type /StructElem /S /text-unit /P 19 0 R /K 22 0 R /ID (ID.013) >>
+<<  /Type /StructElem /C /justify /S /text /P 20 0 R /K [<</Type /MCR /Pg 14 0 R/MCID 6>> <</Type /MCR /Pg 14 0 R/MCID 8>> <</Type /MCR /Pg 14 0 R/MCID 9>> <</Type /MCR /Pg 14 0 R/MCID 10>>] /ID (ID.013) >>
 endobj
 22 0 obj
-<<  /Type /StructElem /C /justify /S /text /P 21 0 R /K [<</Type /MCR /Pg 14 0 R/MCID 6>> <</Type /MCR /Pg 14 0 R/MCID 8>> <</Type /MCR /Pg 14 0 R/MCID 9>> <</Type /MCR /Pg 14 0 R/MCID 10>>] /ID (ID.014) >>
-endobj
-23 0 obj
-<<  /Type /StructElem /S /NonStruct /P 20 0 R /K <</Type /MCR /Pg 14 0 R/MCID 7>> /ID (ID.015) >>
+<<  /Type /StructElem /S /footnotelabel /P 19 0 R /K <</Type /MCR /Pg 14 0 R/MCID 7>> /ID (ID.014) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 38 0 R /ClassMap 39 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
+<<  /Type /StructTreeRoot /IDTree 37 0 R /ClassMap 38 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
 endobj
-41 0 obj
+40 0 obj
 [499.9]
 endobj
-42 0 obj
+41 0 obj
 [795.6 826.2 722.4 826.2 781.4 590.1 767.2 795.6 795.6 1090.7 795.6 795.6 649.1 295.1 531.1 295.1 649.1 826.2 295.1 531.1 590.1 472.1 590.1 472.1 324.6 531.1 590.1 295.1 324.6 560.6 295.1 885.2 590.1 531.1 590.1 560.6 414 419 413.1]
 endobj
-44 0 obj
+43 0 obj
 [611]
 endobj
-45 0 obj
+44 0 obj
 [271.9 326.3 271.9 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 271.9 271.9 761.4 761.4 761.4 462.3 761.4 733.8 693.2 707 747.6 666 638.8 768.1 733.8 353.2 502.9 761 611.7 897 733.8 761.4 666 761.4 720.4 543.8 707 733.8 733.8 1005.8 733.8 733.8 598.2 271.9 489.5 271.9 598.2 761.4 271.9 489.5 543.8 435.1 543.8 435.1 299.1 489.5 543.8 271.9 299.1 516.7 271.9 815.8 543.8 489.5 543.8 516.7 380.7 386.1 380.7 543.8 516.7 707 516.7 516.7]
 endobj
-46 0 obj
+45 0 obj
 [513.8 570.8 456.7 570.8 457.1 314 513.8 570.8 285.4 314 542.3 285.4 856.3 570.8 513.8 570.8 542.3 401.9 405.3 399.6 570.8 542.3 742.1]
 endobj
-47 0 obj
+46 0 obj
 [489.5]
 endobj
-48 0 obj
+47 0 obj
 [333]
 endobj
-49 0 obj
+48 0 obj
 [704.4 665.4 678.7 717.7 639.3 613.2 737.3 704.4 338.8 482.6 730.5 587.1 861.1 704.4 730.9 639.3 730.9 691.5 522 678.7 704.4 704.4 965.6 704.4 704.4 574.2 260.8 469.8 260.8 574.2 730.9 260.8 469.8 522 417.5 522 417.5 287 469.8 522 260.8 287 495.9 260.8 783.1 522 469.8 522 495.9 365.3 370.5 365.3]
 endobj
-50 0 obj
+49 0 obj
 <<
 /Length1 1144
 /Length2 1422
@@ -432,7 +429,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-51 0 obj
+50 0 obj
 <<
 /Type /FontDescriptor
 /FontName /MUQHVU+PdfTeX-Space
@@ -445,10 +442,10 @@ endobj
 /StemV 0
 /XHeight 500
 /CharSet (/space)
-/FontFile 50 0 R
+/FontFile 49 0 R
 >>
 endobj
-52 0 obj
+51 0 obj
 <<
 /Length1 721
 /Length2 1124
@@ -457,7 +454,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-53 0 obj
+52 0 obj
 <<
 /Type /FontDescriptor
 /FontName /YIGRIT+SFRM0600
@@ -470,10 +467,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/asteriskmath)
-/FontFile 52 0 R
+/FontFile 51 0 R
 >>
 endobj
-54 0 obj
+53 0 obj
 <<
 /Length1 721
 /Length2 16768
@@ -482,7 +479,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-55 0 obj
+54 0 obj
 <<
 /Type /FontDescriptor
 /FontName /MMWKYX+SFRM0800
@@ -495,10 +492,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/N/e/o/t)
-/FontFile 54 0 R
+/FontFile 53 0 R
 >>
 endobj
-56 0 obj
+55 0 obj
 <<
 /Length1 721
 /Length2 13820
@@ -507,7 +504,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-57 0 obj
+56 0 obj
 <<
 /Type /FontDescriptor
 /FontName /WLWXUF+SFRM0900
@@ -520,10 +517,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/a/b/e/h/i/l/s/t/u/w)
-/FontFile 56 0 R
+/FontFile 55 0 R
 >>
 endobj
-58 0 obj
+57 0 obj
 <<
 /Length1 721
 /Length2 981
@@ -532,7 +529,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-59 0 obj
+58 0 obj
 <<
 /Type /FontDescriptor
 /FontName /VZMLCI+SFRM1000
@@ -545,10 +542,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/one)
-/FontFile 58 0 R
+/FontFile 57 0 R
 >>
 endobj
-60 0 obj
+59 0 obj
 <<
 /Length1 721
 /Length2 12358
@@ -557,7 +554,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-61 0 obj
+60 0 obj
 <<
 /Type /FontDescriptor
 /FontName /VVUPRB+SFRM1200
@@ -570,10 +567,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/A/B/M/a/asteriskmath/comma/h/o/one/r/six/t/two/u/y/zero)
-/FontFile 60 0 R
+/FontFile 59 0 R
 >>
 endobj
-62 0 obj
+61 0 obj
 <<
 /Length1 721
 /Length2 6947
@@ -582,7 +579,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-63 0 obj
+62 0 obj
 <<
 /Type /FontDescriptor
 /FontName /EMNKTC+SFRM1728
@@ -595,22 +592,22 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/A/e/i/l/t)
-/FontFile 62 0 R
+/FontFile 61 0 R
 >>
 endobj
-40 0 obj
+39 0 obj
 <<
 /Type /Encoding
 /Differences [44/comma 48/zero/one/two 54/six 65/A/B 77/M/N 97/a/b 101/e 104/h/i 108/l 111/o 114/r/s/t/u 119/w 121/y]
 >>
 endobj
-43 0 obj
+42 0 obj
 <<
 /Type /Encoding
 /Differences [42/asteriskmath]
 >>
 endobj
-64 0 obj
+63 0 obj
 <<
 /Length 2030      
 >>
@@ -754,20 +751,20 @@ end
 %%EOF
 endstream
 endobj
-33 0 obj
+32 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /MMWKYX+SFRM0800
-/FontDescriptor 55 0 R
+/FontDescriptor 54 0 R
 /FirstChar 78
 /LastChar 116
-/Widths 42 0 R
-/Encoding 40 0 R
-/ToUnicode 64 0 R
+/Widths 41 0 R
+/Encoding 39 0 R
+/ToUnicode 63 0 R
 >>
 endobj
-65 0 obj
+64 0 obj
 <<
 /Length 2030      
 >>
@@ -911,20 +908,20 @@ end
 %%EOF
 endstream
 endobj
-30 0 obj
+29 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /WLWXUF+SFRM0900
-/FontDescriptor 57 0 R
+/FontDescriptor 56 0 R
 /FirstChar 97
 /LastChar 119
-/Widths 46 0 R
-/Encoding 40 0 R
-/ToUnicode 65 0 R
+/Widths 45 0 R
+/Encoding 39 0 R
+/ToUnicode 64 0 R
 >>
 endobj
-66 0 obj
+65 0 obj
 <<
 /Length 2030      
 >>
@@ -1068,20 +1065,20 @@ end
 %%EOF
 endstream
 endobj
-34 0 obj
+33 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /VZMLCI+SFRM1000
-/FontDescriptor 59 0 R
+/FontDescriptor 58 0 R
 /FirstChar 49
 /LastChar 49
-/Widths 41 0 R
-/Encoding 40 0 R
-/ToUnicode 66 0 R
+/Widths 40 0 R
+/Encoding 39 0 R
+/ToUnicode 65 0 R
 >>
 endobj
-67 0 obj
+66 0 obj
 <<
 /Length 2030      
 >>
@@ -1225,20 +1222,20 @@ end
 %%EOF
 endstream
 endobj
-31 0 obj
+30 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /VVUPRB+SFRM1200
-/FontDescriptor 61 0 R
+/FontDescriptor 60 0 R
 /FirstChar 44
 /LastChar 121
-/Widths 45 0 R
-/Encoding 40 0 R
-/ToUnicode 67 0 R
+/Widths 44 0 R
+/Encoding 39 0 R
+/ToUnicode 66 0 R
 >>
 endobj
-68 0 obj
+67 0 obj
 <<
 /Length 2030      
 >>
@@ -1382,20 +1379,20 @@ end
 %%EOF
 endstream
 endobj
-27 0 obj
+26 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /EMNKTC+SFRM1728
-/FontDescriptor 63 0 R
+/FontDescriptor 62 0 R
 /FirstChar 65
 /LastChar 116
-/Widths 49 0 R
-/Encoding 40 0 R
-/ToUnicode 68 0 R
+/Widths 48 0 R
+/Encoding 39 0 R
+/ToUnicode 67 0 R
 >>
 endobj
-69 0 obj
+68 0 obj
 <<
 /Length 654       
 >>
@@ -1433,19 +1430,19 @@ end
 %%EOF
 endstream
 endobj
-28 0 obj
+27 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /MUQHVU+PdfTeX-Space
-/FontDescriptor 51 0 R
+/FontDescriptor 50 0 R
 /FirstChar 32
 /LastChar 32
-/Widths 48 0 R
-/ToUnicode 69 0 R
+/Widths 47 0 R
+/ToUnicode 68 0 R
 >>
 endobj
-70 0 obj
+69 0 obj
 <<
 /Length 1568      
 >>
@@ -1555,20 +1552,20 @@ end
 %%EOF
 endstream
 endobj
-32 0 obj
+31 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /YIGRIT+SFRM0600
-/FontDescriptor 53 0 R
+/FontDescriptor 52 0 R
 /FirstChar 42
 /LastChar 42
-/Widths 44 0 R
-/Encoding 43 0 R
-/ToUnicode 70 0 R
+/Widths 43 0 R
+/Encoding 42 0 R
+/ToUnicode 69 0 R
 >>
 endobj
-71 0 obj
+70 0 obj
 <<
 /Length 1568      
 >>
@@ -1678,120 +1675,119 @@ end
 %%EOF
 endstream
 endobj
-29 0 obj
+28 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /VVUPRB+SFRM1200
-/FontDescriptor 61 0 R
+/FontDescriptor 60 0 R
 /FirstChar 42
 /LastChar 42
-/Widths 47 0 R
-/Encoding 43 0 R
-/ToUnicode 71 0 R
+/Widths 46 0 R
+/Encoding 42 0 R
+/ToUnicode 70 0 R
 >>
 endobj
-35 0 obj
+34 0 obj
 <<
 /Type /Pages
 /Count 1
 /Kids [14 0 R]
 >>
 endobj
-72 0 obj
+71 0 obj
 <<
 /Type /Catalog
-/Pages 35 0 R
-/MarkInfo 36 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 24 0 R
+/Pages 34 0 R
+/MarkInfo 35 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 23 0 R
 >>
 endobj
-73 0 obj
+72 0 obj
 <<
 /Producer (pdfTeX)/Creator (TeX)/Title <FEFF00410020007400690074006C0065005B00310063006D005D00200077006900740068002000610020007300750062007400690074006C0065>/Author <FEFF0061007500740068006F0072002000410020002C0061007500740068006F007200200042>/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z)
 /Trapped /False
 >>
 endobj
 xref
-0 74
+0 73
 0000000002 65535 f 
 0000013724 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000016660 00000 n 
+0000016556 00000 n 
 0000013807 00000 n 
-0000014239 00000 n 
+0000014223 00000 n 
 0000000000 00000 f 
-0000015019 00000 n 
-0000015113 00000 n 
-0000015189 00000 n 
-0000015265 00000 n 
-0000015375 00000 n 
+0000015003 00000 n 
+0000015097 00000 n 
+0000015173 00000 n 
+0000015249 00000 n 
+0000015359 00000 n 
 0000013417 00000 n 
-0000015538 00000 n 
-0000015671 00000 n 
-0000015792 00000 n 
-0000015912 00000 n 
-0000016032 00000 n 
-0000016143 00000 n 
-0000016235 00000 n 
-0000016323 00000 n 
-0000016546 00000 n 
+0000015522 00000 n 
+0000015655 00000 n 
+0000015776 00000 n 
+0000015896 00000 n 
+0000016016 00000 n 
+0000016127 00000 n 
+0000016215 00000 n 
+0000016438 00000 n 
 0000000015 00000 n 
 0000013552 00000 n 
 0000012089 00000 n 
-0000090647 00000 n 
-0000091538 00000 n 
-0000095133 00000 n 
-0000083847 00000 n 
-0000088380 00000 n 
-0000093329 00000 n 
-0000081580 00000 n 
-0000086114 00000 n 
-0000095310 00000 n 
+0000090543 00000 n 
+0000091434 00000 n 
+0000095029 00000 n 
+0000083743 00000 n 
+0000088276 00000 n 
+0000093225 00000 n 
+0000081476 00000 n 
+0000086010 00000 n 
+0000095206 00000 n 
 0000013771 00000 n 
 0000013920 00000 n 
-0000014202 00000 n 
-0000014818 00000 n 
-0000079266 00000 n 
-0000016778 00000 n 
-0000016802 00000 n 
-0000079422 00000 n 
-0000017051 00000 n 
-0000017073 00000 n 
-0000017546 00000 n 
-0000017698 00000 n 
-0000017722 00000 n 
-0000017744 00000 n 
-0000018058 00000 n 
-0000020722 00000 n 
-0000020940 00000 n 
-0000022882 00000 n 
-0000023107 00000 n 
-0000040694 00000 n 
-0000040921 00000 n 
-0000055560 00000 n 
-0000055799 00000 n 
-0000057597 00000 n 
-0000057820 00000 n 
-0000070997 00000 n 
-0000071272 00000 n 
-0000079037 00000 n 
-0000079491 00000 n 
-0000081758 00000 n 
-0000084025 00000 n 
-0000086291 00000 n 
-0000088558 00000 n 
-0000090825 00000 n 
-0000091702 00000 n 
-0000093506 00000 n 
-0000095369 00000 n 
-0000095484 00000 n 
+0000014186 00000 n 
+0000014802 00000 n 
+0000079162 00000 n 
+0000016674 00000 n 
+0000016698 00000 n 
+0000079318 00000 n 
+0000016947 00000 n 
+0000016969 00000 n 
+0000017442 00000 n 
+0000017594 00000 n 
+0000017618 00000 n 
+0000017640 00000 n 
+0000017954 00000 n 
+0000020618 00000 n 
+0000020836 00000 n 
+0000022778 00000 n 
+0000023003 00000 n 
+0000040590 00000 n 
+0000040817 00000 n 
+0000055456 00000 n 
+0000055695 00000 n 
+0000057493 00000 n 
+0000057716 00000 n 
+0000070893 00000 n 
+0000071168 00000 n 
+0000078933 00000 n 
+0000079387 00000 n 
+0000081654 00000 n 
+0000083921 00000 n 
+0000086187 00000 n 
+0000088454 00000 n 
+0000090721 00000 n 
+0000091598 00000 n 
+0000093402 00000 n 
+0000095265 00000 n 
+0000095380 00000 n 
 trailer
-<< /Size 74
-/Root 72 0 R
-/Info 73 0 R
+<< /Size 73
+/Root 71 0 R
+/Info 72 0 R
 /ID [<9BD18DF3359C1216B83ADB4AA401CC9A> <9BD18DF3359C1216B83ADB4AA401CC9A>] >>
 startxref
-95827
+95723
 %%EOF

--- a/required/latex-lab/testfiles-title/title-003.luatex.tpf
+++ b/required/latex-lab/testfiles-title/title-003.luatex.tpf
@@ -1,6 +1,6 @@
 %PDF-1.5
 %Ã’¡‘≈ÿ–ƒ∆
-23 0 obj
+22 0 obj
 << /Type /Metadata /Subtype /XML /Length 11987 >>      
 stream
 <?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
@@ -245,7 +245,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-26 0 obj
+25 0 obj
 << /Length 1563 >>       
 stream
 /opacity1 gs
@@ -331,32 +331,32 @@ EMC
 EMC
 endstream
 endobj
-25 0 obj
-<< /Type /Page /Contents 26 0 R /Resources 24 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 32 0 R >>
-endobj
 24 0 obj
-<< /ExtGState 1 0 R /Font << /F17 27 0 R /F15 28 0 R /F18 29 0 R /F28 30 0 R /F30 31 0 R >> /ProcSet [ /PDF /Text ] >>
+<< /Type /Page /Contents 25 0 R /Resources 23 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 31 0 R >>
+endobj
+23 0 obj
+<< /ExtGState 1 0 R /Font << /F17 26 0 R /F15 27 0 R /F18 28 0 R /F28 29 0 R /F30 30 0 R >> /ProcSet [ /PDF /Text ] >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-33 0 obj
+32 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 22 0 R 21 0 R] 
+<< /Nums [0 [ 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 21 0 R 20 0 R] 
 ] >>
 endobj
-34 0 obj
-<< /Limits [(ID.002) (ID.015)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 15 0 R (ID.009) 16 0 R (ID.010) 17 0 R (ID.011) 18 0 R (ID.012) 19 0 R (ID.013) 20 0 R (ID.014) 21 0 R (ID.015) 22 0 R ] >>
+33 0 obj
+<< /Limits [(ID.002) (ID.014)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 15 0 R (ID.009) 16 0 R (ID.010) 17 0 R (ID.011) 18 0 R (ID.012) 19 0 R (ID.013) 20 0 R (ID.014) 21 0 R ] >>
 endobj
-35 0 obj
-<< /Kids [34 0 R] >>
+34 0 obj
+<< /Kids [33 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
 endobj
-36 0 obj
+35 0 obj
 << /center <</O/Layout/TextAlign/Center>>
 /justify <</O/Layout/TextAlign/Justify>>
 /TH-both <</O/Table/Scope/Both>>
@@ -377,62 +377,59 @@ endobj
 <<  /Type /StructElem /S /text-unit /P 9 0 R /K [13 0 R 15 0 R 16 0 R 17 0 R] /ID (ID.005) >>
 endobj
 13 0 obj
-<<  /Type /StructElem /C /center /S /Title /P 12 0 R /K [<</Type /MCR /Pg 25 0 R /MCID 0>>  14 0 R ] /ID (ID.006) >>
+<<  /Type /StructElem /C /center /S /Title /P 12 0 R /K [<</Type /MCR /Pg 24 0 R /MCID 0>>  14 0 R ] /ID (ID.006) >>
 endobj
 14 0 obj
-<<  /Type /StructElem /S /footnotemark /P 13 0 R /Ref [ 18 0 R ] /K <</Type /MCR /Pg 25 0 R /MCID 1>>  /ID (ID.007) >>
+<<  /Type /StructElem /S /footnotemark /P 13 0 R /Ref [ 18 0 R ] /K <</Type /MCR /Pg 24 0 R /MCID 1>>  /ID (ID.007) >>
 endobj
 15 0 obj
-<<  /Type /StructElem /C /center /S /Title /P 12 0 R /K <</Type /MCR /Pg 25 0 R /MCID 2>>  /ID (ID.008) >>
+<<  /Type /StructElem /C /center /S /Title /P 12 0 R /K <</Type /MCR /Pg 24 0 R /MCID 2>>  /ID (ID.008) >>
 endobj
 16 0 obj
-<<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 25 0 R /MCID 3>>  /ID (ID.009) >>
+<<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 24 0 R /MCID 3>>  /ID (ID.009) >>
 endobj
 17 0 obj
-<<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 25 0 R /MCID 4>>  /ID (ID.010) >>
+<<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 24 0 R /MCID 4>>  /ID (ID.010) >>
 endobj
 18 0 obj
-<<  /Type /StructElem /S /footnote /P 9 0 R /Ref [ 14 0 R ] /K [19 0 R 20 0 R] /ID (ID.011) >>
+<<  /Type /StructElem /S /footnote /P 9 0 R /Ref [ 14 0 R ] /K [21 0 R 19 0 R] /ID (ID.011) >>
 endobj
 19 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 18 0 R /K 22 0 R /ID (ID.012) >>
+<<  /Type /StructElem /S /text-unit /P 18 0 R /K 20 0 R /ID (ID.012) >>
 endobj
 20 0 obj
-<<  /Type /StructElem /S /text-unit /P 18 0 R /K 21 0 R /ID (ID.013) >>
+<<  /Type /StructElem /C /justify /S /text /P 19 0 R /K [  <</Type /MCR /Pg 24 0 R /MCID 6>>  ] /ID (ID.013) >>
 endobj
 21 0 obj
-<<  /Type /StructElem /C /justify /S /text /P 20 0 R /K [  <</Type /MCR /Pg 25 0 R /MCID 6>>  ] /ID (ID.014) >>
-endobj
-22 0 obj
-<<  /Type /StructElem /S /NonStruct /P 19 0 R /K <</Type /MCR /Pg 25 0 R /MCID 5>>  /ID (ID.015) >>
+<<  /Type /StructElem /S /footnotelabel /P 18 0 R /K <</Type /MCR /Pg 24 0 R /MCID 5>>  /ID (ID.014) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 35 0 R /ClassMap 36 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
+<<  /Type /StructTreeRoot /IDTree 34 0 R /ClassMap 35 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
 endobj
-37 0 obj
+36 0 obj
 [611.1 ]
 endobj
-38 0 obj
+37 0 obj
 [770.7 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 513.9 571 0 0 457.2 0 0 571 285.5 0 0 285.5 0 0 513.9 0 0 0 405.4 399.7 571 0 742.3 ]
 endobj
-39 0 obj
+38 0 obj
 [272 0 0 0 489.6 489.6 489.6 0 0 0 489.6 0 0 0 0 0 0 0 0 0 0 734 693.4 0 0 0 0 0 0 0 0 0 0 897.2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 489.6 0 0 0 0 0 0 544 0 0 0 0 0 0 489.6 0 0 380.8 0 380.8 544 0 0 0 516.8 ]
 endobj
-40 0 obj
+39 0 obj
 [ 103 [ 333 ] ]
 endobj
-42 0 obj
+41 0 obj
 << /Length 13 >>         
 [BINARY STREAM]
 endobj
-43 0 obj
+42 0 obj
 << /Subtype /CIDFontType0C /Length 506 >>        
 [BINARY STREAM]
 endobj
-41 0 obj
-<< /Type /FontDescriptor /FontName /XVZVYO+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 43 0 R /CIDSet 42 0 R >>
+40 0 obj
+<< /Type /FontDescriptor /FontName /XVZVYO+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 42 0 R /CIDSet 41 0 R >>
 endobj
-44 0 obj
+43 0 obj
 << /Length 692 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -468,44 +465,44 @@ end
 %%EOF
 endstream
 endobj
-28 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /XVZVYO+LMRoman10-Regular /DescendantFonts [ 45 0 R ] /ToUnicode 44 0 R >>
+27 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /XVZVYO+LMRoman10-Regular /DescendantFonts [ 44 0 R ] /ToUnicode 43 0 R >>
+endobj
+44 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /XVZVYO+LMRoman10-Regular /FontDescriptor 40 0 R /W 39 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 45 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /XVZVYO+LMRoman10-Regular /FontDescriptor 41 0 R /W 40 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-46 0 obj
 [693.3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 406.4 0 0 0 249.6 0 0 249.6 0 0 0 0 0 0 0 354.1 ]
 endobj
-48 0 obj
+47 0 obj
 << /Length1 1599 /Length2 8302 /Length3 0 /Length 9901 >>       
 [BINARY STREAM]
 endobj
-47 0 obj
-<< /Type /FontDescriptor /FontName /VBFROV+CMR12 /Flags 4 /FontBBox [ -34 -251 988 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 65 /XHeight 431 /CharSet( /A /B /M /a /comma /h /o /one /r /six /t /two /u /y /zero) /FontFile 48 0 R >>
+46 0 obj
+<< /Type /FontDescriptor /FontName /VBFROV+CMR12 /Flags 4 /FontBBox [ -34 -251 988 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 65 /XHeight 431 /CharSet( /A /B /M /a /comma /h /o /one /r /six /t /two /u /y /zero) /FontFile 47 0 R >>
 endobj
-50 0 obj
+49 0 obj
 << /Length1 1444 /Length2 6633 /Length3 0 /Length 8077 >>       
 [BINARY STREAM]
 endobj
-49 0 obj
-<< /Type /FontDescriptor /FontName /PXLAWO+CMR17 /Flags 4 /FontBBox [ -33 -250 945 749 ] /Ascent 694 /CapHeight 683 /Descent -195 /ItalicAngle 0 /StemV 53 /XHeight 430 /CharSet( /A /e /i /l /t) /FontFile 50 0 R >>
+48 0 obj
+<< /Type /FontDescriptor /FontName /PXLAWO+CMR17 /Flags 4 /FontBBox [ -33 -250 945 749 ] /Ascent 694 /CapHeight 683 /Descent -195 /ItalicAngle 0 /StemV 53 /XHeight 430 /CharSet( /A /e /i /l /t) /FontFile 49 0 R >>
 endobj
-52 0 obj
+51 0 obj
 << /Length1 1379 /Length2 5945 /Length3 0 /Length 7324 >>       
 [BINARY STREAM]
 endobj
-51 0 obj
-<< /Type /FontDescriptor /FontName /WIRDCL+CMR6 /Flags 4 /FontBBox [ -20 -250 1193 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 83 /XHeight 431 /CharSet( /one) /FontFile 52 0 R >>
+50 0 obj
+<< /Type /FontDescriptor /FontName /WIRDCL+CMR6 /Flags 4 /FontBBox [ -20 -250 1193 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 83 /XHeight 431 /CharSet( /one) /FontFile 51 0 R >>
 endobj
-54 0 obj
+53 0 obj
 << /Length1 1540 /Length2 8783 /Length3 0 /Length 10323 >>      
 [BINARY STREAM]
 endobj
-53 0 obj
-<< /Type /FontDescriptor /FontName /DTRHJH+CMR9 /Flags 4 /FontBBox [ -39 -250 1036 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 74 /XHeight 431 /CharSet( /N /a /b /e /h /i /l /o /s /t /u /w) /FontFile 54 0 R >>
+52 0 obj
+<< /Type /FontDescriptor /FontName /DTRHJH+CMR9 /Flags 4 /FontBBox [ -39 -250 1036 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 74 /XHeight 431 /CharSet( /N /a /b /e /h /i /l /o /s /t /u /w) /FontFile 53 0 R >>
 endobj
-55 0 obj
+54 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -625,10 +622,10 @@ end
 %%EOF
 endstream
 endobj
-29 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /VBFROV+CMR12 /FontDescriptor 47 0 R /FirstChar 44 /LastChar 121 /Widths 39 0 R /ToUnicode 55 0 R >>
+28 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /VBFROV+CMR12 /FontDescriptor 46 0 R /FirstChar 44 /LastChar 121 /Widths 38 0 R /ToUnicode 54 0 R >>
 endobj
-56 0 obj
+55 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -748,10 +745,10 @@ end
 %%EOF
 endstream
 endobj
-27 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /PXLAWO+CMR17 /FontDescriptor 49 0 R /FirstChar 65 /LastChar 116 /Widths 46 0 R /ToUnicode 56 0 R >>
+26 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /PXLAWO+CMR17 /FontDescriptor 48 0 R /FirstChar 65 /LastChar 116 /Widths 45 0 R /ToUnicode 55 0 R >>
 endobj
-57 0 obj
+56 0 obj
 << /Length 1719 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -871,10 +868,10 @@ end
 %%EOF
 endstream
 endobj
-31 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /WIRDCL+CMR6 /FontDescriptor 51 0 R /FirstChar 49 /LastChar 49 /Widths 37 0 R /ToUnicode 57 0 R >>
+30 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /WIRDCL+CMR6 /FontDescriptor 50 0 R /FirstChar 49 /LastChar 49 /Widths 36 0 R /ToUnicode 56 0 R >>
 endobj
-58 0 obj
+57 0 obj
 << /Length 1719 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -994,83 +991,82 @@ end
 %%EOF
 endstream
 endobj
-30 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /DTRHJH+CMR9 /FontDescriptor 53 0 R /FirstChar 78 /LastChar 119 /Widths 38 0 R /ToUnicode 58 0 R >>
+29 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /DTRHJH+CMR9 /FontDescriptor 52 0 R /FirstChar 78 /LastChar 119 /Widths 37 0 R /ToUnicode 57 0 R >>
 endobj
-32 0 obj
-<< /Type /Pages  /Count 1 /Kids [ 25 0 R ] >>
+31 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 24 0 R ] >>
+endobj
+58 0 obj
+<< /Type /Catalog /Pages 31 0 R /MarkInfo 32 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 22 0 R >>
 endobj
 59 0 obj
-<< /Type /Catalog /Pages 32 0 R /MarkInfo 33 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 23 0 R >>
-endobj
-60 0 obj
 << /Producer (LuaTeX)/Creator (TeX)/Title <FEFF00410020007400690074006C0065005B00310063006D005D00200077006900740068002000610020007300750062007400690074006C0065>/Author <FEFF0061007500740068006F0072002000410020002C0061007500740068006F007200200042>/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 61
+0 60
 0000000002 65535 f 
 0000013990 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000016783 00000 n 
+0000016679 00000 n 
 0000014073 00000 n 
-0000014477 00000 n 
+0000014461 00000 n 
 0000000000 00000 f 
-0000015257 00000 n 
-0000015351 00000 n 
-0000015427 00000 n 
-0000015503 00000 n 
-0000015613 00000 n 
-0000015746 00000 n 
-0000015881 00000 n 
-0000016004 00000 n 
-0000016126 00000 n 
-0000016248 00000 n 
-0000016359 00000 n 
-0000016451 00000 n 
-0000016539 00000 n 
-0000016667 00000 n 
+0000015241 00000 n 
+0000015335 00000 n 
+0000015411 00000 n 
+0000015487 00000 n 
+0000015597 00000 n 
+0000015730 00000 n 
+0000015865 00000 n 
+0000015988 00000 n 
+0000016110 00000 n 
+0000016232 00000 n 
+0000016343 00000 n 
+0000016431 00000 n 
+0000016559 00000 n 
 0000000020 00000 n 
 0000013855 00000 n 
 0000013720 00000 n 
 0000012097 00000 n 
-0000060199 00000 n 
-0000018981 00000 n 
-0000058257 00000 n 
-0000064071 00000 n 
-0000062136 00000 n 
-0000064228 00000 n 
+0000060095 00000 n 
+0000018877 00000 n 
+0000058153 00000 n 
+0000063967 00000 n 
+0000062032 00000 n 
+0000064124 00000 n 
 0000014037 00000 n 
 0000014158 00000 n 
-0000014440 00000 n 
-0000015056 00000 n 
-0000016901 00000 n 
-0000016926 00000 n 
-0000017071 00000 n 
-0000017298 00000 n 
-0000017993 00000 n 
-0000017330 00000 n 
-0000017403 00000 n 
-0000018229 00000 n 
-0000019135 00000 n 
-0000019335 00000 n 
-0000029478 00000 n 
-0000019478 00000 n 
-0000037927 00000 n 
-0000029751 00000 n 
-0000045580 00000 n 
-0000038157 00000 n 
-0000056222 00000 n 
-0000045800 00000 n 
-0000056473 00000 n 
-0000058415 00000 n 
-0000060357 00000 n 
-0000062292 00000 n 
-0000064290 00000 n 
-0000064405 00000 n 
+0000014424 00000 n 
+0000015040 00000 n 
+0000016797 00000 n 
+0000016822 00000 n 
+0000016967 00000 n 
+0000017194 00000 n 
+0000017889 00000 n 
+0000017226 00000 n 
+0000017299 00000 n 
+0000018125 00000 n 
+0000019031 00000 n 
+0000019231 00000 n 
+0000029374 00000 n 
+0000019374 00000 n 
+0000037823 00000 n 
+0000029647 00000 n 
+0000045476 00000 n 
+0000038053 00000 n 
+0000056118 00000 n 
+0000045696 00000 n 
+0000056369 00000 n 
+0000058311 00000 n 
+0000060253 00000 n 
+0000062188 00000 n 
+0000064186 00000 n 
+0000064301 00000 n 
 trailer
-<< /Size 61 /Root 59 0 R /Info 60 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 60 /Root 58 0 R /Info 59 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-64748
+64644
 %%EOF

--- a/required/latex-lab/testfiles-title/title-003.tpf
+++ b/required/latex-lab/testfiles-title/title-003.tpf
@@ -1,6 +1,6 @@
 %PDF-1.5
 %ÐÔÅØ
-24 0 obj
+23 0 obj
 <<
 /Type /Metadata /Subtype /XML
 /Length 11985     
@@ -248,7 +248,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-26 0 obj
+25 0 obj
 <<
 /Length 1152      
 >>
@@ -306,40 +306,40 @@ endobj
 14 0 obj
 <<
 /Type /Page
-/Contents 26 0 R
-/Resources 25 0 R
+/Contents 25 0 R
+/Resources 24 0 R
 /MediaBox [0 0 612 792]
 /Tabs /S /StructParents 0 
-/Parent 32 0 R
+/Parent 31 0 R
 >>
 endobj
-25 0 obj
+24 0 obj
 <<
 /ExtGState 1 0 R 
-/Font << /F40 27 0 R /F65 28 0 R /F49 29 0 R /F50 30 0 R /F64 31 0 R >>
+/Font << /F40 26 0 R /F65 27 0 R /F49 28 0 R /F50 29 0 R /F64 30 0 R >>
 /ProcSet [ /PDF /Text ]
 >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-33 0 obj
+32 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 13 0 R 15 0 R 13 0 R 16 0 R 17 0 R 18 0 R 22 0 R 23 0 R 22 0 R 22 0 R 22 0 R ]
+<< /Nums [0 [ 13 0 R 15 0 R 13 0 R 16 0 R 17 0 R 18 0 R 21 0 R 22 0 R 21 0 R 21 0 R 21 0 R ]
 ] >>
 endobj
-34 0 obj
-<< /Limits [(ID.002) (ID.015)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 15 0 R (ID.008) 16 0 R (ID.009) 17 0 R (ID.010) 18 0 R (ID.011) 19 0 R (ID.012) 20 0 R (ID.013) 21 0 R (ID.014) 22 0 R (ID.015) 23 0 R ] >>
+33 0 obj
+<< /Limits [(ID.002) (ID.014)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 15 0 R (ID.008) 16 0 R (ID.009) 17 0 R (ID.010) 18 0 R (ID.011) 19 0 R (ID.012) 20 0 R (ID.013) 21 0 R (ID.014) 22 0 R ] >>
 endobj
-35 0 obj
-<< /Kids [34 0 R] >>
+34 0 obj
+<< /Kids [33 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
 endobj
-36 0 obj
+35 0 obj
 << /center <</O/Layout/TextAlign/Center>>
 /justify <</O/Layout/TextAlign/Justify>>
 /TH-both <</O/Table/Scope/Both>>
@@ -375,39 +375,36 @@ endobj
 <<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 14 0 R/MCID 5>> /ID (ID.010) >>
 endobj
 19 0 obj
-<<  /Type /StructElem /S /footnote /P 9 0 R /Ref [ 15 0 R ] /K [20 0 R 21 0 R] /ID (ID.011) >>
+<<  /Type /StructElem /S /footnote /P 9 0 R /Ref [ 15 0 R ] /K [22 0 R 20 0 R] /ID (ID.011) >>
 endobj
 20 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 19 0 R /K 23 0 R /ID (ID.012) >>
+<<  /Type /StructElem /S /text-unit /P 19 0 R /K 21 0 R /ID (ID.012) >>
 endobj
 21 0 obj
-<<  /Type /StructElem /S /text-unit /P 19 0 R /K 22 0 R /ID (ID.013) >>
+<<  /Type /StructElem /C /justify /S /text /P 20 0 R /K [<</Type /MCR /Pg 14 0 R/MCID 6>> <</Type /MCR /Pg 14 0 R/MCID 8>> <</Type /MCR /Pg 14 0 R/MCID 9>> <</Type /MCR /Pg 14 0 R/MCID 10>>] /ID (ID.013) >>
 endobj
 22 0 obj
-<<  /Type /StructElem /C /justify /S /text /P 21 0 R /K [<</Type /MCR /Pg 14 0 R/MCID 6>> <</Type /MCR /Pg 14 0 R/MCID 8>> <</Type /MCR /Pg 14 0 R/MCID 9>> <</Type /MCR /Pg 14 0 R/MCID 10>>] /ID (ID.014) >>
-endobj
-23 0 obj
-<<  /Type /StructElem /S /NonStruct /P 20 0 R /K <</Type /MCR /Pg 14 0 R/MCID 7>> /ID (ID.015) >>
+<<  /Type /StructElem /S /footnotelabel /P 19 0 R /K <</Type /MCR /Pg 14 0 R/MCID 7>> /ID (ID.014) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 35 0 R /ClassMap 36 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
+<<  /Type /StructTreeRoot /IDTree 34 0 R /ClassMap 35 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
 endobj
-38 0 obj
+37 0 obj
 [611]
 endobj
-39 0 obj
+38 0 obj
 [770.5 799.2 699.2 799.2 756.3 570.8 742.1 770.5 770.5 1055.9 770.5 770.5 627.9 285.4 513.8 285.4 627.9 799.2 285.4 513.8 570.8 456.7 570.8 457.1 314 513.8 570.8 285.4 314 542.3 285.4 856.3 570.8 513.8 570.8 542.3 401.9 405.3 399.6 570.8 542.3 742.1]
 endobj
-40 0 obj
+39 0 obj
 [271.9 326.3 271.9 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 271.9 271.9 761.4 761.4 761.4 462.3 761.4 733.8 693.2 707 747.6 666 638.8 768.1 733.8 353.2 502.9 761 611.7 897 733.8 761.4 666 761.4 720.4 543.8 707 733.8 733.8 1005.8 733.8 733.8 598.2 271.9 489.5 271.9 598.2 761.4 271.9 489.5 543.8 435.1 543.8 435.1 299.1 489.5 543.8 271.9 299.1 516.7 271.9 815.8 543.8 489.5 543.8 516.7 380.7 386.1 380.7 543.8 516.7 707 516.7 516.7]
 endobj
-41 0 obj
+40 0 obj
 [333]
 endobj
-42 0 obj
+41 0 obj
 [704.4 665.4 678.7 717.7 639.3 613.2 737.3 704.4 338.8 482.6 730.5 587.1 861.1 704.4 730.9 639.3 730.9 691.5 522 678.7 704.4 704.4 965.6 704.4 704.4 574.2 260.8 469.8 260.8 574.2 730.9 260.8 469.8 522 417.5 522 417.5 287 469.8 522 260.8 287 495.9 260.8 783.1 522 469.8 522 495.9 365.3 370.5 365.3]
 endobj
-43 0 obj
+42 0 obj
 <<
 /Length1 1144
 /Length2 1422
@@ -416,7 +413,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-44 0 obj
+43 0 obj
 <<
 /Type /FontDescriptor
 /FontName /MUQHVU+PdfTeX-Space
@@ -429,10 +426,10 @@ endobj
 /StemV 0
 /XHeight 500
 /CharSet (/space)
-/FontFile 43 0 R
+/FontFile 42 0 R
 >>
 endobj
-45 0 obj
+44 0 obj
 <<
 /Length1 721
 /Length2 13847
@@ -441,7 +438,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-46 0 obj
+45 0 obj
 <<
 /Type /FontDescriptor
 /FontName /WMNOAL+SFRM0600
@@ -454,10 +451,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/one)
-/FontFile 45 0 R
+/FontFile 44 0 R
 >>
 endobj
-47 0 obj
+46 0 obj
 <<
 /Length1 721
 /Length2 14175
@@ -466,7 +463,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-48 0 obj
+47 0 obj
 <<
 /Type /FontDescriptor
 /FontName /ZEXONM+SFRM0900
@@ -479,10 +476,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/N/a/b/e/h/i/l/o/s/t/u/w)
-/FontFile 47 0 R
+/FontFile 46 0 R
 >>
 endobj
-49 0 obj
+48 0 obj
 <<
 /Length1 721
 /Length2 11987
@@ -491,7 +488,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-50 0 obj
+49 0 obj
 <<
 /Type /FontDescriptor
 /FontName /XGEWRW+SFRM1200
@@ -504,10 +501,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/A/B/M/a/comma/h/o/one/r/six/t/two/u/y/zero)
-/FontFile 49 0 R
+/FontFile 48 0 R
 >>
 endobj
-51 0 obj
+50 0 obj
 <<
 /Length1 721
 /Length2 6947
@@ -516,7 +513,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-52 0 obj
+51 0 obj
 <<
 /Type /FontDescriptor
 /FontName /EMNKTC+SFRM1728
@@ -529,16 +526,16 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/A/e/i/l/t)
-/FontFile 51 0 R
+/FontFile 50 0 R
 >>
 endobj
-37 0 obj
+36 0 obj
 <<
 /Type /Encoding
 /Differences [44/comma 48/zero/one/two 54/six 65/A/B 77/M/N 97/a/b 101/e 104/h/i 108/l 111/o 114/r/s/t/u 119/w 121/y]
 >>
 endobj
-53 0 obj
+52 0 obj
 <<
 /Length 2030      
 >>
@@ -682,20 +679,20 @@ end
 %%EOF
 endstream
 endobj
-31 0 obj
+30 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /WMNOAL+SFRM0600
-/FontDescriptor 46 0 R
+/FontDescriptor 45 0 R
 /FirstChar 49
 /LastChar 49
-/Widths 38 0 R
-/Encoding 37 0 R
-/ToUnicode 53 0 R
+/Widths 37 0 R
+/Encoding 36 0 R
+/ToUnicode 52 0 R
 >>
 endobj
-54 0 obj
+53 0 obj
 <<
 /Length 2030      
 >>
@@ -839,20 +836,20 @@ end
 %%EOF
 endstream
 endobj
-30 0 obj
+29 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /ZEXONM+SFRM0900
-/FontDescriptor 48 0 R
+/FontDescriptor 47 0 R
 /FirstChar 78
 /LastChar 119
-/Widths 39 0 R
-/Encoding 37 0 R
-/ToUnicode 54 0 R
+/Widths 38 0 R
+/Encoding 36 0 R
+/ToUnicode 53 0 R
 >>
 endobj
-55 0 obj
+54 0 obj
 <<
 /Length 2030      
 >>
@@ -996,20 +993,20 @@ end
 %%EOF
 endstream
 endobj
-29 0 obj
+28 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /XGEWRW+SFRM1200
-/FontDescriptor 50 0 R
+/FontDescriptor 49 0 R
 /FirstChar 44
 /LastChar 121
-/Widths 40 0 R
-/Encoding 37 0 R
-/ToUnicode 55 0 R
+/Widths 39 0 R
+/Encoding 36 0 R
+/ToUnicode 54 0 R
 >>
 endobj
-56 0 obj
+55 0 obj
 <<
 /Length 2030      
 >>
@@ -1153,20 +1150,20 @@ end
 %%EOF
 endstream
 endobj
-27 0 obj
+26 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /EMNKTC+SFRM1728
-/FontDescriptor 52 0 R
+/FontDescriptor 51 0 R
 /FirstChar 65
 /LastChar 116
-/Widths 42 0 R
-/Encoding 37 0 R
-/ToUnicode 56 0 R
+/Widths 41 0 R
+/Encoding 36 0 R
+/ToUnicode 55 0 R
 >>
 endobj
-57 0 obj
+56 0 obj
 <<
 /Length 654       
 >>
@@ -1204,105 +1201,104 @@ end
 %%EOF
 endstream
 endobj
-28 0 obj
+27 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /MUQHVU+PdfTeX-Space
-/FontDescriptor 44 0 R
+/FontDescriptor 43 0 R
 /FirstChar 32
 /LastChar 32
-/Widths 41 0 R
-/ToUnicode 57 0 R
+/Widths 40 0 R
+/ToUnicode 56 0 R
 >>
 endobj
-32 0 obj
+31 0 obj
 <<
 /Type /Pages
 /Count 1
 /Kids [14 0 R]
 >>
 endobj
-58 0 obj
+57 0 obj
 <<
 /Type /Catalog
-/Pages 32 0 R
-/MarkInfo 33 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 24 0 R
+/Pages 31 0 R
+/MarkInfo 32 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 23 0 R
 >>
 endobj
-59 0 obj
+58 0 obj
 <<
 /Producer (pdfTeX)/Creator (TeX)/Title <FEFF00410020007400690074006C0065005B00310063006D005D00200077006900740068002000610020007300750062007400690074006C0065>/Author <FEFF0061007500740068006F0072002000410020002C0061007500740068006F007200200042>/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z)
 /Trapped /False
 >>
 endobj
 xref
-0 60
+0 59
 0000000002 65535 f 
 0000013571 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000016507 00000 n 
+0000016403 00000 n 
 0000013654 00000 n 
-0000014086 00000 n 
+0000014070 00000 n 
 0000000000 00000 f 
-0000014866 00000 n 
-0000014960 00000 n 
-0000015036 00000 n 
-0000015112 00000 n 
-0000015222 00000 n 
+0000014850 00000 n 
+0000014944 00000 n 
+0000015020 00000 n 
+0000015096 00000 n 
+0000015206 00000 n 
 0000013300 00000 n 
-0000015385 00000 n 
-0000015518 00000 n 
-0000015639 00000 n 
-0000015759 00000 n 
-0000015879 00000 n 
-0000015990 00000 n 
-0000016082 00000 n 
-0000016170 00000 n 
-0000016393 00000 n 
+0000015369 00000 n 
+0000015502 00000 n 
+0000015623 00000 n 
+0000015743 00000 n 
+0000015863 00000 n 
+0000015974 00000 n 
+0000016062 00000 n 
+0000016285 00000 n 
 0000000015 00000 n 
 0000013435 00000 n 
 0000012089 00000 n 
-0000080838 00000 n 
-0000081729 00000 n 
-0000078571 00000 n 
-0000076304 00000 n 
-0000074038 00000 n 
-0000081893 00000 n 
+0000080734 00000 n 
+0000081625 00000 n 
+0000078467 00000 n 
+0000076200 00000 n 
+0000073934 00000 n 
+0000081789 00000 n 
 0000013618 00000 n 
 0000013767 00000 n 
-0000014049 00000 n 
-0000014665 00000 n 
-0000071793 00000 n 
-0000016625 00000 n 
-0000016647 00000 n 
-0000016914 00000 n 
-0000017387 00000 n 
-0000017409 00000 n 
-0000017723 00000 n 
-0000020387 00000 n 
-0000020605 00000 n 
-0000035271 00000 n 
-0000035494 00000 n 
-0000050488 00000 n 
-0000050731 00000 n 
-0000063537 00000 n 
-0000063799 00000 n 
-0000071564 00000 n 
-0000071949 00000 n 
-0000074215 00000 n 
-0000076482 00000 n 
-0000078749 00000 n 
-0000081016 00000 n 
-0000081952 00000 n 
-0000082067 00000 n 
+0000014033 00000 n 
+0000014649 00000 n 
+0000071689 00000 n 
+0000016521 00000 n 
+0000016543 00000 n 
+0000016810 00000 n 
+0000017283 00000 n 
+0000017305 00000 n 
+0000017619 00000 n 
+0000020283 00000 n 
+0000020501 00000 n 
+0000035167 00000 n 
+0000035390 00000 n 
+0000050384 00000 n 
+0000050627 00000 n 
+0000063433 00000 n 
+0000063695 00000 n 
+0000071460 00000 n 
+0000071845 00000 n 
+0000074111 00000 n 
+0000076378 00000 n 
+0000078645 00000 n 
+0000080912 00000 n 
+0000081848 00000 n 
+0000081963 00000 n 
 trailer
-<< /Size 60
-/Root 58 0 R
-/Info 59 0 R
+<< /Size 59
+/Root 57 0 R
+/Info 58 0 R
 /ID [<9BD18DF3359C1216B83ADB4AA401CC9A> <9BD18DF3359C1216B83ADB4AA401CC9A>] >>
 startxref
-82410
+82306
 %%EOF

--- a/required/latex-lab/testfiles-title/title-004.luatex.tpf
+++ b/required/latex-lab/testfiles-title/title-004.luatex.tpf
@@ -1,6 +1,6 @@
 %PDF-1.5
 %Ã’¡‘≈ÿ–ƒ∆
-23 0 obj
+22 0 obj
 << /Type /Metadata /Subtype /XML /Length 11979 >>      
 stream
 <?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
@@ -245,7 +245,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-26 0 obj
+25 0 obj
 << /Length 1736 >>       
 stream
 /opacity1 gs
@@ -345,32 +345,32 @@ EMC
 EMC
 endstream
 endobj
-25 0 obj
-<< /Type /Page /Contents 26 0 R /Resources 24 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 35 0 R >>
-endobj
 24 0 obj
-<< /ExtGState 1 0 R /Font << /F17 27 0 R /F15 28 0 R /F28 29 0 R /F29 30 0 R /F18 31 0 R /F42 32 0 R /F30 33 0 R /F16 34 0 R >> /ProcSet [ /PDF /Text ] >>
+<< /Type /Page /Contents 25 0 R /Resources 23 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 34 0 R >>
+endobj
+23 0 obj
+<< /ExtGState 1 0 R /Font << /F17 26 0 R /F15 27 0 R /F28 28 0 R /F29 29 0 R /F18 30 0 R /F42 31 0 R /F30 32 0 R /F16 33 0 R >> /ProcSet [ /PDF /Text ] >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-36 0 obj
+35 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 22 0 R 21 0 R] 
+<< /Nums [0 [ 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 21 0 R 20 0 R] 
 ] >>
 endobj
-37 0 obj
-<< /Limits [(ID.002) (ID.015)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 15 0 R (ID.009) 16 0 R (ID.010) 17 0 R (ID.011) 18 0 R (ID.012) 19 0 R (ID.013) 20 0 R (ID.014) 21 0 R (ID.015) 22 0 R ] >>
+36 0 obj
+<< /Limits [(ID.002) (ID.014)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 15 0 R (ID.009) 16 0 R (ID.010) 17 0 R (ID.011) 18 0 R (ID.012) 19 0 R (ID.013) 20 0 R (ID.014) 21 0 R ] >>
 endobj
-38 0 obj
-<< /Kids [37 0 R] >>
+37 0 obj
+<< /Kids [36 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
 endobj
-39 0 obj
+38 0 obj
 << /center <</O/Layout/TextAlign/Center>>
 /justify <</O/Layout/TextAlign/Justify>>
 /TH-both <</O/Table/Scope/Both>>
@@ -391,71 +391,68 @@ endobj
 <<  /Type /StructElem /S /text-unit /P 9 0 R /K [13 0 R 15 0 R 16 0 R 17 0 R] /ID (ID.005) >>
 endobj
 13 0 obj
-<<  /Type /StructElem /C /center /S /Title /P 12 0 R /K [<</Type /MCR /Pg 25 0 R /MCID 0>>  14 0 R ] /ID (ID.006) >>
+<<  /Type /StructElem /C /center /S /Title /P 12 0 R /K [<</Type /MCR /Pg 24 0 R /MCID 0>>  14 0 R ] /ID (ID.006) >>
 endobj
 14 0 obj
-<<  /Type /StructElem /S /footnotemark /P 13 0 R /Ref [ 18 0 R ] /K <</Type /MCR /Pg 25 0 R /MCID 1>>  /ID (ID.007) >>
+<<  /Type /StructElem /S /footnotemark /P 13 0 R /Ref [ 18 0 R ] /K <</Type /MCR /Pg 24 0 R /MCID 1>>  /ID (ID.007) >>
 endobj
 15 0 obj
-<<  /Type /StructElem /C /center /S /Title /P 12 0 R /K <</Type /MCR /Pg 25 0 R /MCID 2>>  /ID (ID.008) >>
+<<  /Type /StructElem /C /center /S /Title /P 12 0 R /K <</Type /MCR /Pg 24 0 R /MCID 2>>  /ID (ID.008) >>
 endobj
 16 0 obj
-<<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 25 0 R /MCID 3>>  /ID (ID.009) >>
+<<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 24 0 R /MCID 3>>  /ID (ID.009) >>
 endobj
 17 0 obj
-<<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 25 0 R /MCID 4>>  /ID (ID.010) >>
+<<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 24 0 R /MCID 4>>  /ID (ID.010) >>
 endobj
 18 0 obj
-<<  /Type /StructElem /S /footnote /P 9 0 R /Ref [ 14 0 R ] /K [19 0 R 20 0 R] /ID (ID.011) >>
+<<  /Type /StructElem /S /footnote /P 9 0 R /Ref [ 14 0 R ] /K [21 0 R 19 0 R] /ID (ID.011) >>
 endobj
 19 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 18 0 R /K 22 0 R /ID (ID.012) >>
+<<  /Type /StructElem /S /text-unit /P 18 0 R /K 20 0 R /ID (ID.012) >>
 endobj
 20 0 obj
-<<  /Type /StructElem /S /text-unit /P 18 0 R /K 21 0 R /ID (ID.013) >>
+<<  /Type /StructElem /C /justify /S /text /P 19 0 R /K [  <</Type /MCR /Pg 24 0 R /MCID 6>>  ] /ID (ID.013) >>
 endobj
 21 0 obj
-<<  /Type /StructElem /C /justify /S /text /P 20 0 R /K [  <</Type /MCR /Pg 25 0 R /MCID 6>>  ] /ID (ID.014) >>
-endobj
-22 0 obj
-<<  /Type /StructElem /S /NonStruct /P 19 0 R /K <</Type /MCR /Pg 25 0 R /MCID 5>>  /ID (ID.015) >>
+<<  /Type /StructElem /S /footnotelabel /P 18 0 R /K <</Type /MCR /Pg 24 0 R /MCID 5>>  /ID (ID.014) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 38 0 R /ClassMap 39 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
+<<  /Type /StructTreeRoot /IDTree 37 0 R /ClassMap 38 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
 endobj
-40 0 obj
+39 0 obj
 [500 ]
 endobj
-41 0 obj
+40 0 obj
 [795.8 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 472.2 0 0 0 0 0 0 0 0 0 531.3 0 0 0 0 413.2 ]
 endobj
-43 0 obj
+42 0 obj
 [611 ]
 endobj
-44 0 obj
+43 0 obj
 [272 0 0 0 489.6 489.6 489.6 0 0 0 489.6 0 0 0 0 0 0 0 0 0 0 734 693.4 0 0 0 0 0 0 0 0 0 0 897.2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 489.6 0 0 0 0 0 0 544 0 0 0 0 0 0 489.6 0 0 380.8 0 380.8 544 0 0 0 516.8 ]
 endobj
-45 0 obj
+44 0 obj
 [513.9 571 0 0 457.2 0 0 571 285.5 0 0 285.5 0 0 0 0 0 0 405.4 399.7 571 0 742.3 ]
 endobj
-46 0 obj
+45 0 obj
 [489.5 ]
 endobj
-47 0 obj
+46 0 obj
 [ 103 [ 333 ] ]
 endobj
-49 0 obj
+48 0 obj
 << /Length 13 >>         
 [BINARY STREAM]
 endobj
-50 0 obj
+49 0 obj
 << /Subtype /CIDFontType0C /Length 506 >>        
 [BINARY STREAM]
 endobj
-48 0 obj
-<< /Type /FontDescriptor /FontName /XVZVYO+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 50 0 R /CIDSet 49 0 R >>
+47 0 obj
+<< /Type /FontDescriptor /FontName /XVZVYO+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 49 0 R /CIDSet 48 0 R >>
 endobj
-51 0 obj
+50 0 obj
 << /Length 692 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -491,68 +488,68 @@ end
 %%EOF
 endstream
 endobj
-28 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /XVZVYO+LMRoman10-Regular /DescendantFonts [ 52 0 R ] /ToUnicode 51 0 R >>
+27 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /XVZVYO+LMRoman10-Regular /DescendantFonts [ 51 0 R ] /ToUnicode 50 0 R >>
+endobj
+51 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /XVZVYO+LMRoman10-Regular /FontDescriptor 47 0 R /W 46 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 52 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /XVZVYO+LMRoman10-Regular /FontDescriptor 48 0 R /W 47 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-53 0 obj
 [693.3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 406.4 0 0 0 249.6 0 0 249.6 0 0 0 0 0 0 0 354.1 ]
 endobj
-55 0 obj
+54 0 obj
 << /Length1 1387 /Length2 5943 /Length3 0 /Length 7330 >>       
 [BINARY STREAM]
 endobj
-54 0 obj
-<< /Type /FontDescriptor /FontName /SDXKYB+CMR10 /Flags 4 /FontBBox [ -40 -250 1009 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 69 /XHeight 431 /CharSet( /one) /FontFile 55 0 R >>
+53 0 obj
+<< /Type /FontDescriptor /FontName /SDXKYB+CMR10 /Flags 4 /FontBBox [ -40 -250 1009 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 69 /XHeight 431 /CharSet( /one) /FontFile 54 0 R >>
 endobj
-57 0 obj
+56 0 obj
 << /Length1 1599 /Length2 8302 /Length3 0 /Length 9901 >>       
 [BINARY STREAM]
 endobj
-56 0 obj
-<< /Type /FontDescriptor /FontName /VBFROV+CMR12 /Flags 4 /FontBBox [ -34 -251 988 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 65 /XHeight 431 /CharSet( /A /B /M /a /comma /h /o /one /r /six /t /two /u /y /zero) /FontFile 57 0 R >>
+55 0 obj
+<< /Type /FontDescriptor /FontName /VBFROV+CMR12 /Flags 4 /FontBBox [ -34 -251 988 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 65 /XHeight 431 /CharSet( /A /B /M /a /comma /h /o /one /r /six /t /two /u /y /zero) /FontFile 56 0 R >>
 endobj
-59 0 obj
+58 0 obj
 << /Length1 1444 /Length2 6633 /Length3 0 /Length 8077 >>       
 [BINARY STREAM]
 endobj
-58 0 obj
-<< /Type /FontDescriptor /FontName /PXLAWO+CMR17 /Flags 4 /FontBBox [ -33 -250 945 749 ] /Ascent 694 /CapHeight 683 /Descent -195 /ItalicAngle 0 /StemV 53 /XHeight 430 /CharSet( /A /e /i /l /t) /FontFile 59 0 R >>
+57 0 obj
+<< /Type /FontDescriptor /FontName /PXLAWO+CMR17 /Flags 4 /FontBBox [ -33 -250 945 749 ] /Ascent 694 /CapHeight 683 /Descent -195 /ItalicAngle 0 /StemV 53 /XHeight 430 /CharSet( /A /e /i /l /t) /FontFile 58 0 R >>
 endobj
-61 0 obj
+60 0 obj
 << /Length1 1422 /Length2 6395 /Length3 0 /Length 7817 >>       
 [BINARY STREAM]
 endobj
-60 0 obj
-<< /Type /FontDescriptor /FontName /FRWMVG+CMR8 /Flags 4 /FontBBox [ -36 -250 1070 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 76 /XHeight 431 /CharSet( /N /e /o /t) /FontFile 61 0 R >>
+59 0 obj
+<< /Type /FontDescriptor /FontName /FRWMVG+CMR8 /Flags 4 /FontBBox [ -36 -250 1070 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 76 /XHeight 431 /CharSet( /N /e /o /t) /FontFile 60 0 R >>
 endobj
-63 0 obj
+62 0 obj
 << /Length1 1511 /Length2 8440 /Length3 0 /Length 9951 >>       
 [BINARY STREAM]
 endobj
-62 0 obj
-<< /Type /FontDescriptor /FontName /BSXKTW+CMR9 /Flags 4 /FontBBox [ -39 -250 1036 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 74 /XHeight 431 /CharSet( /a /b /e /h /i /l /s /t /u /w) /FontFile 63 0 R >>
+61 0 obj
+<< /Type /FontDescriptor /FontName /BSXKTW+CMR9 /Flags 4 /FontBBox [ -39 -250 1036 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 74 /XHeight 431 /CharSet( /a /b /e /h /i /l /s /t /u /w) /FontFile 62 0 R >>
 endobj
-65 0 obj
+64 0 obj
 << /Length1 721 /Length2 1124 /Length3 0 /Length 1845 >>       
 [BINARY STREAM]
 endobj
-64 0 obj
-<< /Type /FontDescriptor /FontName /YIGRIT+SFRM0600 /Flags 4 /FontBBox [ -210 -320 1719 944 ] /Ascent 0 /CapHeight 0 /Descent 0 /ItalicAngle 0 /StemV 50 /XHeight 430 /CharSet( /asteriskmath) /FontFile 65 0 R >>
+63 0 obj
+<< /Type /FontDescriptor /FontName /YIGRIT+SFRM0600 /Flags 4 /FontBBox [ -210 -320 1719 944 ] /Ascent 0 /CapHeight 0 /Descent 0 /ItalicAngle 0 /StemV 50 /XHeight 430 /CharSet( /asteriskmath) /FontFile 64 0 R >>
 endobj
-67 0 obj
+66 0 obj
 << /Length1 721 /Length2 5420 /Length3 0 /Length 6141 >>       
 [BINARY STREAM]
 endobj
-66 0 obj
-<< /Type /FontDescriptor /FontName /RYQARY+SFRM1200 /Flags 4 /FontBBox [ -185 -320 1420 942 ] /Ascent 0 /CapHeight 0 /Descent 0 /ItalicAngle 0 /StemV 50 /XHeight 430 /CharSet( /asteriskmath) /FontFile 67 0 R >>
+65 0 obj
+<< /Type /FontDescriptor /FontName /RYQARY+SFRM1200 /Flags 4 /FontBBox [ -185 -320 1420 942 ] /Ascent 0 /CapHeight 0 /Descent 0 /ItalicAngle 0 /StemV 50 /XHeight 430 /CharSet( /asteriskmath) /FontFile 66 0 R >>
 endobj
-42 0 obj
+41 0 obj
 << /Type /Encoding /Differences [ 42 /asteriskmath ] >>
 endobj
-68 0 obj
+67 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -672,10 +669,10 @@ end
 %%EOF
 endstream
 endobj
-34 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /SDXKYB+CMR10 /FontDescriptor 54 0 R /FirstChar 49 /LastChar 49 /Widths 40 0 R /ToUnicode 68 0 R >>
+33 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /SDXKYB+CMR10 /FontDescriptor 53 0 R /FirstChar 49 /LastChar 49 /Widths 39 0 R /ToUnicode 67 0 R >>
 endobj
-69 0 obj
+68 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -795,10 +792,10 @@ end
 %%EOF
 endstream
 endobj
-31 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /VBFROV+CMR12 /FontDescriptor 56 0 R /FirstChar 44 /LastChar 121 /Widths 44 0 R /ToUnicode 69 0 R >>
+30 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /VBFROV+CMR12 /FontDescriptor 55 0 R /FirstChar 44 /LastChar 121 /Widths 43 0 R /ToUnicode 68 0 R >>
 endobj
-70 0 obj
+69 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -918,10 +915,10 @@ end
 %%EOF
 endstream
 endobj
-27 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /PXLAWO+CMR17 /FontDescriptor 58 0 R /FirstChar 65 /LastChar 116 /Widths 53 0 R /ToUnicode 70 0 R >>
+26 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /PXLAWO+CMR17 /FontDescriptor 57 0 R /FirstChar 65 /LastChar 116 /Widths 52 0 R /ToUnicode 69 0 R >>
 endobj
-71 0 obj
+70 0 obj
 << /Length 1719 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -1041,10 +1038,10 @@ end
 %%EOF
 endstream
 endobj
-33 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /FRWMVG+CMR8 /FontDescriptor 60 0 R /FirstChar 78 /LastChar 116 /Widths 41 0 R /ToUnicode 71 0 R >>
+32 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /FRWMVG+CMR8 /FontDescriptor 59 0 R /FirstChar 78 /LastChar 116 /Widths 40 0 R /ToUnicode 70 0 R >>
 endobj
-72 0 obj
+71 0 obj
 << /Length 1719 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -1164,8 +1161,119 @@ end
 %%EOF
 endstream
 endobj
-30 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /BSXKTW+CMR9 /FontDescriptor 62 0 R /FirstChar 97 /LastChar 119 /Widths 45 0 R /ToUnicode 72 0 R >>
+29 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /BSXKTW+CMR9 /FontDescriptor 61 0 R /FirstChar 97 /LastChar 119 /Widths 44 0 R /ToUnicode 71 0 R >>
+endobj
+72 0 obj
+<< /Length 1523 >>       
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: ProcSet (CIDInit)
+%%IncludeResource: ProcSet (CIDInit)
+%%BeginResource: CMap (TeX-cm-super-ts1-0)
+%%Title: (TeX-cm-super-ts1-0 TeX cm-super-ts1 0)
+%%Version: 1.000
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<< /Registry (TeX)
+/Ordering (cm-super-ts1)
+/Supplement 0
+>> def
+/CMapName /TeX-cm-super-ts1-0 def
+/CMapType 2 def
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+7 beginbfrange
+<30> <39> <0030>
+<84> <85> <2020>
+<A0> <A1> <2045>
+<A2> <AA> <00A2>
+<AE> <B7> <00AE>
+<B9> <BA> <00B9>
+<BC> <BE> <00BC>
+endbfrange
+66 beginbfchar
+<00> <0060>
+<01> <00B4>
+<04> <00A8>
+<05> <02DD>
+<07> <02C7>
+<09> <00AF>
+<0B> <00B8>
+<0C> <02DB>
+<0D> <201A>
+<12> <201E>
+<16> <F6DE>
+<17> <200C>
+<18> <2190>
+<19> <2192>
+<1F> <200C>
+<20> <2422>
+<24> <0024>
+<27> <0027>
+<2A> <2217>
+<2C> <002C>
+<2E> <002E>
+<2F> <2044>
+<3C> <2329>
+<3D> <2212>
+<3E> <232A>
+<4D> <2127>
+<4F> <25CB>
+<57> <2126>
+<5B> <301A>
+<5D> <301B>
+<5E> <2191>
+<5F> <2193>
+<60> <0060>
+<6E> <266A>
+<80> <02D8>
+<81> <02C7>
+<82> <02DD>
+<83> <00A0030F>
+<86> <2016>
+<87> <2030>
+<88> <2022>
+<89> <2103>
+<8A> <0024>
+<8B> <00A2>
+<8C> <0192>
+<8D> <20A1>
+<8E> <20A9>
+<8F> <20A6>
+<92> <20A4>
+<94> <203D>
+<96> <20AB>
+<97> <2122>
+<98> <2031>
+<99> <00B6>
+<9A> <0E3F>
+<9B> <2116>
+<9D> <212E>
+<9E> <25E6>
+<9F> <2120>
+<AC> <00AC>
+<AD> <2117>
+<B8> <203B>
+<BB> <221A>
+<BF> <20AC>
+<D6> <00D7>
+<F6> <00F7>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+31 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /YIGRIT+SFRM0600 /FontDescriptor 63 0 R /FirstChar 42 /LastChar 42 /Widths 42 0 R /Encoding 41 0 R /ToUnicode 72 0 R >>
 endobj
 73 0 obj
 << /Length 1523 >>       
@@ -1275,210 +1383,98 @@ end
 %%EOF
 endstream
 endobj
-32 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /YIGRIT+SFRM0600 /FontDescriptor 64 0 R /FirstChar 42 /LastChar 42 /Widths 43 0 R /Encoding 42 0 R /ToUnicode 73 0 R >>
+28 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /RYQARY+SFRM1200 /FontDescriptor 65 0 R /FirstChar 42 /LastChar 42 /Widths 45 0 R /Encoding 41 0 R /ToUnicode 73 0 R >>
+endobj
+34 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 24 0 R ] >>
 endobj
 74 0 obj
-<< /Length 1523 >>       
-stream
-%!PS-Adobe-3.0 Resource-CMap
-%%DocumentNeededResources: ProcSet (CIDInit)
-%%IncludeResource: ProcSet (CIDInit)
-%%BeginResource: CMap (TeX-cm-super-ts1-0)
-%%Title: (TeX-cm-super-ts1-0 TeX cm-super-ts1 0)
-%%Version: 1.000
-%%EndComments
-/CIDInit /ProcSet findresource begin
-12 dict begin
-begincmap
-/CIDSystemInfo
-<< /Registry (TeX)
-/Ordering (cm-super-ts1)
-/Supplement 0
->> def
-/CMapName /TeX-cm-super-ts1-0 def
-/CMapType 2 def
-1 begincodespacerange
-<00> <FF>
-endcodespacerange
-7 beginbfrange
-<30> <39> <0030>
-<84> <85> <2020>
-<A0> <A1> <2045>
-<A2> <AA> <00A2>
-<AE> <B7> <00AE>
-<B9> <BA> <00B9>
-<BC> <BE> <00BC>
-endbfrange
-66 beginbfchar
-<00> <0060>
-<01> <00B4>
-<04> <00A8>
-<05> <02DD>
-<07> <02C7>
-<09> <00AF>
-<0B> <00B8>
-<0C> <02DB>
-<0D> <201A>
-<12> <201E>
-<16> <F6DE>
-<17> <200C>
-<18> <2190>
-<19> <2192>
-<1F> <200C>
-<20> <2422>
-<24> <0024>
-<27> <0027>
-<2A> <2217>
-<2C> <002C>
-<2E> <002E>
-<2F> <2044>
-<3C> <2329>
-<3D> <2212>
-<3E> <232A>
-<4D> <2127>
-<4F> <25CB>
-<57> <2126>
-<5B> <301A>
-<5D> <301B>
-<5E> <2191>
-<5F> <2193>
-<60> <0060>
-<6E> <266A>
-<80> <02D8>
-<81> <02C7>
-<82> <02DD>
-<83> <00A0030F>
-<86> <2016>
-<87> <2030>
-<88> <2022>
-<89> <2103>
-<8A> <0024>
-<8B> <00A2>
-<8C> <0192>
-<8D> <20A1>
-<8E> <20A9>
-<8F> <20A6>
-<92> <20A4>
-<94> <203D>
-<96> <20AB>
-<97> <2122>
-<98> <2031>
-<99> <00B6>
-<9A> <0E3F>
-<9B> <2116>
-<9D> <212E>
-<9E> <25E6>
-<9F> <2120>
-<AC> <00AC>
-<AD> <2117>
-<B8> <203B>
-<BB> <221A>
-<BF> <20AC>
-<D6> <00D7>
-<F6> <00F7>
-endbfchar
-endcmap
-CMapName currentdict /CMap defineresource pop
-end
-end
-%%EndResource
-%%EOF
-endstream
-endobj
-29 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /RYQARY+SFRM1200 /FontDescriptor 66 0 R /FirstChar 42 /LastChar 42 /Widths 46 0 R /Encoding 42 0 R /ToUnicode 74 0 R >>
-endobj
-35 0 obj
-<< /Type /Pages  /Count 1 /Kids [ 25 0 R ] >>
+<< /Type /Catalog /Pages 34 0 R /MarkInfo 35 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 22 0 R >>
 endobj
 75 0 obj
-<< /Type /Catalog /Pages 35 0 R /MarkInfo 36 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 23 0 R >>
-endobj
-76 0 obj
 << /Producer (LuaTeX)/Creator (TeX)/Title <FEFF00410020007400690074006C00650020007700690074006800200047007200FC00DF0065>/Author <FEFF0061007500740068006F0072002000410020002C0061007500740068006F007200200042>/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 77
+0 76
 0000000002 65535 f 
 0000014191 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000016984 00000 n 
+0000016880 00000 n 
 0000014274 00000 n 
-0000014678 00000 n 
+0000014662 00000 n 
 0000000000 00000 f 
-0000015458 00000 n 
-0000015552 00000 n 
-0000015628 00000 n 
-0000015704 00000 n 
-0000015814 00000 n 
-0000015947 00000 n 
-0000016082 00000 n 
-0000016205 00000 n 
-0000016327 00000 n 
-0000016449 00000 n 
-0000016560 00000 n 
-0000016652 00000 n 
-0000016740 00000 n 
-0000016868 00000 n 
+0000015442 00000 n 
+0000015536 00000 n 
+0000015612 00000 n 
+0000015688 00000 n 
+0000015798 00000 n 
+0000015931 00000 n 
+0000016066 00000 n 
+0000016189 00000 n 
+0000016311 00000 n 
+0000016433 00000 n 
+0000016544 00000 n 
+0000016632 00000 n 
+0000016760 00000 n 
 0000000020 00000 n 
 0000014020 00000 n 
 0000013885 00000 n 
 0000012089 00000 n 
-0000078934 00000 n 
-0000019295 00000 n 
-0000086307 00000 n 
-0000082807 00000 n 
-0000076992 00000 n 
-0000084547 00000 n 
-0000080871 00000 n 
-0000075051 00000 n 
-0000086484 00000 n 
+0000078830 00000 n 
+0000019191 00000 n 
+0000086203 00000 n 
+0000082703 00000 n 
+0000076888 00000 n 
+0000084443 00000 n 
+0000080767 00000 n 
+0000074947 00000 n 
+0000086380 00000 n 
 0000014238 00000 n 
 0000014359 00000 n 
-0000014641 00000 n 
-0000015257 00000 n 
-0000017102 00000 n 
-0000017125 00000 n 
-0000073195 00000 n 
-0000017238 00000 n 
-0000017261 00000 n 
-0000017488 00000 n 
-0000017587 00000 n 
-0000017612 00000 n 
-0000018307 00000 n 
-0000017644 00000 n 
-0000017717 00000 n 
-0000018543 00000 n 
-0000019449 00000 n 
-0000019649 00000 n 
-0000027221 00000 n 
-0000019792 00000 n 
-0000037442 00000 n 
-0000027442 00000 n 
-0000045891 00000 n 
-0000037715 00000 n 
-0000054037 00000 n 
-0000046121 00000 n 
-0000064314 00000 n 
-0000054264 00000 n 
-0000066502 00000 n 
-0000064559 00000 n 
-0000072968 00000 n 
-0000066729 00000 n 
-0000073267 00000 n 
-0000075208 00000 n 
-0000077150 00000 n 
-0000079092 00000 n 
-0000081028 00000 n 
-0000082964 00000 n 
-0000084724 00000 n 
-0000086546 00000 n 
-0000086661 00000 n 
+0000014625 00000 n 
+0000015241 00000 n 
+0000016998 00000 n 
+0000017021 00000 n 
+0000073091 00000 n 
+0000017134 00000 n 
+0000017157 00000 n 
+0000017384 00000 n 
+0000017483 00000 n 
+0000017508 00000 n 
+0000018203 00000 n 
+0000017540 00000 n 
+0000017613 00000 n 
+0000018439 00000 n 
+0000019345 00000 n 
+0000019545 00000 n 
+0000027117 00000 n 
+0000019688 00000 n 
+0000037338 00000 n 
+0000027338 00000 n 
+0000045787 00000 n 
+0000037611 00000 n 
+0000053933 00000 n 
+0000046017 00000 n 
+0000064210 00000 n 
+0000054160 00000 n 
+0000066398 00000 n 
+0000064455 00000 n 
+0000072864 00000 n 
+0000066625 00000 n 
+0000073163 00000 n 
+0000075104 00000 n 
+0000077046 00000 n 
+0000078988 00000 n 
+0000080924 00000 n 
+0000082860 00000 n 
+0000084620 00000 n 
+0000086442 00000 n 
+0000086557 00000 n 
 trailer
-<< /Size 77 /Root 75 0 R /Info 76 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 76 /Root 74 0 R /Info 75 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-86964
+86860
 %%EOF

--- a/required/latex-lab/testfiles-title/title-004.tpf
+++ b/required/latex-lab/testfiles-title/title-004.tpf
@@ -1,6 +1,6 @@
 %PDF-1.5
 %ÐÔÅØ
-24 0 obj
+23 0 obj
 <<
 /Type /Metadata /Subtype /XML
 /Length 11977     
@@ -248,7 +248,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-26 0 obj
+25 0 obj
 <<
 /Length 1269      
 >>
@@ -313,40 +313,40 @@ endobj
 14 0 obj
 <<
 /Type /Page
-/Contents 26 0 R
-/Resources 25 0 R
+/Contents 25 0 R
+/Resources 24 0 R
 /MediaBox [0 0 612 792]
 /Tabs /S /StructParents 0 
-/Parent 35 0 R
+/Parent 34 0 R
 >>
 endobj
-25 0 obj
+24 0 obj
 <<
 /ExtGState 1 0 R 
-/Font << /F40 27 0 R /F64 28 0 R /F50 29 0 R /F51 30 0 R /F49 31 0 R /F63 32 0 R /F60 33 0 R /F39 34 0 R >>
+/Font << /F40 26 0 R /F64 27 0 R /F50 28 0 R /F51 29 0 R /F49 30 0 R /F63 31 0 R /F60 32 0 R /F39 33 0 R >>
 /ProcSet [ /PDF /Text ]
 >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-36 0 obj
+35 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 13 0 R 15 0 R 13 0 R 16 0 R 17 0 R 18 0 R 22 0 R 23 0 R 22 0 R 22 0 R 22 0 R ]
+<< /Nums [0 [ 13 0 R 15 0 R 13 0 R 16 0 R 17 0 R 18 0 R 21 0 R 22 0 R 21 0 R 21 0 R 21 0 R ]
 ] >>
 endobj
-37 0 obj
-<< /Limits [(ID.002) (ID.015)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 15 0 R (ID.008) 16 0 R (ID.009) 17 0 R (ID.010) 18 0 R (ID.011) 19 0 R (ID.012) 20 0 R (ID.013) 21 0 R (ID.014) 22 0 R (ID.015) 23 0 R ] >>
+36 0 obj
+<< /Limits [(ID.002) (ID.014)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 15 0 R (ID.008) 16 0 R (ID.009) 17 0 R (ID.010) 18 0 R (ID.011) 19 0 R (ID.012) 20 0 R (ID.013) 21 0 R (ID.014) 22 0 R ] >>
 endobj
-38 0 obj
-<< /Kids [37 0 R] >>
+37 0 obj
+<< /Kids [36 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
 endobj
-39 0 obj
+38 0 obj
 << /center <</O/Layout/TextAlign/Center>>
 /justify <</O/Layout/TextAlign/Justify>>
 /TH-both <</O/Table/Scope/Both>>
@@ -382,48 +382,45 @@ endobj
 <<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 14 0 R/MCID 5>> /ID (ID.010) >>
 endobj
 19 0 obj
-<<  /Type /StructElem /S /footnote /P 9 0 R /Ref [ 15 0 R ] /K [20 0 R 21 0 R] /ID (ID.011) >>
+<<  /Type /StructElem /S /footnote /P 9 0 R /Ref [ 15 0 R ] /K [22 0 R 20 0 R] /ID (ID.011) >>
 endobj
 20 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 19 0 R /K 23 0 R /ID (ID.012) >>
+<<  /Type /StructElem /S /text-unit /P 19 0 R /K 21 0 R /ID (ID.012) >>
 endobj
 21 0 obj
-<<  /Type /StructElem /S /text-unit /P 19 0 R /K 22 0 R /ID (ID.013) >>
+<<  /Type /StructElem /C /justify /S /text /P 20 0 R /K [<</Type /MCR /Pg 14 0 R/MCID 6>> <</Type /MCR /Pg 14 0 R/MCID 8>> <</Type /MCR /Pg 14 0 R/MCID 9>> <</Type /MCR /Pg 14 0 R/MCID 10>>] /ID (ID.013) >>
 endobj
 22 0 obj
-<<  /Type /StructElem /C /justify /S /text /P 21 0 R /K [<</Type /MCR /Pg 14 0 R/MCID 6>> <</Type /MCR /Pg 14 0 R/MCID 8>> <</Type /MCR /Pg 14 0 R/MCID 9>> <</Type /MCR /Pg 14 0 R/MCID 10>>] /ID (ID.014) >>
-endobj
-23 0 obj
-<<  /Type /StructElem /S /NonStruct /P 20 0 R /K <</Type /MCR /Pg 14 0 R/MCID 7>> /ID (ID.015) >>
+<<  /Type /StructElem /S /footnotelabel /P 19 0 R /K <</Type /MCR /Pg 14 0 R/MCID 7>> /ID (ID.014) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 38 0 R /ClassMap 39 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
+<<  /Type /StructTreeRoot /IDTree 37 0 R /ClassMap 38 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
 endobj
-41 0 obj
+40 0 obj
 [499.9]
 endobj
-42 0 obj
+41 0 obj
 [795.6 826.2 722.4 826.2 781.4 590.1 767.2 795.6 795.6 1090.7 795.6 795.6 649.1 295.1 531.1 295.1 649.1 826.2 295.1 531.1 590.1 472.1 590.1 472.1 324.6 531.1 590.1 295.1 324.6 560.6 295.1 885.2 590.1 531.1 590.1 560.6 414 419 413.1]
 endobj
-44 0 obj
+43 0 obj
 [611]
 endobj
-45 0 obj
+44 0 obj
 [271.9 326.3 271.9 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 271.9 271.9 761.4 761.4 761.4 462.3 761.4 733.8 693.2 707 747.6 666 638.8 768.1 733.8 353.2 502.9 761 611.7 897 733.8 761.4 666 761.4 720.4 543.8 707 733.8 733.8 1005.8 733.8 733.8 598.2 271.9 489.5 271.9 598.2 761.4 271.9 489.5 543.8 435.1 543.8 435.1 299.1 489.5 543.8 271.9 299.1 516.7 271.9 815.8 543.8 489.5 543.8 516.7 380.7 386.1 380.7 543.8 516.7 707 516.7 516.7]
 endobj
-46 0 obj
+45 0 obj
 [513.8 570.8 456.7 570.8 457.1 314 513.8 570.8 285.4 314 542.3 285.4 856.3 570.8 513.8 570.8 542.3 401.9 405.3 399.6 570.8 542.3 742.1]
 endobj
-47 0 obj
+46 0 obj
 [489.5]
 endobj
-48 0 obj
+47 0 obj
 [333]
 endobj
-49 0 obj
+48 0 obj
 [704.4 665.4 678.7 717.7 639.3 613.2 737.3 704.4 338.8 482.6 730.5 587.1 861.1 704.4 730.9 639.3 730.9 691.5 522 678.7 704.4 704.4 965.6 704.4 704.4 574.2 260.8 469.8 260.8 574.2 730.9 260.8 469.8 522 417.5 522 417.5 287 469.8 522 260.8 287 495.9 260.8 783.1 522 469.8 522 495.9 365.3 370.5 365.3]
 endobj
-50 0 obj
+49 0 obj
 <<
 /Length1 1144
 /Length2 1422
@@ -432,7 +429,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-51 0 obj
+50 0 obj
 <<
 /Type /FontDescriptor
 /FontName /MUQHVU+PdfTeX-Space
@@ -445,10 +442,10 @@ endobj
 /StemV 0
 /XHeight 500
 /CharSet (/space)
-/FontFile 50 0 R
+/FontFile 49 0 R
 >>
 endobj
-52 0 obj
+51 0 obj
 <<
 /Length1 721
 /Length2 1124
@@ -457,7 +454,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-53 0 obj
+52 0 obj
 <<
 /Type /FontDescriptor
 /FontName /YIGRIT+SFRM0600
@@ -470,10 +467,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/asteriskmath)
-/FontFile 52 0 R
+/FontFile 51 0 R
 >>
 endobj
-54 0 obj
+53 0 obj
 <<
 /Length1 721
 /Length2 16768
@@ -482,7 +479,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-55 0 obj
+54 0 obj
 <<
 /Type /FontDescriptor
 /FontName /MMWKYX+SFRM0800
@@ -495,10 +492,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/N/e/o/t)
-/FontFile 54 0 R
+/FontFile 53 0 R
 >>
 endobj
-56 0 obj
+55 0 obj
 <<
 /Length1 721
 /Length2 13820
@@ -507,7 +504,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-57 0 obj
+56 0 obj
 <<
 /Type /FontDescriptor
 /FontName /WLWXUF+SFRM0900
@@ -520,10 +517,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/a/b/e/h/i/l/s/t/u/w)
-/FontFile 56 0 R
+/FontFile 55 0 R
 >>
 endobj
-58 0 obj
+57 0 obj
 <<
 /Length1 721
 /Length2 981
@@ -532,7 +529,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-59 0 obj
+58 0 obj
 <<
 /Type /FontDescriptor
 /FontName /VZMLCI+SFRM1000
@@ -545,10 +542,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/one)
-/FontFile 58 0 R
+/FontFile 57 0 R
 >>
 endobj
-60 0 obj
+59 0 obj
 <<
 /Length1 721
 /Length2 12358
@@ -557,7 +554,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-61 0 obj
+60 0 obj
 <<
 /Type /FontDescriptor
 /FontName /VVUPRB+SFRM1200
@@ -570,10 +567,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/A/B/M/a/asteriskmath/comma/h/o/one/r/six/t/two/u/y/zero)
-/FontFile 60 0 R
+/FontFile 59 0 R
 >>
 endobj
-62 0 obj
+61 0 obj
 <<
 /Length1 721
 /Length2 6947
@@ -582,7 +579,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-63 0 obj
+62 0 obj
 <<
 /Type /FontDescriptor
 /FontName /EMNKTC+SFRM1728
@@ -595,22 +592,22 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/A/e/i/l/t)
-/FontFile 62 0 R
+/FontFile 61 0 R
 >>
 endobj
-40 0 obj
+39 0 obj
 <<
 /Type /Encoding
 /Differences [44/comma 48/zero/one/two 54/six 65/A/B 77/M/N 97/a/b 101/e 104/h/i 108/l 111/o 114/r/s/t/u 119/w 121/y]
 >>
 endobj
-43 0 obj
+42 0 obj
 <<
 /Type /Encoding
 /Differences [42/asteriskmath]
 >>
 endobj
-64 0 obj
+63 0 obj
 <<
 /Length 2030      
 >>
@@ -754,20 +751,20 @@ end
 %%EOF
 endstream
 endobj
-33 0 obj
+32 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /MMWKYX+SFRM0800
-/FontDescriptor 55 0 R
+/FontDescriptor 54 0 R
 /FirstChar 78
 /LastChar 116
-/Widths 42 0 R
-/Encoding 40 0 R
-/ToUnicode 64 0 R
+/Widths 41 0 R
+/Encoding 39 0 R
+/ToUnicode 63 0 R
 >>
 endobj
-65 0 obj
+64 0 obj
 <<
 /Length 2030      
 >>
@@ -911,20 +908,20 @@ end
 %%EOF
 endstream
 endobj
-30 0 obj
+29 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /WLWXUF+SFRM0900
-/FontDescriptor 57 0 R
+/FontDescriptor 56 0 R
 /FirstChar 97
 /LastChar 119
-/Widths 46 0 R
-/Encoding 40 0 R
-/ToUnicode 65 0 R
+/Widths 45 0 R
+/Encoding 39 0 R
+/ToUnicode 64 0 R
 >>
 endobj
-66 0 obj
+65 0 obj
 <<
 /Length 2030      
 >>
@@ -1068,20 +1065,20 @@ end
 %%EOF
 endstream
 endobj
-34 0 obj
+33 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /VZMLCI+SFRM1000
-/FontDescriptor 59 0 R
+/FontDescriptor 58 0 R
 /FirstChar 49
 /LastChar 49
-/Widths 41 0 R
-/Encoding 40 0 R
-/ToUnicode 66 0 R
+/Widths 40 0 R
+/Encoding 39 0 R
+/ToUnicode 65 0 R
 >>
 endobj
-67 0 obj
+66 0 obj
 <<
 /Length 2030      
 >>
@@ -1225,20 +1222,20 @@ end
 %%EOF
 endstream
 endobj
-31 0 obj
+30 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /VVUPRB+SFRM1200
-/FontDescriptor 61 0 R
+/FontDescriptor 60 0 R
 /FirstChar 44
 /LastChar 121
-/Widths 45 0 R
-/Encoding 40 0 R
-/ToUnicode 67 0 R
+/Widths 44 0 R
+/Encoding 39 0 R
+/ToUnicode 66 0 R
 >>
 endobj
-68 0 obj
+67 0 obj
 <<
 /Length 2030      
 >>
@@ -1382,20 +1379,20 @@ end
 %%EOF
 endstream
 endobj
-27 0 obj
+26 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /EMNKTC+SFRM1728
-/FontDescriptor 63 0 R
+/FontDescriptor 62 0 R
 /FirstChar 65
 /LastChar 116
-/Widths 49 0 R
-/Encoding 40 0 R
-/ToUnicode 68 0 R
+/Widths 48 0 R
+/Encoding 39 0 R
+/ToUnicode 67 0 R
 >>
 endobj
-69 0 obj
+68 0 obj
 <<
 /Length 654       
 >>
@@ -1433,19 +1430,19 @@ end
 %%EOF
 endstream
 endobj
-28 0 obj
+27 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /MUQHVU+PdfTeX-Space
-/FontDescriptor 51 0 R
+/FontDescriptor 50 0 R
 /FirstChar 32
 /LastChar 32
-/Widths 48 0 R
-/ToUnicode 69 0 R
+/Widths 47 0 R
+/ToUnicode 68 0 R
 >>
 endobj
-70 0 obj
+69 0 obj
 <<
 /Length 1568      
 >>
@@ -1555,20 +1552,20 @@ end
 %%EOF
 endstream
 endobj
-32 0 obj
+31 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /YIGRIT+SFRM0600
-/FontDescriptor 53 0 R
+/FontDescriptor 52 0 R
 /FirstChar 42
 /LastChar 42
-/Widths 44 0 R
-/Encoding 43 0 R
-/ToUnicode 70 0 R
+/Widths 43 0 R
+/Encoding 42 0 R
+/ToUnicode 69 0 R
 >>
 endobj
-71 0 obj
+70 0 obj
 <<
 /Length 1568      
 >>
@@ -1678,120 +1675,119 @@ end
 %%EOF
 endstream
 endobj
-29 0 obj
+28 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /VVUPRB+SFRM1200
-/FontDescriptor 61 0 R
+/FontDescriptor 60 0 R
 /FirstChar 42
 /LastChar 42
-/Widths 47 0 R
-/Encoding 43 0 R
-/ToUnicode 71 0 R
+/Widths 46 0 R
+/Encoding 42 0 R
+/ToUnicode 70 0 R
 >>
 endobj
-35 0 obj
+34 0 obj
 <<
 /Type /Pages
 /Count 1
 /Kids [14 0 R]
 >>
 endobj
-72 0 obj
+71 0 obj
 <<
 /Type /Catalog
-/Pages 35 0 R
-/MarkInfo 36 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 24 0 R
+/Pages 34 0 R
+/MarkInfo 35 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 23 0 R
 >>
 endobj
-73 0 obj
+72 0 obj
 <<
 /Producer (pdfTeX)/Creator (TeX)/Title <FEFF00410020007400690074006C00650020007700690074006800200047007200FC00DF0065>/Author <FEFF0061007500740068006F0072002000410020002C0061007500740068006F007200200042>/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z)
 /Trapped /False
 >>
 endobj
 xref
-0 74
+0 73
 0000000002 65535 f 
 0000013716 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000016652 00000 n 
+0000016548 00000 n 
 0000013799 00000 n 
-0000014231 00000 n 
+0000014215 00000 n 
 0000000000 00000 f 
-0000015011 00000 n 
-0000015105 00000 n 
-0000015181 00000 n 
-0000015257 00000 n 
-0000015367 00000 n 
+0000014995 00000 n 
+0000015089 00000 n 
+0000015165 00000 n 
+0000015241 00000 n 
+0000015351 00000 n 
 0000013409 00000 n 
-0000015530 00000 n 
-0000015663 00000 n 
-0000015784 00000 n 
-0000015904 00000 n 
-0000016024 00000 n 
-0000016135 00000 n 
-0000016227 00000 n 
-0000016315 00000 n 
-0000016538 00000 n 
+0000015514 00000 n 
+0000015647 00000 n 
+0000015768 00000 n 
+0000015888 00000 n 
+0000016008 00000 n 
+0000016119 00000 n 
+0000016207 00000 n 
+0000016430 00000 n 
 0000000015 00000 n 
 0000013544 00000 n 
 0000012081 00000 n 
-0000090639 00000 n 
-0000091530 00000 n 
-0000095125 00000 n 
-0000083839 00000 n 
-0000088372 00000 n 
-0000093321 00000 n 
-0000081572 00000 n 
-0000086106 00000 n 
-0000095302 00000 n 
+0000090535 00000 n 
+0000091426 00000 n 
+0000095021 00000 n 
+0000083735 00000 n 
+0000088268 00000 n 
+0000093217 00000 n 
+0000081468 00000 n 
+0000086002 00000 n 
+0000095198 00000 n 
 0000013763 00000 n 
 0000013912 00000 n 
-0000014194 00000 n 
-0000014810 00000 n 
-0000079258 00000 n 
-0000016770 00000 n 
-0000016794 00000 n 
-0000079414 00000 n 
-0000017043 00000 n 
-0000017065 00000 n 
-0000017538 00000 n 
-0000017690 00000 n 
-0000017714 00000 n 
-0000017736 00000 n 
-0000018050 00000 n 
-0000020714 00000 n 
-0000020932 00000 n 
-0000022874 00000 n 
-0000023099 00000 n 
-0000040686 00000 n 
-0000040913 00000 n 
-0000055552 00000 n 
-0000055791 00000 n 
-0000057589 00000 n 
-0000057812 00000 n 
-0000070989 00000 n 
-0000071264 00000 n 
-0000079029 00000 n 
-0000079483 00000 n 
-0000081750 00000 n 
-0000084017 00000 n 
-0000086283 00000 n 
-0000088550 00000 n 
-0000090817 00000 n 
-0000091694 00000 n 
-0000093498 00000 n 
-0000095361 00000 n 
-0000095476 00000 n 
+0000014178 00000 n 
+0000014794 00000 n 
+0000079154 00000 n 
+0000016666 00000 n 
+0000016690 00000 n 
+0000079310 00000 n 
+0000016939 00000 n 
+0000016961 00000 n 
+0000017434 00000 n 
+0000017586 00000 n 
+0000017610 00000 n 
+0000017632 00000 n 
+0000017946 00000 n 
+0000020610 00000 n 
+0000020828 00000 n 
+0000022770 00000 n 
+0000022995 00000 n 
+0000040582 00000 n 
+0000040809 00000 n 
+0000055448 00000 n 
+0000055687 00000 n 
+0000057485 00000 n 
+0000057708 00000 n 
+0000070885 00000 n 
+0000071160 00000 n 
+0000078925 00000 n 
+0000079379 00000 n 
+0000081646 00000 n 
+0000083913 00000 n 
+0000086179 00000 n 
+0000088446 00000 n 
+0000090713 00000 n 
+0000091590 00000 n 
+0000093394 00000 n 
+0000095257 00000 n 
+0000095372 00000 n 
 trailer
-<< /Size 74
-/Root 72 0 R
-/Info 73 0 R
+<< /Size 73
+/Root 71 0 R
+/Info 72 0 R
 /ID [<9BD18DF3359C1216B83ADB4AA401CC9A> <9BD18DF3359C1216B83ADB4AA401CC9A>] >>
 startxref
-95779
+95675
 %%EOF

--- a/required/latex-lab/testfiles-title/title-005.luatex.tpf
+++ b/required/latex-lab/testfiles-title/title-005.luatex.tpf
@@ -1,6 +1,6 @@
 %PDF-1.5
 %Ã’¡‘≈ÿ–ƒ∆
-23 0 obj
+22 0 obj
 << /Type /Metadata /Subtype /XML /Length 12012 >>      
 stream
 <?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
@@ -246,7 +246,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-26 0 obj
+25 0 obj
 << /Length 1736 >>       
 stream
 /opacity1 gs
@@ -346,32 +346,32 @@ EMC
 EMC
 endstream
 endobj
-25 0 obj
-<< /Type /Page /Contents 26 0 R /Resources 24 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 35 0 R >>
-endobj
 24 0 obj
-<< /ExtGState 1 0 R /Font << /F17 27 0 R /F15 28 0 R /F28 29 0 R /F29 30 0 R /F18 31 0 R /F42 32 0 R /F30 33 0 R /F16 34 0 R >> /ProcSet [ /PDF /Text ] >>
+<< /Type /Page /Contents 25 0 R /Resources 23 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 34 0 R >>
+endobj
+23 0 obj
+<< /ExtGState 1 0 R /Font << /F17 26 0 R /F15 27 0 R /F28 28 0 R /F29 29 0 R /F18 30 0 R /F42 31 0 R /F30 32 0 R /F16 33 0 R >> /ProcSet [ /PDF /Text ] >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-36 0 obj
+35 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 22 0 R 21 0 R] 
+<< /Nums [0 [ 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 21 0 R 20 0 R] 
 ] >>
 endobj
-37 0 obj
-<< /Limits [(ID.002) (ID.015)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 15 0 R (ID.009) 16 0 R (ID.010) 17 0 R (ID.011) 18 0 R (ID.012) 19 0 R (ID.013) 20 0 R (ID.014) 21 0 R (ID.015) 22 0 R ] >>
+36 0 obj
+<< /Limits [(ID.002) (ID.014)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 14 0 R (ID.008) 15 0 R (ID.009) 16 0 R (ID.010) 17 0 R (ID.011) 18 0 R (ID.012) 19 0 R (ID.013) 20 0 R (ID.014) 21 0 R ] >>
 endobj
-38 0 obj
-<< /Kids [37 0 R] >>
+37 0 obj
+<< /Kids [36 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
 endobj
-39 0 obj
+38 0 obj
 << /center <</O/Layout/TextAlign/Center>>
 /justify <</O/Layout/TextAlign/Justify>>
 /TH-both <</O/Table/Scope/Both>>
@@ -392,71 +392,68 @@ endobj
 <<  /Type /StructElem /S /text-unit /P 9 0 R /K [13 0 R 15 0 R 16 0 R 17 0 R] /ID (ID.005) >>
 endobj
 13 0 obj
-<<  /Type /StructElem /C /center /S /Title /P 12 0 R /K [<</Type /MCR /Pg 25 0 R /MCID 0>>  14 0 R ] /ID (ID.006) >>
+<<  /Type /StructElem /C /center /S /Title /P 12 0 R /K [<</Type /MCR /Pg 24 0 R /MCID 0>>  14 0 R ] /ID (ID.006) >>
 endobj
 14 0 obj
-<<  /Type /StructElem /S /footnotemark /P 13 0 R /Ref [ 18 0 R ] /K <</Type /MCR /Pg 25 0 R /MCID 1>>  /ID (ID.007) >>
+<<  /Type /StructElem /S /footnotemark /P 13 0 R /Ref [ 18 0 R ] /K <</Type /MCR /Pg 24 0 R /MCID 1>>  /ID (ID.007) >>
 endobj
 15 0 obj
-<<  /Type /StructElem /C /center /S /Title /P 12 0 R /K <</Type /MCR /Pg 25 0 R /MCID 2>>  /ID (ID.008) >>
+<<  /Type /StructElem /C /center /S /Title /P 12 0 R /K <</Type /MCR /Pg 24 0 R /MCID 2>>  /ID (ID.008) >>
 endobj
 16 0 obj
-<<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 25 0 R /MCID 3>>  /ID (ID.009) >>
+<<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 24 0 R /MCID 3>>  /ID (ID.009) >>
 endobj
 17 0 obj
-<<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 25 0 R /MCID 4>>  /ID (ID.010) >>
+<<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 24 0 R /MCID 4>>  /ID (ID.010) >>
 endobj
 18 0 obj
-<<  /Type /StructElem /S /footnote /P 9 0 R /Ref [ 14 0 R ] /K [19 0 R 20 0 R] /ID (ID.011) >>
+<<  /Type /StructElem /S /footnote /P 9 0 R /Ref [ 14 0 R ] /K [21 0 R 19 0 R] /ID (ID.011) >>
 endobj
 19 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 18 0 R /K 22 0 R /ID (ID.012) >>
+<<  /Type /StructElem /S /text-unit /P 18 0 R /K 20 0 R /ID (ID.012) >>
 endobj
 20 0 obj
-<<  /Type /StructElem /S /text-unit /P 18 0 R /K 21 0 R /ID (ID.013) >>
+<<  /Type /StructElem /C /justify /S /text /P 19 0 R /K [  <</Type /MCR /Pg 24 0 R /MCID 6>>  ] /ID (ID.013) >>
 endobj
 21 0 obj
-<<  /Type /StructElem /C /justify /S /text /P 20 0 R /K [  <</Type /MCR /Pg 25 0 R /MCID 6>>  ] /ID (ID.014) >>
-endobj
-22 0 obj
-<<  /Type /StructElem /S /NonStruct /P 19 0 R /K <</Type /MCR /Pg 25 0 R /MCID 5>>  /ID (ID.015) >>
+<<  /Type /StructElem /S /footnotelabel /P 18 0 R /K <</Type /MCR /Pg 24 0 R /MCID 5>>  /ID (ID.014) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 38 0 R /ClassMap 39 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
+<<  /Type /StructTreeRoot /IDTree 37 0 R /ClassMap 38 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
 endobj
-40 0 obj
+39 0 obj
 [500 ]
 endobj
-41 0 obj
+40 0 obj
 [795.8 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 472.2 0 0 0 0 0 0 0 0 0 531.3 0 0 0 0 413.2 ]
 endobj
-43 0 obj
+42 0 obj
 [611 ]
 endobj
-44 0 obj
+43 0 obj
 [272 0 0 0 489.6 489.6 489.6 0 0 0 489.6 0 0 0 0 0 0 0 0 0 0 734 693.4 0 0 0 0 0 0 0 0 0 0 897.2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 489.6 0 0 0 0 0 0 544 0 0 0 0 0 0 489.6 0 0 380.8 0 380.8 544 0 0 0 516.8 ]
 endobj
-45 0 obj
+44 0 obj
 [513.9 571 0 0 457.2 0 0 571 285.5 0 0 285.5 0 0 0 0 0 0 405.4 399.7 571 0 742.3 ]
 endobj
-46 0 obj
+45 0 obj
 [489.5 ]
 endobj
-47 0 obj
+46 0 obj
 [ 103 [ 333 ] ]
 endobj
-49 0 obj
+48 0 obj
 << /Length 13 >>         
 [BINARY STREAM]
 endobj
-50 0 obj
+49 0 obj
 << /Subtype /CIDFontType0C /Length 506 >>        
 [BINARY STREAM]
 endobj
-48 0 obj
-<< /Type /FontDescriptor /FontName /XVZVYO+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 50 0 R /CIDSet 49 0 R >>
+47 0 obj
+<< /Type /FontDescriptor /FontName /XVZVYO+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 49 0 R /CIDSet 48 0 R >>
 endobj
-51 0 obj
+50 0 obj
 << /Length 692 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -492,68 +489,68 @@ end
 %%EOF
 endstream
 endobj
-28 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /XVZVYO+LMRoman10-Regular /DescendantFonts [ 52 0 R ] /ToUnicode 51 0 R >>
+27 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /XVZVYO+LMRoman10-Regular /DescendantFonts [ 51 0 R ] /ToUnicode 50 0 R >>
+endobj
+51 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /XVZVYO+LMRoman10-Regular /FontDescriptor 47 0 R /W 46 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 52 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /XVZVYO+LMRoman10-Regular /FontDescriptor 48 0 R /W 47 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-53 0 obj
 [693.3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 406.4 0 0 0 249.6 0 0 249.6 0 0 0 0 0 0 0 354.1 ]
 endobj
-55 0 obj
+54 0 obj
 << /Length1 1387 /Length2 5943 /Length3 0 /Length 7330 >>       
 [BINARY STREAM]
 endobj
-54 0 obj
-<< /Type /FontDescriptor /FontName /SDXKYB+CMR10 /Flags 4 /FontBBox [ -40 -250 1009 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 69 /XHeight 431 /CharSet( /one) /FontFile 55 0 R >>
+53 0 obj
+<< /Type /FontDescriptor /FontName /SDXKYB+CMR10 /Flags 4 /FontBBox [ -40 -250 1009 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 69 /XHeight 431 /CharSet( /one) /FontFile 54 0 R >>
 endobj
-57 0 obj
+56 0 obj
 << /Length1 1599 /Length2 8302 /Length3 0 /Length 9901 >>       
 [BINARY STREAM]
 endobj
-56 0 obj
-<< /Type /FontDescriptor /FontName /VBFROV+CMR12 /Flags 4 /FontBBox [ -34 -251 988 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 65 /XHeight 431 /CharSet( /A /B /M /a /comma /h /o /one /r /six /t /two /u /y /zero) /FontFile 57 0 R >>
+55 0 obj
+<< /Type /FontDescriptor /FontName /VBFROV+CMR12 /Flags 4 /FontBBox [ -34 -251 988 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 65 /XHeight 431 /CharSet( /A /B /M /a /comma /h /o /one /r /six /t /two /u /y /zero) /FontFile 56 0 R >>
 endobj
-59 0 obj
+58 0 obj
 << /Length1 1444 /Length2 6633 /Length3 0 /Length 8077 >>       
 [BINARY STREAM]
 endobj
-58 0 obj
-<< /Type /FontDescriptor /FontName /PXLAWO+CMR17 /Flags 4 /FontBBox [ -33 -250 945 749 ] /Ascent 694 /CapHeight 683 /Descent -195 /ItalicAngle 0 /StemV 53 /XHeight 430 /CharSet( /A /e /i /l /t) /FontFile 59 0 R >>
+57 0 obj
+<< /Type /FontDescriptor /FontName /PXLAWO+CMR17 /Flags 4 /FontBBox [ -33 -250 945 749 ] /Ascent 694 /CapHeight 683 /Descent -195 /ItalicAngle 0 /StemV 53 /XHeight 430 /CharSet( /A /e /i /l /t) /FontFile 58 0 R >>
 endobj
-61 0 obj
+60 0 obj
 << /Length1 1422 /Length2 6395 /Length3 0 /Length 7817 >>       
 [BINARY STREAM]
 endobj
-60 0 obj
-<< /Type /FontDescriptor /FontName /FRWMVG+CMR8 /Flags 4 /FontBBox [ -36 -250 1070 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 76 /XHeight 431 /CharSet( /N /e /o /t) /FontFile 61 0 R >>
+59 0 obj
+<< /Type /FontDescriptor /FontName /FRWMVG+CMR8 /Flags 4 /FontBBox [ -36 -250 1070 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 76 /XHeight 431 /CharSet( /N /e /o /t) /FontFile 60 0 R >>
 endobj
-63 0 obj
+62 0 obj
 << /Length1 1511 /Length2 8440 /Length3 0 /Length 9951 >>       
 [BINARY STREAM]
 endobj
-62 0 obj
-<< /Type /FontDescriptor /FontName /BSXKTW+CMR9 /Flags 4 /FontBBox [ -39 -250 1036 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 74 /XHeight 431 /CharSet( /a /b /e /h /i /l /s /t /u /w) /FontFile 63 0 R >>
+61 0 obj
+<< /Type /FontDescriptor /FontName /BSXKTW+CMR9 /Flags 4 /FontBBox [ -39 -250 1036 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 74 /XHeight 431 /CharSet( /a /b /e /h /i /l /s /t /u /w) /FontFile 62 0 R >>
 endobj
-65 0 obj
+64 0 obj
 << /Length1 721 /Length2 1124 /Length3 0 /Length 1845 >>       
 [BINARY STREAM]
 endobj
-64 0 obj
-<< /Type /FontDescriptor /FontName /YIGRIT+SFRM0600 /Flags 4 /FontBBox [ -210 -320 1719 944 ] /Ascent 0 /CapHeight 0 /Descent 0 /ItalicAngle 0 /StemV 50 /XHeight 430 /CharSet( /asteriskmath) /FontFile 65 0 R >>
+63 0 obj
+<< /Type /FontDescriptor /FontName /YIGRIT+SFRM0600 /Flags 4 /FontBBox [ -210 -320 1719 944 ] /Ascent 0 /CapHeight 0 /Descent 0 /ItalicAngle 0 /StemV 50 /XHeight 430 /CharSet( /asteriskmath) /FontFile 64 0 R >>
 endobj
-67 0 obj
+66 0 obj
 << /Length1 721 /Length2 5420 /Length3 0 /Length 6141 >>       
 [BINARY STREAM]
 endobj
-66 0 obj
-<< /Type /FontDescriptor /FontName /RYQARY+SFRM1200 /Flags 4 /FontBBox [ -185 -320 1420 942 ] /Ascent 0 /CapHeight 0 /Descent 0 /ItalicAngle 0 /StemV 50 /XHeight 430 /CharSet( /asteriskmath) /FontFile 67 0 R >>
+65 0 obj
+<< /Type /FontDescriptor /FontName /RYQARY+SFRM1200 /Flags 4 /FontBBox [ -185 -320 1420 942 ] /Ascent 0 /CapHeight 0 /Descent 0 /ItalicAngle 0 /StemV 50 /XHeight 430 /CharSet( /asteriskmath) /FontFile 66 0 R >>
 endobj
-42 0 obj
+41 0 obj
 << /Type /Encoding /Differences [ 42 /asteriskmath ] >>
 endobj
-68 0 obj
+67 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -673,10 +670,10 @@ end
 %%EOF
 endstream
 endobj
-34 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /SDXKYB+CMR10 /FontDescriptor 54 0 R /FirstChar 49 /LastChar 49 /Widths 40 0 R /ToUnicode 68 0 R >>
+33 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /SDXKYB+CMR10 /FontDescriptor 53 0 R /FirstChar 49 /LastChar 49 /Widths 39 0 R /ToUnicode 67 0 R >>
 endobj
-69 0 obj
+68 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -796,10 +793,10 @@ end
 %%EOF
 endstream
 endobj
-31 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /VBFROV+CMR12 /FontDescriptor 56 0 R /FirstChar 44 /LastChar 121 /Widths 44 0 R /ToUnicode 69 0 R >>
+30 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /VBFROV+CMR12 /FontDescriptor 55 0 R /FirstChar 44 /LastChar 121 /Widths 43 0 R /ToUnicode 68 0 R >>
 endobj
-70 0 obj
+69 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -919,10 +916,10 @@ end
 %%EOF
 endstream
 endobj
-27 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /PXLAWO+CMR17 /FontDescriptor 58 0 R /FirstChar 65 /LastChar 116 /Widths 53 0 R /ToUnicode 70 0 R >>
+26 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /PXLAWO+CMR17 /FontDescriptor 57 0 R /FirstChar 65 /LastChar 116 /Widths 52 0 R /ToUnicode 69 0 R >>
 endobj
-71 0 obj
+70 0 obj
 << /Length 1719 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -1042,10 +1039,10 @@ end
 %%EOF
 endstream
 endobj
-33 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /FRWMVG+CMR8 /FontDescriptor 60 0 R /FirstChar 78 /LastChar 116 /Widths 41 0 R /ToUnicode 71 0 R >>
+32 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /FRWMVG+CMR8 /FontDescriptor 59 0 R /FirstChar 78 /LastChar 116 /Widths 40 0 R /ToUnicode 70 0 R >>
 endobj
-72 0 obj
+71 0 obj
 << /Length 1719 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -1165,8 +1162,119 @@ end
 %%EOF
 endstream
 endobj
-30 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /BSXKTW+CMR9 /FontDescriptor 62 0 R /FirstChar 97 /LastChar 119 /Widths 45 0 R /ToUnicode 72 0 R >>
+29 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /BSXKTW+CMR9 /FontDescriptor 61 0 R /FirstChar 97 /LastChar 119 /Widths 44 0 R /ToUnicode 71 0 R >>
+endobj
+72 0 obj
+<< /Length 1523 >>       
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: ProcSet (CIDInit)
+%%IncludeResource: ProcSet (CIDInit)
+%%BeginResource: CMap (TeX-cm-super-ts1-0)
+%%Title: (TeX-cm-super-ts1-0 TeX cm-super-ts1 0)
+%%Version: 1.000
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<< /Registry (TeX)
+/Ordering (cm-super-ts1)
+/Supplement 0
+>> def
+/CMapName /TeX-cm-super-ts1-0 def
+/CMapType 2 def
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+7 beginbfrange
+<30> <39> <0030>
+<84> <85> <2020>
+<A0> <A1> <2045>
+<A2> <AA> <00A2>
+<AE> <B7> <00AE>
+<B9> <BA> <00B9>
+<BC> <BE> <00BC>
+endbfrange
+66 beginbfchar
+<00> <0060>
+<01> <00B4>
+<04> <00A8>
+<05> <02DD>
+<07> <02C7>
+<09> <00AF>
+<0B> <00B8>
+<0C> <02DB>
+<0D> <201A>
+<12> <201E>
+<16> <F6DE>
+<17> <200C>
+<18> <2190>
+<19> <2192>
+<1F> <200C>
+<20> <2422>
+<24> <0024>
+<27> <0027>
+<2A> <2217>
+<2C> <002C>
+<2E> <002E>
+<2F> <2044>
+<3C> <2329>
+<3D> <2212>
+<3E> <232A>
+<4D> <2127>
+<4F> <25CB>
+<57> <2126>
+<5B> <301A>
+<5D> <301B>
+<5E> <2191>
+<5F> <2193>
+<60> <0060>
+<6E> <266A>
+<80> <02D8>
+<81> <02C7>
+<82> <02DD>
+<83> <00A0030F>
+<86> <2016>
+<87> <2030>
+<88> <2022>
+<89> <2103>
+<8A> <0024>
+<8B> <00A2>
+<8C> <0192>
+<8D> <20A1>
+<8E> <20A9>
+<8F> <20A6>
+<92> <20A4>
+<94> <203D>
+<96> <20AB>
+<97> <2122>
+<98> <2031>
+<99> <00B6>
+<9A> <0E3F>
+<9B> <2116>
+<9D> <212E>
+<9E> <25E6>
+<9F> <2120>
+<AC> <00AC>
+<AD> <2117>
+<B8> <203B>
+<BB> <221A>
+<BF> <20AC>
+<D6> <00D7>
+<F6> <00F7>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+31 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /YIGRIT+SFRM0600 /FontDescriptor 63 0 R /FirstChar 42 /LastChar 42 /Widths 42 0 R /Encoding 41 0 R /ToUnicode 72 0 R >>
 endobj
 73 0 obj
 << /Length 1523 >>       
@@ -1276,210 +1384,98 @@ end
 %%EOF
 endstream
 endobj
-32 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /YIGRIT+SFRM0600 /FontDescriptor 64 0 R /FirstChar 42 /LastChar 42 /Widths 43 0 R /Encoding 42 0 R /ToUnicode 73 0 R >>
+28 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /RYQARY+SFRM1200 /FontDescriptor 65 0 R /FirstChar 42 /LastChar 42 /Widths 45 0 R /Encoding 41 0 R /ToUnicode 73 0 R >>
+endobj
+34 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 24 0 R ] >>
 endobj
 74 0 obj
-<< /Length 1523 >>       
-stream
-%!PS-Adobe-3.0 Resource-CMap
-%%DocumentNeededResources: ProcSet (CIDInit)
-%%IncludeResource: ProcSet (CIDInit)
-%%BeginResource: CMap (TeX-cm-super-ts1-0)
-%%Title: (TeX-cm-super-ts1-0 TeX cm-super-ts1 0)
-%%Version: 1.000
-%%EndComments
-/CIDInit /ProcSet findresource begin
-12 dict begin
-begincmap
-/CIDSystemInfo
-<< /Registry (TeX)
-/Ordering (cm-super-ts1)
-/Supplement 0
->> def
-/CMapName /TeX-cm-super-ts1-0 def
-/CMapType 2 def
-1 begincodespacerange
-<00> <FF>
-endcodespacerange
-7 beginbfrange
-<30> <39> <0030>
-<84> <85> <2020>
-<A0> <A1> <2045>
-<A2> <AA> <00A2>
-<AE> <B7> <00AE>
-<B9> <BA> <00B9>
-<BC> <BE> <00BC>
-endbfrange
-66 beginbfchar
-<00> <0060>
-<01> <00B4>
-<04> <00A8>
-<05> <02DD>
-<07> <02C7>
-<09> <00AF>
-<0B> <00B8>
-<0C> <02DB>
-<0D> <201A>
-<12> <201E>
-<16> <F6DE>
-<17> <200C>
-<18> <2190>
-<19> <2192>
-<1F> <200C>
-<20> <2422>
-<24> <0024>
-<27> <0027>
-<2A> <2217>
-<2C> <002C>
-<2E> <002E>
-<2F> <2044>
-<3C> <2329>
-<3D> <2212>
-<3E> <232A>
-<4D> <2127>
-<4F> <25CB>
-<57> <2126>
-<5B> <301A>
-<5D> <301B>
-<5E> <2191>
-<5F> <2193>
-<60> <0060>
-<6E> <266A>
-<80> <02D8>
-<81> <02C7>
-<82> <02DD>
-<83> <00A0030F>
-<86> <2016>
-<87> <2030>
-<88> <2022>
-<89> <2103>
-<8A> <0024>
-<8B> <00A2>
-<8C> <0192>
-<8D> <20A1>
-<8E> <20A9>
-<8F> <20A6>
-<92> <20A4>
-<94> <203D>
-<96> <20AB>
-<97> <2122>
-<98> <2031>
-<99> <00B6>
-<9A> <0E3F>
-<9B> <2116>
-<9D> <212E>
-<9E> <25E6>
-<9F> <2120>
-<AC> <00AC>
-<AD> <2117>
-<B8> <203B>
-<BB> <221A>
-<BF> <20AC>
-<D6> <00D7>
-<F6> <00F7>
-endbfchar
-endcmap
-CMapName currentdict /CMap defineresource pop
-end
-end
-%%EndResource
-%%EOF
-endstream
-endobj
-29 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /RYQARY+SFRM1200 /FontDescriptor 66 0 R /FirstChar 42 /LastChar 42 /Widths 46 0 R /Encoding 42 0 R /ToUnicode 74 0 R >>
-endobj
-35 0 obj
-<< /Type /Pages  /Count 1 /Kids [ 25 0 R ] >>
+<< /Type /Catalog /Pages 34 0 R /MarkInfo 35 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 22 0 R >>
 endobj
 75 0 obj
-<< /Type /Catalog /Pages 35 0 R /MarkInfo 36 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 23 0 R >>
-endobj
-76 0 obj
 << /Producer (LuaTeX)/Creator (TeX)/Title <FEFF00410020007400690074006C0065>/Author <FEFF0061007500740068006F0072002000410020002C0061007500740068006F007200200042>/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 77
+0 76
 0000000002 65535 f 
 0000014224 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000017017 00000 n 
+0000016913 00000 n 
 0000014307 00000 n 
-0000014711 00000 n 
+0000014695 00000 n 
 0000000000 00000 f 
-0000015491 00000 n 
-0000015585 00000 n 
-0000015661 00000 n 
-0000015737 00000 n 
-0000015847 00000 n 
-0000015980 00000 n 
-0000016115 00000 n 
-0000016238 00000 n 
-0000016360 00000 n 
-0000016482 00000 n 
-0000016593 00000 n 
-0000016685 00000 n 
-0000016773 00000 n 
-0000016901 00000 n 
+0000015475 00000 n 
+0000015569 00000 n 
+0000015645 00000 n 
+0000015721 00000 n 
+0000015831 00000 n 
+0000015964 00000 n 
+0000016099 00000 n 
+0000016222 00000 n 
+0000016344 00000 n 
+0000016466 00000 n 
+0000016577 00000 n 
+0000016665 00000 n 
+0000016793 00000 n 
 0000000020 00000 n 
 0000014053 00000 n 
 0000013918 00000 n 
 0000012122 00000 n 
-0000078967 00000 n 
-0000019328 00000 n 
-0000086340 00000 n 
-0000082840 00000 n 
-0000077025 00000 n 
-0000084580 00000 n 
-0000080904 00000 n 
-0000075084 00000 n 
-0000086517 00000 n 
+0000078863 00000 n 
+0000019224 00000 n 
+0000086236 00000 n 
+0000082736 00000 n 
+0000076921 00000 n 
+0000084476 00000 n 
+0000080800 00000 n 
+0000074980 00000 n 
+0000086413 00000 n 
 0000014271 00000 n 
 0000014392 00000 n 
-0000014674 00000 n 
-0000015290 00000 n 
-0000017135 00000 n 
-0000017158 00000 n 
-0000073228 00000 n 
-0000017271 00000 n 
-0000017294 00000 n 
-0000017521 00000 n 
-0000017620 00000 n 
-0000017645 00000 n 
-0000018340 00000 n 
-0000017677 00000 n 
-0000017750 00000 n 
-0000018576 00000 n 
-0000019482 00000 n 
-0000019682 00000 n 
-0000027254 00000 n 
-0000019825 00000 n 
-0000037475 00000 n 
-0000027475 00000 n 
-0000045924 00000 n 
-0000037748 00000 n 
-0000054070 00000 n 
-0000046154 00000 n 
-0000064347 00000 n 
-0000054297 00000 n 
-0000066535 00000 n 
-0000064592 00000 n 
-0000073001 00000 n 
-0000066762 00000 n 
-0000073300 00000 n 
-0000075241 00000 n 
-0000077183 00000 n 
-0000079125 00000 n 
-0000081061 00000 n 
-0000082997 00000 n 
-0000084757 00000 n 
-0000086579 00000 n 
-0000086694 00000 n 
+0000014658 00000 n 
+0000015274 00000 n 
+0000017031 00000 n 
+0000017054 00000 n 
+0000073124 00000 n 
+0000017167 00000 n 
+0000017190 00000 n 
+0000017417 00000 n 
+0000017516 00000 n 
+0000017541 00000 n 
+0000018236 00000 n 
+0000017573 00000 n 
+0000017646 00000 n 
+0000018472 00000 n 
+0000019378 00000 n 
+0000019578 00000 n 
+0000027150 00000 n 
+0000019721 00000 n 
+0000037371 00000 n 
+0000027371 00000 n 
+0000045820 00000 n 
+0000037644 00000 n 
+0000053966 00000 n 
+0000046050 00000 n 
+0000064243 00000 n 
+0000054193 00000 n 
+0000066431 00000 n 
+0000064488 00000 n 
+0000072897 00000 n 
+0000066658 00000 n 
+0000073196 00000 n 
+0000075137 00000 n 
+0000077079 00000 n 
+0000079021 00000 n 
+0000080957 00000 n 
+0000082893 00000 n 
+0000084653 00000 n 
+0000086475 00000 n 
+0000086590 00000 n 
 trailer
-<< /Size 77 /Root 75 0 R /Info 76 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 76 /Root 74 0 R /Info 75 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-86953
+86849
 %%EOF

--- a/required/latex-lab/testfiles-title/title-005.tpf
+++ b/required/latex-lab/testfiles-title/title-005.tpf
@@ -1,6 +1,6 @@
 %PDF-1.5
 %ÐÔÅØ
-24 0 obj
+23 0 obj
 <<
 /Type /Metadata /Subtype /XML
 /Length 12010     
@@ -249,7 +249,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-26 0 obj
+25 0 obj
 <<
 /Length 1269      
 >>
@@ -314,40 +314,40 @@ endobj
 14 0 obj
 <<
 /Type /Page
-/Contents 26 0 R
-/Resources 25 0 R
+/Contents 25 0 R
+/Resources 24 0 R
 /MediaBox [0 0 612 792]
 /Tabs /S /StructParents 0 
-/Parent 35 0 R
+/Parent 34 0 R
 >>
 endobj
-25 0 obj
+24 0 obj
 <<
 /ExtGState 1 0 R 
-/Font << /F40 27 0 R /F64 28 0 R /F50 29 0 R /F51 30 0 R /F49 31 0 R /F63 32 0 R /F60 33 0 R /F39 34 0 R >>
+/Font << /F40 26 0 R /F64 27 0 R /F50 28 0 R /F51 29 0 R /F49 30 0 R /F63 31 0 R /F60 32 0 R /F39 33 0 R >>
 /ProcSet [ /PDF /Text ]
 >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-36 0 obj
+35 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 13 0 R 15 0 R 13 0 R 16 0 R 17 0 R 18 0 R 22 0 R 23 0 R 22 0 R 22 0 R 22 0 R ]
+<< /Nums [0 [ 13 0 R 15 0 R 13 0 R 16 0 R 17 0 R 18 0 R 21 0 R 22 0 R 21 0 R 21 0 R 21 0 R ]
 ] >>
 endobj
-37 0 obj
-<< /Limits [(ID.002) (ID.015)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 15 0 R (ID.008) 16 0 R (ID.009) 17 0 R (ID.010) 18 0 R (ID.011) 19 0 R (ID.012) 20 0 R (ID.013) 21 0 R (ID.014) 22 0 R (ID.015) 23 0 R ] >>
+36 0 obj
+<< /Limits [(ID.002) (ID.014)]/Names [(ID.002) 9 0 R (ID.003) 10 0 R (ID.004) 11 0 R (ID.005) 12 0 R (ID.006) 13 0 R (ID.007) 15 0 R (ID.008) 16 0 R (ID.009) 17 0 R (ID.010) 18 0 R (ID.011) 19 0 R (ID.012) 20 0 R (ID.013) 21 0 R (ID.014) 22 0 R ] >>
 endobj
-38 0 obj
-<< /Kids [37 0 R] >>
+37 0 obj
+<< /Kids [36 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
 endobj
-39 0 obj
+38 0 obj
 << /center <</O/Layout/TextAlign/Center>>
 /justify <</O/Layout/TextAlign/Justify>>
 /TH-both <</O/Table/Scope/Both>>
@@ -383,48 +383,45 @@ endobj
 <<  /Type /StructElem /C /center /S /text /P 12 0 R /K <</Type /MCR /Pg 14 0 R/MCID 5>> /ID (ID.010) >>
 endobj
 19 0 obj
-<<  /Type /StructElem /S /footnote /P 9 0 R /Ref [ 15 0 R ] /K [20 0 R 21 0 R] /ID (ID.011) >>
+<<  /Type /StructElem /S /footnote /P 9 0 R /Ref [ 15 0 R ] /K [22 0 R 20 0 R] /ID (ID.011) >>
 endobj
 20 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 19 0 R /K 23 0 R /ID (ID.012) >>
+<<  /Type /StructElem /S /text-unit /P 19 0 R /K 21 0 R /ID (ID.012) >>
 endobj
 21 0 obj
-<<  /Type /StructElem /S /text-unit /P 19 0 R /K 22 0 R /ID (ID.013) >>
+<<  /Type /StructElem /C /justify /S /text /P 20 0 R /K [<</Type /MCR /Pg 14 0 R/MCID 6>> <</Type /MCR /Pg 14 0 R/MCID 8>> <</Type /MCR /Pg 14 0 R/MCID 9>> <</Type /MCR /Pg 14 0 R/MCID 10>>] /ID (ID.013) >>
 endobj
 22 0 obj
-<<  /Type /StructElem /C /justify /S /text /P 21 0 R /K [<</Type /MCR /Pg 14 0 R/MCID 6>> <</Type /MCR /Pg 14 0 R/MCID 8>> <</Type /MCR /Pg 14 0 R/MCID 9>> <</Type /MCR /Pg 14 0 R/MCID 10>>] /ID (ID.014) >>
-endobj
-23 0 obj
-<<  /Type /StructElem /S /NonStruct /P 20 0 R /K <</Type /MCR /Pg 14 0 R/MCID 7>> /ID (ID.015) >>
+<<  /Type /StructElem /S /footnotelabel /P 19 0 R /K <</Type /MCR /Pg 14 0 R/MCID 7>> /ID (ID.014) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 38 0 R /ClassMap 39 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
+<<  /Type /StructTreeRoot /IDTree 37 0 R /ClassMap 38 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 9 0 R >>
 endobj
-41 0 obj
+40 0 obj
 [499.9]
 endobj
-42 0 obj
+41 0 obj
 [795.6 826.2 722.4 826.2 781.4 590.1 767.2 795.6 795.6 1090.7 795.6 795.6 649.1 295.1 531.1 295.1 649.1 826.2 295.1 531.1 590.1 472.1 590.1 472.1 324.6 531.1 590.1 295.1 324.6 560.6 295.1 885.2 590.1 531.1 590.1 560.6 414 419 413.1]
 endobj
-44 0 obj
+43 0 obj
 [611]
 endobj
-45 0 obj
+44 0 obj
 [271.9 326.3 271.9 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 271.9 271.9 761.4 761.4 761.4 462.3 761.4 733.8 693.2 707 747.6 666 638.8 768.1 733.8 353.2 502.9 761 611.7 897 733.8 761.4 666 761.4 720.4 543.8 707 733.8 733.8 1005.8 733.8 733.8 598.2 271.9 489.5 271.9 598.2 761.4 271.9 489.5 543.8 435.1 543.8 435.1 299.1 489.5 543.8 271.9 299.1 516.7 271.9 815.8 543.8 489.5 543.8 516.7 380.7 386.1 380.7 543.8 516.7 707 516.7 516.7]
 endobj
-46 0 obj
+45 0 obj
 [513.8 570.8 456.7 570.8 457.1 314 513.8 570.8 285.4 314 542.3 285.4 856.3 570.8 513.8 570.8 542.3 401.9 405.3 399.6 570.8 542.3 742.1]
 endobj
-47 0 obj
+46 0 obj
 [489.5]
 endobj
-48 0 obj
+47 0 obj
 [333]
 endobj
-49 0 obj
+48 0 obj
 [704.4 665.4 678.7 717.7 639.3 613.2 737.3 704.4 338.8 482.6 730.5 587.1 861.1 704.4 730.9 639.3 730.9 691.5 522 678.7 704.4 704.4 965.6 704.4 704.4 574.2 260.8 469.8 260.8 574.2 730.9 260.8 469.8 522 417.5 522 417.5 287 469.8 522 260.8 287 495.9 260.8 783.1 522 469.8 522 495.9 365.3 370.5 365.3]
 endobj
-50 0 obj
+49 0 obj
 <<
 /Length1 1144
 /Length2 1422
@@ -433,7 +430,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-51 0 obj
+50 0 obj
 <<
 /Type /FontDescriptor
 /FontName /MUQHVU+PdfTeX-Space
@@ -446,10 +443,10 @@ endobj
 /StemV 0
 /XHeight 500
 /CharSet (/space)
-/FontFile 50 0 R
+/FontFile 49 0 R
 >>
 endobj
-52 0 obj
+51 0 obj
 <<
 /Length1 721
 /Length2 1124
@@ -458,7 +455,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-53 0 obj
+52 0 obj
 <<
 /Type /FontDescriptor
 /FontName /YIGRIT+SFRM0600
@@ -471,10 +468,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/asteriskmath)
-/FontFile 52 0 R
+/FontFile 51 0 R
 >>
 endobj
-54 0 obj
+53 0 obj
 <<
 /Length1 721
 /Length2 16768
@@ -483,7 +480,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-55 0 obj
+54 0 obj
 <<
 /Type /FontDescriptor
 /FontName /MMWKYX+SFRM0800
@@ -496,10 +493,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/N/e/o/t)
-/FontFile 54 0 R
+/FontFile 53 0 R
 >>
 endobj
-56 0 obj
+55 0 obj
 <<
 /Length1 721
 /Length2 13820
@@ -508,7 +505,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-57 0 obj
+56 0 obj
 <<
 /Type /FontDescriptor
 /FontName /WLWXUF+SFRM0900
@@ -521,10 +518,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/a/b/e/h/i/l/s/t/u/w)
-/FontFile 56 0 R
+/FontFile 55 0 R
 >>
 endobj
-58 0 obj
+57 0 obj
 <<
 /Length1 721
 /Length2 981
@@ -533,7 +530,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-59 0 obj
+58 0 obj
 <<
 /Type /FontDescriptor
 /FontName /VZMLCI+SFRM1000
@@ -546,10 +543,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/one)
-/FontFile 58 0 R
+/FontFile 57 0 R
 >>
 endobj
-60 0 obj
+59 0 obj
 <<
 /Length1 721
 /Length2 12358
@@ -558,7 +555,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-61 0 obj
+60 0 obj
 <<
 /Type /FontDescriptor
 /FontName /VVUPRB+SFRM1200
@@ -571,10 +568,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/A/B/M/a/asteriskmath/comma/h/o/one/r/six/t/two/u/y/zero)
-/FontFile 60 0 R
+/FontFile 59 0 R
 >>
 endobj
-62 0 obj
+61 0 obj
 <<
 /Length1 721
 /Length2 6947
@@ -583,7 +580,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-63 0 obj
+62 0 obj
 <<
 /Type /FontDescriptor
 /FontName /EMNKTC+SFRM1728
@@ -596,22 +593,22 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/A/e/i/l/t)
-/FontFile 62 0 R
+/FontFile 61 0 R
 >>
 endobj
-40 0 obj
+39 0 obj
 <<
 /Type /Encoding
 /Differences [44/comma 48/zero/one/two 54/six 65/A/B 77/M/N 97/a/b 101/e 104/h/i 108/l 111/o 114/r/s/t/u 119/w 121/y]
 >>
 endobj
-43 0 obj
+42 0 obj
 <<
 /Type /Encoding
 /Differences [42/asteriskmath]
 >>
 endobj
-64 0 obj
+63 0 obj
 <<
 /Length 2030      
 >>
@@ -755,20 +752,20 @@ end
 %%EOF
 endstream
 endobj
-33 0 obj
+32 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /MMWKYX+SFRM0800
-/FontDescriptor 55 0 R
+/FontDescriptor 54 0 R
 /FirstChar 78
 /LastChar 116
-/Widths 42 0 R
-/Encoding 40 0 R
-/ToUnicode 64 0 R
+/Widths 41 0 R
+/Encoding 39 0 R
+/ToUnicode 63 0 R
 >>
 endobj
-65 0 obj
+64 0 obj
 <<
 /Length 2030      
 >>
@@ -912,20 +909,20 @@ end
 %%EOF
 endstream
 endobj
-30 0 obj
+29 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /WLWXUF+SFRM0900
-/FontDescriptor 57 0 R
+/FontDescriptor 56 0 R
 /FirstChar 97
 /LastChar 119
-/Widths 46 0 R
-/Encoding 40 0 R
-/ToUnicode 65 0 R
+/Widths 45 0 R
+/Encoding 39 0 R
+/ToUnicode 64 0 R
 >>
 endobj
-66 0 obj
+65 0 obj
 <<
 /Length 2030      
 >>
@@ -1069,20 +1066,20 @@ end
 %%EOF
 endstream
 endobj
-34 0 obj
+33 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /VZMLCI+SFRM1000
-/FontDescriptor 59 0 R
+/FontDescriptor 58 0 R
 /FirstChar 49
 /LastChar 49
-/Widths 41 0 R
-/Encoding 40 0 R
-/ToUnicode 66 0 R
+/Widths 40 0 R
+/Encoding 39 0 R
+/ToUnicode 65 0 R
 >>
 endobj
-67 0 obj
+66 0 obj
 <<
 /Length 2030      
 >>
@@ -1226,20 +1223,20 @@ end
 %%EOF
 endstream
 endobj
-31 0 obj
+30 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /VVUPRB+SFRM1200
-/FontDescriptor 61 0 R
+/FontDescriptor 60 0 R
 /FirstChar 44
 /LastChar 121
-/Widths 45 0 R
-/Encoding 40 0 R
-/ToUnicode 67 0 R
+/Widths 44 0 R
+/Encoding 39 0 R
+/ToUnicode 66 0 R
 >>
 endobj
-68 0 obj
+67 0 obj
 <<
 /Length 2030      
 >>
@@ -1383,20 +1380,20 @@ end
 %%EOF
 endstream
 endobj
-27 0 obj
+26 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /EMNKTC+SFRM1728
-/FontDescriptor 63 0 R
+/FontDescriptor 62 0 R
 /FirstChar 65
 /LastChar 116
-/Widths 49 0 R
-/Encoding 40 0 R
-/ToUnicode 68 0 R
+/Widths 48 0 R
+/Encoding 39 0 R
+/ToUnicode 67 0 R
 >>
 endobj
-69 0 obj
+68 0 obj
 <<
 /Length 654       
 >>
@@ -1434,19 +1431,19 @@ end
 %%EOF
 endstream
 endobj
-28 0 obj
+27 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /MUQHVU+PdfTeX-Space
-/FontDescriptor 51 0 R
+/FontDescriptor 50 0 R
 /FirstChar 32
 /LastChar 32
-/Widths 48 0 R
-/ToUnicode 69 0 R
+/Widths 47 0 R
+/ToUnicode 68 0 R
 >>
 endobj
-70 0 obj
+69 0 obj
 <<
 /Length 1568      
 >>
@@ -1556,20 +1553,20 @@ end
 %%EOF
 endstream
 endobj
-32 0 obj
+31 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /YIGRIT+SFRM0600
-/FontDescriptor 53 0 R
+/FontDescriptor 52 0 R
 /FirstChar 42
 /LastChar 42
-/Widths 44 0 R
-/Encoding 43 0 R
-/ToUnicode 70 0 R
+/Widths 43 0 R
+/Encoding 42 0 R
+/ToUnicode 69 0 R
 >>
 endobj
-71 0 obj
+70 0 obj
 <<
 /Length 1568      
 >>
@@ -1679,120 +1676,119 @@ end
 %%EOF
 endstream
 endobj
-29 0 obj
+28 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /VVUPRB+SFRM1200
-/FontDescriptor 61 0 R
+/FontDescriptor 60 0 R
 /FirstChar 42
 /LastChar 42
-/Widths 47 0 R
-/Encoding 43 0 R
-/ToUnicode 71 0 R
+/Widths 46 0 R
+/Encoding 42 0 R
+/ToUnicode 70 0 R
 >>
 endobj
-35 0 obj
+34 0 obj
 <<
 /Type /Pages
 /Count 1
 /Kids [14 0 R]
 >>
 endobj
-72 0 obj
+71 0 obj
 <<
 /Type /Catalog
-/Pages 35 0 R
-/MarkInfo 36 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 24 0 R
+/Pages 34 0 R
+/MarkInfo 35 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 23 0 R
 >>
 endobj
-73 0 obj
+72 0 obj
 <<
 /Producer (pdfTeX)/Creator (TeX)/Title <FEFF00410020007400690074006C0065>/Author <FEFF0061007500740068006F0072002000410020002C0061007500740068006F007200200042>/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z)
 /Trapped /False
 >>
 endobj
 xref
-0 74
+0 73
 0000000002 65535 f 
 0000013749 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000016685 00000 n 
+0000016581 00000 n 
 0000013832 00000 n 
-0000014264 00000 n 
+0000014248 00000 n 
 0000000000 00000 f 
-0000015044 00000 n 
-0000015138 00000 n 
-0000015214 00000 n 
-0000015290 00000 n 
-0000015400 00000 n 
+0000015028 00000 n 
+0000015122 00000 n 
+0000015198 00000 n 
+0000015274 00000 n 
+0000015384 00000 n 
 0000013442 00000 n 
-0000015563 00000 n 
-0000015696 00000 n 
-0000015817 00000 n 
-0000015937 00000 n 
-0000016057 00000 n 
-0000016168 00000 n 
-0000016260 00000 n 
-0000016348 00000 n 
-0000016571 00000 n 
+0000015547 00000 n 
+0000015680 00000 n 
+0000015801 00000 n 
+0000015921 00000 n 
+0000016041 00000 n 
+0000016152 00000 n 
+0000016240 00000 n 
+0000016463 00000 n 
 0000000015 00000 n 
 0000013577 00000 n 
 0000012114 00000 n 
-0000090672 00000 n 
-0000091563 00000 n 
-0000095158 00000 n 
-0000083872 00000 n 
-0000088405 00000 n 
-0000093354 00000 n 
-0000081605 00000 n 
-0000086139 00000 n 
-0000095335 00000 n 
+0000090568 00000 n 
+0000091459 00000 n 
+0000095054 00000 n 
+0000083768 00000 n 
+0000088301 00000 n 
+0000093250 00000 n 
+0000081501 00000 n 
+0000086035 00000 n 
+0000095231 00000 n 
 0000013796 00000 n 
 0000013945 00000 n 
-0000014227 00000 n 
-0000014843 00000 n 
-0000079291 00000 n 
-0000016803 00000 n 
-0000016827 00000 n 
-0000079447 00000 n 
-0000017076 00000 n 
-0000017098 00000 n 
-0000017571 00000 n 
-0000017723 00000 n 
-0000017747 00000 n 
-0000017769 00000 n 
-0000018083 00000 n 
-0000020747 00000 n 
-0000020965 00000 n 
-0000022907 00000 n 
-0000023132 00000 n 
-0000040719 00000 n 
-0000040946 00000 n 
-0000055585 00000 n 
-0000055824 00000 n 
-0000057622 00000 n 
-0000057845 00000 n 
-0000071022 00000 n 
-0000071297 00000 n 
-0000079062 00000 n 
-0000079516 00000 n 
-0000081783 00000 n 
-0000084050 00000 n 
-0000086316 00000 n 
-0000088583 00000 n 
-0000090850 00000 n 
-0000091727 00000 n 
-0000093531 00000 n 
-0000095394 00000 n 
-0000095509 00000 n 
+0000014211 00000 n 
+0000014827 00000 n 
+0000079187 00000 n 
+0000016699 00000 n 
+0000016723 00000 n 
+0000079343 00000 n 
+0000016972 00000 n 
+0000016994 00000 n 
+0000017467 00000 n 
+0000017619 00000 n 
+0000017643 00000 n 
+0000017665 00000 n 
+0000017979 00000 n 
+0000020643 00000 n 
+0000020861 00000 n 
+0000022803 00000 n 
+0000023028 00000 n 
+0000040615 00000 n 
+0000040842 00000 n 
+0000055481 00000 n 
+0000055720 00000 n 
+0000057518 00000 n 
+0000057741 00000 n 
+0000070918 00000 n 
+0000071193 00000 n 
+0000078958 00000 n 
+0000079412 00000 n 
+0000081679 00000 n 
+0000083946 00000 n 
+0000086212 00000 n 
+0000088479 00000 n 
+0000090746 00000 n 
+0000091623 00000 n 
+0000093427 00000 n 
+0000095290 00000 n 
+0000095405 00000 n 
 trailer
-<< /Size 74
-/Root 72 0 R
-/Info 73 0 R
+<< /Size 73
+/Root 71 0 R
+/Info 72 0 R
 /ID [<9BD18DF3359C1216B83ADB4AA401CC9A> <9BD18DF3359C1216B83ADB4AA401CC9A>] >>
 startxref
-95768
+95664
 %%EOF

--- a/required/latex-lab/testfiles-title/title-006.luatex.tpf
+++ b/required/latex-lab/testfiles-title/title-006.luatex.tpf
@@ -3,7 +3,7 @@
 18 0 obj
 << /Type/OBJR/Obj 17 0 R/Pg 9 0 R >>
 endobj
-27 0 obj
+26 0 obj
 << /Type /Metadata /Subtype /XML /Length 11998 >>      
 stream
 <?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>
@@ -248,7 +248,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-29 0 obj
+28 0 obj
 << /Length 1582 >>       
 stream
 /opacity1 gs
@@ -337,62 +337,62 @@ EMC
 endstream
 endobj
 9 0 obj
-<< /Type /Page /Contents 29 0 R /Resources 28 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 43 0 R /Annots 44 0 R >>
+<< /Type /Page /Contents 28 0 R /Resources 27 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 42 0 R /Annots 43 0 R >>
 endobj
-44 0 obj
+43 0 obj
 [ 17 0 R ]
 endobj
 17 0 obj
-<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 1  /Rect [ 323.911 476.398 332.254 492.342 ]/A  << /S /GoTo /D (footnote*.7) /SD 39 0 R >> >>
+<< /Type /Annot /Subtype /Link /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 1  /Rect [ 323.911 476.398 332.254 492.342 ]/A  << /S /GoTo /D (footnote*.7) /SD 38 0 R >> >>
 endobj
-30 0 obj
+29 0 obj
 << /D [ 9 0 R /XYZ 132.768 705.06 null ] >>
 endobj
-31 0 obj
+30 0 obj
 [ 10 0 R /XYZ 132.768 705.06 null ]
 endobj
-32 0 obj
+31 0 obj
 << /D [ 9 0 R /XYZ 133.768 667.198 null ] >>
 endobj
-33 0 obj
+32 0 obj
 [ 10 0 R /XYZ 133.768 667.198 null ]
 endobj
-38 0 obj
+37 0 obj
 << /D [ 9 0 R /XYZ 133.768 231.657 null ] >>
+endobj
+38 0 obj
+[ 24 0 R /XYZ 133.768 231.657 null ]
 endobj
 39 0 obj
-[ 25 0 R /XYZ 133.768 231.657 null ]
-endobj
-40 0 obj
 << /D [ 9 0 R /XYZ 133.768 231.657 null ] >>
 endobj
-41 0 obj
-[ 25 0 R /XYZ 133.768 231.657 null ]
+40 0 obj
+[ 24 0 R /XYZ 133.768 231.657 null ]
 endobj
-28 0 obj
-<< /ExtGState 1 0 R /Font << /F17 34 0 R /F15 35 0 R /F18 36 0 R /F28 37 0 R /F30 42 0 R >> /ProcSet [ /PDF /Text ] >>
+27 0 obj
+<< /ExtGState 1 0 R /Font << /F17 33 0 R /F15 34 0 R /F18 35 0 R /F28 36 0 R /F30 41 0 R >> /ProcSet [ /PDF /Text ] >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-45 0 obj
+44 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 14 0 R 16 0 R 19 0 R 20 0 R 21 0 R 26 0 R 25 0 R] 
+<< /Nums [0 [ 14 0 R 16 0 R 19 0 R 20 0 R 21 0 R 25 0 R 24 0 R] 
 1 16 0 R
 ] >>
 endobj
-46 0 obj
-<< /Limits [(ID.002) (ID.016)]/Names [(ID.002) 10 0 R (ID.003) 11 0 R (ID.004) 12 0 R (ID.005) 13 0 R (ID.006) 14 0 R (ID.007) 15 0 R (ID.008) 16 0 R (ID.009) 19 0 R (ID.010) 20 0 R (ID.011) 21 0 R (ID.012) 22 0 R (ID.013) 23 0 R (ID.014) 24 0 R (ID.015) 25 0 R (ID.016) 26 0 R ] >>
+45 0 obj
+<< /Limits [(ID.002) (ID.015)]/Names [(ID.002) 10 0 R (ID.003) 11 0 R (ID.004) 12 0 R (ID.005) 13 0 R (ID.006) 14 0 R (ID.007) 15 0 R (ID.008) 16 0 R (ID.009) 19 0 R (ID.010) 20 0 R (ID.011) 21 0 R (ID.012) 22 0 R (ID.013) 23 0 R (ID.014) 24 0 R (ID.015) 25 0 R ] >>
 endobj
-47 0 obj
-<< /Kids [46 0 R] >>
+46 0 obj
+<< /Kids [45 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
 endobj
-48 0 obj
+47 0 obj
 << /center <</O/Layout/TextAlign/Center>>
 /justify <</O/Layout/TextAlign/Justify>>
 /TH-both <</O/Table/Scope/Both>>
@@ -431,47 +431,44 @@ endobj
 <<  /Type /StructElem /C /center /S /text /P 13 0 R /K <</Type /MCR /Pg 9 0 R /MCID 4>>  /ID (ID.011) >>
 endobj
 22 0 obj
-<<  /Type /StructElem /S /footnote /P 10 0 R /Ref [ 15 0 R ] /K [23 0 R 24 0 R] /ID (ID.012) >>
+<<  /Type /StructElem /S /footnote /P 10 0 R /Ref [ 15 0 R ] /K [25 0 R 23 0 R] /ID (ID.012) >>
 endobj
 23 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 22 0 R /K 26 0 R /ID (ID.013) >>
+<<  /Type /StructElem /S /text-unit /P 22 0 R /K 24 0 R /ID (ID.013) >>
 endobj
 24 0 obj
-<<  /Type /StructElem /S /text-unit /P 22 0 R /K 25 0 R /ID (ID.014) >>
+<<  /Type /StructElem /C /justify /S /text /P 23 0 R /K [  <</Type /MCR /Pg 9 0 R /MCID 6>>  ] /ID (ID.014) >>
 endobj
 25 0 obj
-<<  /Type /StructElem /C /justify /S /text /P 24 0 R /K [  <</Type /MCR /Pg 9 0 R /MCID 6>>  ] /ID (ID.015) >>
-endobj
-26 0 obj
-<<  /Type /StructElem /S /NonStruct /P 23 0 R /K <</Type /MCR /Pg 9 0 R /MCID 5>>  /ID (ID.016) >>
+<<  /Type /StructElem /S /footnotelabel /P 22 0 R /K <</Type /MCR /Pg 9 0 R /MCID 5>>  /ID (ID.015) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 47 0 R /ClassMap 48 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 10 0 R >>
+<<  /Type /StructTreeRoot /IDTree 46 0 R /ClassMap 47 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 10 0 R >>
 endobj
-49 0 obj
+48 0 obj
 [611.1 ]
 endobj
-50 0 obj
+49 0 obj
 [770.7 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 513.9 571 0 0 457.2 0 0 571 285.5 0 0 285.5 0 0 513.9 0 0 0 405.4 399.7 571 0 742.3 ]
 endobj
-51 0 obj
+50 0 obj
 [272 0 0 0 489.6 489.6 489.6 0 0 0 489.6 0 0 0 0 0 0 0 0 0 0 734 693.4 0 0 0 0 0 0 0 0 0 0 897.2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 489.6 0 0 0 0 0 0 544 0 0 0 0 0 0 489.6 0 0 380.8 0 380.8 544 0 0 0 516.8 ]
 endobj
-52 0 obj
+51 0 obj
 [ 103 [ 333 ] ]
 endobj
-54 0 obj
+53 0 obj
 << /Length 13 >>         
 [BINARY STREAM]
 endobj
-55 0 obj
+54 0 obj
 << /Subtype /CIDFontType0C /Length 506 >>        
 [BINARY STREAM]
 endobj
-53 0 obj
-<< /Type /FontDescriptor /FontName /XVZVYO+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 55 0 R /CIDSet 54 0 R >>
+52 0 obj
+<< /Type /FontDescriptor /FontName /XVZVYO+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 54 0 R /CIDSet 53 0 R >>
 endobj
-56 0 obj
+55 0 obj
 << /Length 692 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -507,44 +504,44 @@ end
 %%EOF
 endstream
 endobj
-35 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /XVZVYO+LMRoman10-Regular /DescendantFonts [ 57 0 R ] /ToUnicode 56 0 R >>
+34 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /XVZVYO+LMRoman10-Regular /DescendantFonts [ 56 0 R ] /ToUnicode 55 0 R >>
+endobj
+56 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /XVZVYO+LMRoman10-Regular /FontDescriptor 52 0 R /W 51 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 57 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /XVZVYO+LMRoman10-Regular /FontDescriptor 53 0 R /W 52 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-58 0 obj
 [693.3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 406.4 0 0 0 249.6 0 0 249.6 0 0 0 0 0 0 0 354.1 ]
 endobj
-60 0 obj
+59 0 obj
 << /Length1 1599 /Length2 8302 /Length3 0 /Length 9901 >>       
 [BINARY STREAM]
 endobj
-59 0 obj
-<< /Type /FontDescriptor /FontName /VBFROV+CMR12 /Flags 4 /FontBBox [ -34 -251 988 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 65 /XHeight 431 /CharSet( /A /B /M /a /comma /h /o /one /r /six /t /two /u /y /zero) /FontFile 60 0 R >>
+58 0 obj
+<< /Type /FontDescriptor /FontName /VBFROV+CMR12 /Flags 4 /FontBBox [ -34 -251 988 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 65 /XHeight 431 /CharSet( /A /B /M /a /comma /h /o /one /r /six /t /two /u /y /zero) /FontFile 59 0 R >>
 endobj
-62 0 obj
+61 0 obj
 << /Length1 1444 /Length2 6633 /Length3 0 /Length 8077 >>       
 [BINARY STREAM]
 endobj
-61 0 obj
-<< /Type /FontDescriptor /FontName /PXLAWO+CMR17 /Flags 4 /FontBBox [ -33 -250 945 749 ] /Ascent 694 /CapHeight 683 /Descent -195 /ItalicAngle 0 /StemV 53 /XHeight 430 /CharSet( /A /e /i /l /t) /FontFile 62 0 R >>
+60 0 obj
+<< /Type /FontDescriptor /FontName /PXLAWO+CMR17 /Flags 4 /FontBBox [ -33 -250 945 749 ] /Ascent 694 /CapHeight 683 /Descent -195 /ItalicAngle 0 /StemV 53 /XHeight 430 /CharSet( /A /e /i /l /t) /FontFile 61 0 R >>
 endobj
-64 0 obj
+63 0 obj
 << /Length1 1379 /Length2 5945 /Length3 0 /Length 7324 >>       
 [BINARY STREAM]
 endobj
-63 0 obj
-<< /Type /FontDescriptor /FontName /WIRDCL+CMR6 /Flags 4 /FontBBox [ -20 -250 1193 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 83 /XHeight 431 /CharSet( /one) /FontFile 64 0 R >>
+62 0 obj
+<< /Type /FontDescriptor /FontName /WIRDCL+CMR6 /Flags 4 /FontBBox [ -20 -250 1193 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 83 /XHeight 431 /CharSet( /one) /FontFile 63 0 R >>
 endobj
-66 0 obj
+65 0 obj
 << /Length1 1540 /Length2 8783 /Length3 0 /Length 10323 >>      
 [BINARY STREAM]
 endobj
-65 0 obj
-<< /Type /FontDescriptor /FontName /DTRHJH+CMR9 /Flags 4 /FontBBox [ -39 -250 1036 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 74 /XHeight 431 /CharSet( /N /a /b /e /h /i /l /o /s /t /u /w) /FontFile 66 0 R >>
+64 0 obj
+<< /Type /FontDescriptor /FontName /DTRHJH+CMR9 /Flags 4 /FontBBox [ -39 -250 1036 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 74 /XHeight 431 /CharSet( /N /a /b /e /h /i /l /o /s /t /u /w) /FontFile 65 0 R >>
 endobj
-67 0 obj
+66 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -664,10 +661,10 @@ end
 %%EOF
 endstream
 endobj
-36 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /VBFROV+CMR12 /FontDescriptor 59 0 R /FirstChar 44 /LastChar 121 /Widths 51 0 R /ToUnicode 67 0 R >>
+35 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /VBFROV+CMR12 /FontDescriptor 58 0 R /FirstChar 44 /LastChar 121 /Widths 50 0 R /ToUnicode 66 0 R >>
 endobj
-68 0 obj
+67 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -787,10 +784,10 @@ end
 %%EOF
 endstream
 endobj
-34 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /PXLAWO+CMR17 /FontDescriptor 61 0 R /FirstChar 65 /LastChar 116 /Widths 58 0 R /ToUnicode 68 0 R >>
+33 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /PXLAWO+CMR17 /FontDescriptor 60 0 R /FirstChar 65 /LastChar 116 /Widths 57 0 R /ToUnicode 67 0 R >>
 endobj
-69 0 obj
+68 0 obj
 << /Length 1719 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -910,10 +907,10 @@ end
 %%EOF
 endstream
 endobj
-42 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /WIRDCL+CMR6 /FontDescriptor 63 0 R /FirstChar 49 /LastChar 49 /Widths 49 0 R /ToUnicode 69 0 R >>
+41 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /WIRDCL+CMR6 /FontDescriptor 62 0 R /FirstChar 49 /LastChar 49 /Widths 48 0 R /ToUnicode 68 0 R >>
 endobj
-70 0 obj
+69 0 obj
 << /Length 1719 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -1033,53 +1030,52 @@ end
 %%EOF
 endstream
 endobj
-37 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /DTRHJH+CMR9 /FontDescriptor 65 0 R /FirstChar 78 /LastChar 119 /Widths 50 0 R /ToUnicode 70 0 R >>
+36 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /DTRHJH+CMR9 /FontDescriptor 64 0 R /FirstChar 78 /LastChar 119 /Widths 49 0 R /ToUnicode 69 0 R >>
 endobj
-43 0 obj
+42 0 obj
 << /Type /Pages  /Count 1 /Kids [ 9 0 R ] >>
 endobj
+70 0 obj
+<< /Names [ (Doc-Start) 31 0 R (footnote*.12) 39 0 R (footnote*.7) 37 0 R (page.1) 29 0 R ] /Limits [ (Doc-Start) (page.1) ] >>
+endobj
 71 0 obj
-<< /Names [ (Doc-Start) 32 0 R (footnote*.12) 40 0 R (footnote*.7) 38 0 R (page.1) 30 0 R ] /Limits [ (Doc-Start) (page.1) ] >>
+<< /Dests 70 0 R >>
 endobj
 72 0 obj
-<< /Dests 71 0 R >>
+<< /Type /Catalog /Pages 42 0 R /Names 71 0 R /MarkInfo 44 0 R/PageMode /UseOutlines/OpenAction <</S/GoTo /D [9 0 R /Fit] /SD [10 0 R/Fit]>>/Lang (en)/PageLabels <</Nums[0<</S/D>>]>>/StructTreeRoot 5 0 R/Metadata 26 0 R >>
 endobj
 73 0 obj
-<< /Type /Catalog /Pages 43 0 R /Names 72 0 R /MarkInfo 45 0 R/PageMode /UseOutlines/OpenAction <</S/GoTo /D [9 0 R /Fit] /SD [10 0 R/Fit]>>/Lang (en)/PageLabels <</Nums[0<</S/D>>]>>/StructTreeRoot 5 0 R/Metadata 27 0 R >>
-endobj
-74 0 obj
 << /Producer (LuaTeX)/Creator <FEFF004C006100540065005800200077006900740068002000680079007000650072007200650066>/Title <FEFF00410020007400690074006C0065002000730065007400200077006900740068002000680079007000650072007200650066>/Author <FEFF0061007500740068006F0072002000410020002C0061007500740068006F007200200042>/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 75
+0 74
 0000000002 65535 f 
 0000014788 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000017699 00000 n 
+0000017595 00000 n 
 0000014871 00000 n 
-0000015301 00000 n 
+0000015285 00000 n 
 0000000000 00000 f 
 0000013803 00000 n 
-0000016081 00000 n 
-0000016176 00000 n 
-0000016252 00000 n 
-0000016328 00000 n 
-0000016439 00000 n 
-0000016571 00000 n 
-0000016682 00000 n 
+0000016065 00000 n 
+0000016160 00000 n 
+0000016236 00000 n 
+0000016312 00000 n 
+0000016423 00000 n 
+0000016555 00000 n 
+0000016666 00000 n 
 0000013979 00000 n 
 0000000020 00000 n 
-0000016801 00000 n 
-0000016923 00000 n 
-0000017044 00000 n 
-0000017165 00000 n 
-0000017277 00000 n 
-0000017369 00000 n 
-0000017457 00000 n 
-0000017584 00000 n 
+0000016785 00000 n 
+0000016907 00000 n 
+0000017028 00000 n 
+0000017149 00000 n 
+0000017261 00000 n 
+0000017349 00000 n 
+0000017476 00000 n 
 0000000073 00000 n 
 0000014653 00000 n 
 0000012161 00000 n 
@@ -1087,49 +1083,49 @@ xref
 0000014259 00000 n 
 0000014311 00000 n 
 0000014372 00000 n 
-0000061116 00000 n 
-0000019898 00000 n 
-0000059174 00000 n 
-0000064988 00000 n 
+0000061012 00000 n 
+0000019794 00000 n 
+0000059070 00000 n 
+0000064884 00000 n 
 0000014425 00000 n 
 0000014486 00000 n 
 0000014539 00000 n 
 0000014600 00000 n 
-0000063053 00000 n 
-0000065145 00000 n 
+0000062949 00000 n 
+0000065041 00000 n 
 0000013952 00000 n 
 0000014835 00000 n 
 0000014965 00000 n 
-0000015264 00000 n 
-0000015880 00000 n 
-0000017818 00000 n 
-0000017843 00000 n 
-0000017988 00000 n 
-0000018215 00000 n 
-0000018910 00000 n 
-0000018247 00000 n 
-0000018320 00000 n 
-0000019146 00000 n 
-0000020052 00000 n 
-0000020252 00000 n 
-0000030395 00000 n 
-0000020395 00000 n 
-0000038844 00000 n 
-0000030668 00000 n 
-0000046497 00000 n 
-0000039074 00000 n 
-0000057139 00000 n 
-0000046717 00000 n 
-0000057390 00000 n 
-0000059332 00000 n 
-0000061274 00000 n 
-0000063209 00000 n 
-0000065206 00000 n 
-0000065350 00000 n 
-0000065386 00000 n 
-0000065625 00000 n 
+0000015248 00000 n 
+0000015864 00000 n 
+0000017714 00000 n 
+0000017739 00000 n 
+0000017884 00000 n 
+0000018111 00000 n 
+0000018806 00000 n 
+0000018143 00000 n 
+0000018216 00000 n 
+0000019042 00000 n 
+0000019948 00000 n 
+0000020148 00000 n 
+0000030291 00000 n 
+0000020291 00000 n 
+0000038740 00000 n 
+0000030564 00000 n 
+0000046393 00000 n 
+0000038970 00000 n 
+0000057035 00000 n 
+0000046613 00000 n 
+0000057286 00000 n 
+0000059228 00000 n 
+0000061170 00000 n 
+0000063105 00000 n 
+0000065102 00000 n 
+0000065246 00000 n 
+0000065282 00000 n 
+0000065521 00000 n 
 trailer
-<< /Size 75 /Root 73 0 R /Info 74 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 74 /Root 72 0 R /Info 73 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-66033
+65929
 %%EOF

--- a/required/latex-lab/testfiles-title/title-006.tpf
+++ b/required/latex-lab/testfiles-title/title-006.tpf
@@ -3,7 +3,7 @@
 18 0 obj
 << /Type/OBJR/Obj 17 0 R/Pg 9 0 R >>
 endobj
-27 0 obj
+26 0 obj
 <<
 /Type /Metadata /Subtype /XML
 /Length 11996     
@@ -251,7 +251,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-29 0 obj
+28 0 obj
 <<
 /Length 1207      
 >>
@@ -313,11 +313,11 @@ endobj
 9 0 obj
 <<
 /Type /Page
-/Contents 29 0 R
-/Resources 28 0 R
+/Contents 28 0 R
+/Resources 27 0 R
 /MediaBox [0 0 612 792]
 /Tabs /S /StructParents 0 
-/Parent 43 0 R
+/Parent 42 0 R
 /Annots [ 17 0 R ]
 >>
 endobj
@@ -327,69 +327,69 @@ endobj
 /Subtype /Link
 /Contents (ref) /Border [0 0 1] /H /I /C [0.701176 0.4 0.414118] /StructParent 1 
 /Rect [324.584 476.388 332.926 492.336]
-/A << /S /GoTo /D (footnote*.7) /SD 39 0 R >>
+/A << /S /GoTo /D (footnote*.7) /SD 38 0 R >>
 >>
 endobj
-30 0 obj
+29 0 obj
 <<
 /D [9 0 R /XYZ 132.768 705.06 null]
 >>
 endobj
-31 0 obj
+30 0 obj
 [10 0 R /XYZ 132.768 705.06 null]
 endobj
-32 0 obj
+31 0 obj
 <<
 /D [9 0 R /XYZ 133.768 667.198 null]
 >>
 endobj
-33 0 obj
+32 0 obj
 [10 0 R /XYZ 133.768 667.198 null]
 endobj
-38 0 obj
+37 0 obj
 <<
 /D [9 0 R /XYZ 133.768 231.667 null]
 >>
+endobj
+38 0 obj
+[24 0 R /XYZ 133.768 231.667 null]
 endobj
 39 0 obj
-[25 0 R /XYZ 133.768 231.667 null]
-endobj
-40 0 obj
 <<
 /D [9 0 R /XYZ 133.768 231.667 null]
 >>
 endobj
-41 0 obj
-[25 0 R /XYZ 133.768 231.667 null]
+40 0 obj
+[24 0 R /XYZ 133.768 231.667 null]
 endobj
-28 0 obj
+27 0 obj
 <<
 /ExtGState 1 0 R 
-/Font << /F40 34 0 R /F65 35 0 R /F49 36 0 R /F50 37 0 R /F64 42 0 R >>
+/Font << /F40 33 0 R /F65 34 0 R /F49 35 0 R /F50 36 0 R /F64 41 0 R >>
 /ProcSet [ /PDF /Text ]
 >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-44 0 obj
+43 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 14 0 R 15 0 R 16 0 R 15 0 R 14 0 R 19 0 R 20 0 R 21 0 R 25 0 R 26 0 R 25 0 R 25 0 R 25 0 R ]
+<< /Nums [0 [ 14 0 R 15 0 R 16 0 R 15 0 R 14 0 R 19 0 R 20 0 R 21 0 R 24 0 R 25 0 R 24 0 R 24 0 R 24 0 R ]
 1 16 0 R
 ] >>
 endobj
-45 0 obj
-<< /Limits [(ID.002) (ID.016)]/Names [(ID.002) 10 0 R (ID.003) 11 0 R (ID.004) 12 0 R (ID.005) 13 0 R (ID.006) 14 0 R (ID.007) 15 0 R (ID.008) 16 0 R (ID.009) 19 0 R (ID.010) 20 0 R (ID.011) 21 0 R (ID.012) 22 0 R (ID.013) 23 0 R (ID.014) 24 0 R (ID.015) 25 0 R (ID.016) 26 0 R ] >>
+44 0 obj
+<< /Limits [(ID.002) (ID.015)]/Names [(ID.002) 10 0 R (ID.003) 11 0 R (ID.004) 12 0 R (ID.005) 13 0 R (ID.006) 14 0 R (ID.007) 15 0 R (ID.008) 16 0 R (ID.009) 19 0 R (ID.010) 20 0 R (ID.011) 21 0 R (ID.012) 22 0 R (ID.013) 23 0 R (ID.014) 24 0 R (ID.015) 25 0 R ] >>
 endobj
-46 0 obj
-<< /Kids [45 0 R] >>
+45 0 obj
+<< /Kids [44 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
 endobj
-47 0 obj
+46 0 obj
 << /center <</O/Layout/TextAlign/Center>>
 /justify <</O/Layout/TextAlign/Justify>>
 /TH-both <</O/Table/Scope/Both>>
@@ -428,39 +428,36 @@ endobj
 <<  /Type /StructElem /C /center /S /text /P 13 0 R /K <</Type /MCR /Pg 9 0 R/MCID 7>> /ID (ID.011) >>
 endobj
 22 0 obj
-<<  /Type /StructElem /S /footnote /P 10 0 R /Ref [ 15 0 R ] /K [23 0 R 24 0 R] /ID (ID.012) >>
+<<  /Type /StructElem /S /footnote /P 10 0 R /Ref [ 15 0 R ] /K [25 0 R 23 0 R] /ID (ID.012) >>
 endobj
 23 0 obj
-<<  /Type /StructElem /S /footnotelabel /P 22 0 R /K 26 0 R /ID (ID.013) >>
+<<  /Type /StructElem /S /text-unit /P 22 0 R /K 24 0 R /ID (ID.013) >>
 endobj
 24 0 obj
-<<  /Type /StructElem /S /text-unit /P 22 0 R /K 25 0 R /ID (ID.014) >>
+<<  /Type /StructElem /C /justify /S /text /P 23 0 R /K [<</Type /MCR /Pg 9 0 R/MCID 8>> <</Type /MCR /Pg 9 0 R/MCID 10>> <</Type /MCR /Pg 9 0 R/MCID 11>> <</Type /MCR /Pg 9 0 R/MCID 12>>] /ID (ID.014) >>
 endobj
 25 0 obj
-<<  /Type /StructElem /C /justify /S /text /P 24 0 R /K [<</Type /MCR /Pg 9 0 R/MCID 8>> <</Type /MCR /Pg 9 0 R/MCID 10>> <</Type /MCR /Pg 9 0 R/MCID 11>> <</Type /MCR /Pg 9 0 R/MCID 12>>] /ID (ID.015) >>
-endobj
-26 0 obj
-<<  /Type /StructElem /S /NonStruct /P 23 0 R /K <</Type /MCR /Pg 9 0 R/MCID 9>> /ID (ID.016) >>
+<<  /Type /StructElem /S /footnotelabel /P 22 0 R /K <</Type /MCR /Pg 9 0 R/MCID 9>> /ID (ID.015) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /IDTree 46 0 R /ClassMap 47 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 10 0 R >>
+<<  /Type /StructTreeRoot /IDTree 45 0 R /ClassMap 46 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 10 0 R >>
 endobj
-49 0 obj
+48 0 obj
 [611]
 endobj
-50 0 obj
+49 0 obj
 [770.5 799.2 699.2 799.2 756.3 570.8 742.1 770.5 770.5 1055.9 770.5 770.5 627.9 285.4 513.8 285.4 627.9 799.2 285.4 513.8 570.8 456.7 570.8 457.1 314 513.8 570.8 285.4 314 542.3 285.4 856.3 570.8 513.8 570.8 542.3 401.9 405.3 399.6 570.8 542.3 742.1]
 endobj
-51 0 obj
+50 0 obj
 [271.9 326.3 271.9 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 271.9 271.9 761.4 761.4 761.4 462.3 761.4 733.8 693.2 707 747.6 666 638.8 768.1 733.8 353.2 502.9 761 611.7 897 733.8 761.4 666 761.4 720.4 543.8 707 733.8 733.8 1005.8 733.8 733.8 598.2 271.9 489.5 271.9 598.2 761.4 271.9 489.5 543.8 435.1 543.8 435.1 299.1 489.5 543.8 271.9 299.1 516.7 271.9 815.8 543.8 489.5 543.8 516.7 380.7 386.1 380.7 543.8 516.7 707 516.7 516.7]
 endobj
-52 0 obj
+51 0 obj
 [333]
 endobj
-53 0 obj
+52 0 obj
 [704.4 665.4 678.7 717.7 639.3 613.2 737.3 704.4 338.8 482.6 730.5 587.1 861.1 704.4 730.9 639.3 730.9 691.5 522 678.7 704.4 704.4 965.6 704.4 704.4 574.2 260.8 469.8 260.8 574.2 730.9 260.8 469.8 522 417.5 522 417.5 287 469.8 522 260.8 287 495.9 260.8 783.1 522 469.8 522 495.9 365.3 370.5 365.3]
 endobj
-54 0 obj
+53 0 obj
 <<
 /Length1 1144
 /Length2 1422
@@ -469,7 +466,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-55 0 obj
+54 0 obj
 <<
 /Type /FontDescriptor
 /FontName /MUQHVU+PdfTeX-Space
@@ -482,10 +479,10 @@ endobj
 /StemV 0
 /XHeight 500
 /CharSet (/space)
-/FontFile 54 0 R
+/FontFile 53 0 R
 >>
 endobj
-56 0 obj
+55 0 obj
 <<
 /Length1 721
 /Length2 13847
@@ -494,7 +491,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-57 0 obj
+56 0 obj
 <<
 /Type /FontDescriptor
 /FontName /WMNOAL+SFRM0600
@@ -507,10 +504,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/one)
-/FontFile 56 0 R
+/FontFile 55 0 R
 >>
 endobj
-58 0 obj
+57 0 obj
 <<
 /Length1 721
 /Length2 14175
@@ -519,7 +516,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-59 0 obj
+58 0 obj
 <<
 /Type /FontDescriptor
 /FontName /ZEXONM+SFRM0900
@@ -532,10 +529,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/N/a/b/e/h/i/l/o/s/t/u/w)
-/FontFile 58 0 R
+/FontFile 57 0 R
 >>
 endobj
-60 0 obj
+59 0 obj
 <<
 /Length1 721
 /Length2 11987
@@ -544,7 +541,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-61 0 obj
+60 0 obj
 <<
 /Type /FontDescriptor
 /FontName /XGEWRW+SFRM1200
@@ -557,10 +554,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/A/B/M/a/comma/h/o/one/r/six/t/two/u/y/zero)
-/FontFile 60 0 R
+/FontFile 59 0 R
 >>
 endobj
-62 0 obj
+61 0 obj
 <<
 /Length1 721
 /Length2 6947
@@ -569,7 +566,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-63 0 obj
+62 0 obj
 <<
 /Type /FontDescriptor
 /FontName /EMNKTC+SFRM1728
@@ -582,16 +579,16 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/A/e/i/l/t)
-/FontFile 62 0 R
+/FontFile 61 0 R
 >>
 endobj
-48 0 obj
+47 0 obj
 <<
 /Type /Encoding
 /Differences [44/comma 48/zero/one/two 54/six 65/A/B 77/M/N 97/a/b 101/e 104/h/i 108/l 111/o 114/r/s/t/u 119/w 121/y]
 >>
 endobj
-64 0 obj
+63 0 obj
 <<
 /Length 2030      
 >>
@@ -735,20 +732,20 @@ end
 %%EOF
 endstream
 endobj
-42 0 obj
+41 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /WMNOAL+SFRM0600
-/FontDescriptor 57 0 R
+/FontDescriptor 56 0 R
 /FirstChar 49
 /LastChar 49
-/Widths 49 0 R
-/Encoding 48 0 R
-/ToUnicode 64 0 R
+/Widths 48 0 R
+/Encoding 47 0 R
+/ToUnicode 63 0 R
 >>
 endobj
-65 0 obj
+64 0 obj
 <<
 /Length 2030      
 >>
@@ -892,20 +889,20 @@ end
 %%EOF
 endstream
 endobj
-37 0 obj
+36 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /ZEXONM+SFRM0900
-/FontDescriptor 59 0 R
+/FontDescriptor 58 0 R
 /FirstChar 78
 /LastChar 119
-/Widths 50 0 R
-/Encoding 48 0 R
-/ToUnicode 65 0 R
+/Widths 49 0 R
+/Encoding 47 0 R
+/ToUnicode 64 0 R
 >>
 endobj
-66 0 obj
+65 0 obj
 <<
 /Length 2030      
 >>
@@ -1049,20 +1046,20 @@ end
 %%EOF
 endstream
 endobj
-36 0 obj
+35 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /XGEWRW+SFRM1200
-/FontDescriptor 61 0 R
+/FontDescriptor 60 0 R
 /FirstChar 44
 /LastChar 121
-/Widths 51 0 R
-/Encoding 48 0 R
-/ToUnicode 66 0 R
+/Widths 50 0 R
+/Encoding 47 0 R
+/ToUnicode 65 0 R
 >>
 endobj
-67 0 obj
+66 0 obj
 <<
 /Length 2030      
 >>
@@ -1206,20 +1203,20 @@ end
 %%EOF
 endstream
 endobj
-34 0 obj
+33 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /EMNKTC+SFRM1728
-/FontDescriptor 63 0 R
+/FontDescriptor 62 0 R
 /FirstChar 65
 /LastChar 116
-/Widths 53 0 R
-/Encoding 48 0 R
-/ToUnicode 67 0 R
+/Widths 52 0 R
+/Encoding 47 0 R
+/ToUnicode 66 0 R
 >>
 endobj
-68 0 obj
+67 0 obj
 <<
 /Length 654       
 >>
@@ -1257,79 +1254,78 @@ end
 %%EOF
 endstream
 endobj
-35 0 obj
+34 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /MUQHVU+PdfTeX-Space
-/FontDescriptor 55 0 R
+/FontDescriptor 54 0 R
 /FirstChar 32
 /LastChar 32
-/Widths 52 0 R
-/ToUnicode 68 0 R
+/Widths 51 0 R
+/ToUnicode 67 0 R
 >>
 endobj
-43 0 obj
+42 0 obj
 <<
 /Type /Pages
 /Count 1
 /Kids [9 0 R]
 >>
 endobj
+68 0 obj
+<<
+/Names [(Doc-Start) 31 0 R (footnote*.12) 39 0 R (footnote*.7) 37 0 R (page.1) 29 0 R]
+/Limits [(Doc-Start) (page.1)]
+>>
+endobj
 69 0 obj
 <<
-/Names [(Doc-Start) 32 0 R (footnote*.12) 40 0 R (footnote*.7) 38 0 R (page.1) 30 0 R]
-/Limits [(Doc-Start) (page.1)]
+/Dests 68 0 R
 >>
 endobj
 70 0 obj
 <<
-/Dests 69 0 R
+/Type /Catalog
+/Pages 42 0 R
+/Names 69 0 R
+/MarkInfo 43 0 R/PageMode /UseOutlines/OpenAction <</S/GoTo /D [9 0 R /Fit] /SD [10 0 R/Fit]>>/Lang (en)/PageLabels <</Nums[0<</S/D>>]>>/StructTreeRoot 5 0 R/Metadata 26 0 R
 >>
 endobj
 71 0 obj
-<<
-/Type /Catalog
-/Pages 43 0 R
-/Names 70 0 R
-/MarkInfo 44 0 R/PageMode /UseOutlines/OpenAction <</S/GoTo /D [9 0 R /Fit] /SD [10 0 R/Fit]>>/Lang (en)/PageLabels <</Nums[0<</S/D>>]>>/StructTreeRoot 5 0 R/Metadata 27 0 R
->>
-endobj
-72 0 obj
 <<
 /Producer (pdfTeX)/Creator <FEFF004C006100540065005800200077006900740068002000680079007000650072007200650066>/Title <FEFF00410020007400690074006C0065002000730065007400200077006900740068002000680079007000650072007200650066>/Author <FEFF0061007500740068006F0072002000410020002C0061007500740068006F007200200042>/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z)
 /Trapped /False
 >>
 endobj
 xref
-0 73
+0 72
 0000000002 65535 f 
 0000014364 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000008 00000 f 
-0000017492 00000 n 
+0000017388 00000 n 
 0000014447 00000 n 
-0000014919 00000 n 
+0000014903 00000 n 
 0000000000 00000 f 
 0000013419 00000 n 
-0000015699 00000 n 
-0000015794 00000 n 
-0000015870 00000 n 
-0000015946 00000 n 
-0000016057 00000 n 
-0000016218 00000 n 
-0000016391 00000 n 
+0000015683 00000 n 
+0000015778 00000 n 
+0000015854 00000 n 
+0000015930 00000 n 
+0000016041 00000 n 
+0000016202 00000 n 
+0000016375 00000 n 
 0000013572 00000 n 
 0000000015 00000 n 
-0000016508 00000 n 
-0000016628 00000 n 
-0000016747 00000 n 
-0000016866 00000 n 
-0000016978 00000 n 
-0000017070 00000 n 
-0000017158 00000 n 
-0000017379 00000 n 
+0000016492 00000 n 
+0000016612 00000 n 
+0000016731 00000 n 
+0000016850 00000 n 
+0000016962 00000 n 
+0000017050 00000 n 
+0000017271 00000 n 
 0000000068 00000 n 
 0000014228 00000 n 
 0000012153 00000 n 
@@ -1337,50 +1333,50 @@ xref
 0000013848 00000 n 
 0000013898 00000 n 
 0000013957 00000 n 
-0000081824 00000 n 
-0000082715 00000 n 
-0000079557 00000 n 
-0000077290 00000 n 
+0000081720 00000 n 
+0000082611 00000 n 
+0000079453 00000 n 
+0000077186 00000 n 
 0000014008 00000 n 
 0000014067 00000 n 
 0000014118 00000 n 
 0000014177 00000 n 
-0000075024 00000 n 
-0000082879 00000 n 
+0000074920 00000 n 
+0000082775 00000 n 
 0000014411 00000 n 
 0000014583 00000 n 
-0000014882 00000 n 
-0000015498 00000 n 
-0000072779 00000 n 
-0000017611 00000 n 
-0000017633 00000 n 
-0000017900 00000 n 
-0000018373 00000 n 
-0000018395 00000 n 
-0000018709 00000 n 
-0000021373 00000 n 
-0000021591 00000 n 
-0000036257 00000 n 
-0000036480 00000 n 
-0000051474 00000 n 
-0000051717 00000 n 
-0000064523 00000 n 
-0000064785 00000 n 
-0000072550 00000 n 
-0000072935 00000 n 
-0000075201 00000 n 
-0000077468 00000 n 
-0000079735 00000 n 
-0000082002 00000 n 
-0000082937 00000 n 
-0000083077 00000 n 
-0000083113 00000 n 
-0000083352 00000 n 
+0000014866 00000 n 
+0000015482 00000 n 
+0000072675 00000 n 
+0000017507 00000 n 
+0000017529 00000 n 
+0000017796 00000 n 
+0000018269 00000 n 
+0000018291 00000 n 
+0000018605 00000 n 
+0000021269 00000 n 
+0000021487 00000 n 
+0000036153 00000 n 
+0000036376 00000 n 
+0000051370 00000 n 
+0000051613 00000 n 
+0000064419 00000 n 
+0000064681 00000 n 
+0000072446 00000 n 
+0000072831 00000 n 
+0000075097 00000 n 
+0000077364 00000 n 
+0000079631 00000 n 
+0000081898 00000 n 
+0000082833 00000 n 
+0000082973 00000 n 
+0000083009 00000 n 
+0000083248 00000 n 
 trailer
-<< /Size 73
-/Root 71 0 R
-/Info 72 0 R
+<< /Size 72
+/Root 70 0 R
+/Info 71 0 R
 /ID [<9BD18DF3359C1216B83ADB4AA401CC9A> <9BD18DF3359C1216B83ADB4AA401CC9A>] >>
 startxref
-83760
+83656
 %%EOF

--- a/required/latex-lab/testfiles-title/title-007.luatex.tpf
+++ b/required/latex-lab/testfiles-title/title-007.luatex.tpf
@@ -1,6 +1,6 @@
 %PDF-2.0
 %Ã’¡‘≈ÿ–ƒ∆
-36 0 obj
+35 0 obj
 << /Type /Metadata /Subtype /XML /Length 11987 >>      
 stream
 <?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
@@ -245,7 +245,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-39 0 obj
+38 0 obj
 << /Length 1734 >>       
 stream
 /opacity1 gs
@@ -345,32 +345,32 @@ EMC
 EMC
 endstream
 endobj
-38 0 obj
-<< /Type /Page /Contents 39 0 R /Resources 37 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 48 0 R >>
-endobj
 37 0 obj
-<< /ExtGState 1 0 R /Font << /F17 40 0 R /F15 41 0 R /F28 42 0 R /F29 43 0 R /F18 44 0 R /F42 45 0 R /F30 46 0 R /F16 47 0 R >> >>
+<< /Type /Page /Contents 38 0 R /Resources 36 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 47 0 R >>
+endobj
+36 0 obj
+<< /ExtGState 1 0 R /Font << /F17 39 0 R /F15 40 0 R /F28 41 0 R /F29 42 0 R /F18 43 0 R /F42 44 0 R /F30 45 0 R /F16 46 0 R >> >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-49 0 obj
+48 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 35 0 R 34 0 R] 
+<< /Nums [0 [ 26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 34 0 R 33 0 R] 
 ] >>
 endobj
-50 0 obj
-<< /Limits [(ID.002) (ID.016)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 27 0 R (ID.009) 28 0 R (ID.010) 29 0 R (ID.011) 30 0 R (ID.012) 31 0 R (ID.013) 32 0 R (ID.014) 33 0 R (ID.015) 34 0 R (ID.016) 35 0 R ] >>
+49 0 obj
+<< /Limits [(ID.002) (ID.015)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 27 0 R (ID.009) 28 0 R (ID.010) 29 0 R (ID.011) 30 0 R (ID.012) 31 0 R (ID.013) 32 0 R (ID.014) 33 0 R (ID.015) 34 0 R ] >>
 endobj
-51 0 obj
-<< /Kids [50 0 R] >>
+50 0 obj
+<< /Kids [49 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
 endobj
-52 0 obj
+51 0 obj
 << /center <</O/Layout/TextAlign/Center>>
 /justify <</O/Layout/TextAlign/Justify>>
 /TH-both <</O/Table/Scope/Both>>
@@ -421,67 +421,64 @@ endobj
 <<  /Type /StructElem /S /Title /NS 11 0 R  /P 24 0 R /K [26 0 R 28 0 R] /ID (ID.006) >>
 endobj
 26 0 obj
-<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 25 0 R /K [<</Type /MCR /Pg 38 0 R /MCID 0>>  27 0 R ] /ID (ID.007) >>
+<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 25 0 R /K [<</Type /MCR /Pg 37 0 R /MCID 0>>  27 0 R ] /ID (ID.007) >>
 endobj
 27 0 obj
-<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 26 0 R /Ref [ 31 0 R ] /K <</Type /MCR /Pg 38 0 R /MCID 1>>  /ID (ID.008) >>
+<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 26 0 R /Ref [ 31 0 R ] /K <</Type /MCR /Pg 37 0 R /MCID 1>>  /ID (ID.008) >>
 endobj
 28 0 obj
-<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 25 0 R /K <</Type /MCR /Pg 38 0 R /MCID 2>>  /ID (ID.009) >>
+<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 25 0 R /K <</Type /MCR /Pg 37 0 R /MCID 2>>  /ID (ID.009) >>
 endobj
 29 0 obj
-<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 24 0 R /K <</Type /MCR /Pg 38 0 R /MCID 3>>  /ID (ID.010) >>
+<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 24 0 R /K <</Type /MCR /Pg 37 0 R /MCID 3>>  /ID (ID.010) >>
 endobj
 30 0 obj
-<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 24 0 R /K <</Type /MCR /Pg 38 0 R /MCID 4>>  /ID (ID.011) >>
+<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 24 0 R /K <</Type /MCR /Pg 37 0 R /MCID 4>>  /ID (ID.011) >>
 endobj
 31 0 obj
-<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 21 0 R /Ref [ 27 0 R ] /K [32 0 R 33 0 R] /ID (ID.012) >>
+<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 21 0 R /Ref [ 27 0 R ] /K [34 0 R 32 0 R] /ID (ID.012) >>
 endobj
 32 0 obj
-<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 31 0 R /K 35 0 R /ID (ID.013) >>
+<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 31 0 R /K 33 0 R /ID (ID.013) >>
 endobj
 33 0 obj
-<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 31 0 R /K 34 0 R /ID (ID.014) >>
+<<  /Type /StructElem /C /justify /S /text /NS 15 0 R  /P 32 0 R /K [  <</Type /MCR /Pg 37 0 R /MCID 6>>  ] /ID (ID.014) >>
 endobj
 34 0 obj
-<<  /Type /StructElem /C /justify /S /text /NS 15 0 R  /P 33 0 R /K [  <</Type /MCR /Pg 38 0 R /MCID 6>>  ] /ID (ID.015) >>
-endobj
-35 0 obj
-<<  /Type /StructElem /S /NonStruct /NS 11 0 R  /P 32 0 R /K <</Type /MCR /Pg 38 0 R /MCID 5>>  /ID (ID.016) >>
+<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 31 0 R /K <</Type /MCR /Pg 37 0 R /MCID 5>>  /ID (ID.015) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 51 0 R /ClassMap 52 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
+<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 50 0 R /ClassMap 51 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
 endobj
-53 0 obj
+52 0 obj
 [500 ]
 endobj
-54 0 obj
+53 0 obj
 [795.8 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 472.2 0 0 0 0 0 0 0 0 0 531.3 0 0 0 0 413.2 ]
 endobj
-56 0 obj
+55 0 obj
 [611 ]
 endobj
-57 0 obj
+56 0 obj
 [272 0 0 0 489.6 489.6 489.6 0 0 0 489.6 0 0 0 0 0 0 0 0 0 0 734 693.4 0 0 0 0 0 0 0 0 0 0 897.2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 489.6 0 0 0 0 0 0 544 0 0 0 0 0 0 489.6 0 0 380.8 0 380.8 544 0 0 0 516.8 ]
 endobj
-58 0 obj
+57 0 obj
 [513.9 571 0 0 457.2 0 0 571 285.5 0 0 285.5 0 0 0 0 0 0 405.4 399.7 571 0 742.3 ]
 endobj
-59 0 obj
+58 0 obj
 [489.5 ]
 endobj
-60 0 obj
+59 0 obj
 [ 103 [ 333 ] ]
 endobj
-62 0 obj
+61 0 obj
 << /Subtype /CIDFontType0C /Length 506 >>        
 [BINARY STREAM]
 endobj
-61 0 obj
-<< /Type /FontDescriptor /FontName /XVZVYO+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 62 0 R >>
+60 0 obj
+<< /Type /FontDescriptor /FontName /XVZVYO+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 61 0 R >>
 endobj
-63 0 obj
+62 0 obj
 << /Length 692 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -517,68 +514,68 @@ end
 %%EOF
 endstream
 endobj
-41 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /XVZVYO+LMRoman10-Regular /DescendantFonts [ 64 0 R ] /ToUnicode 63 0 R >>
+40 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /XVZVYO+LMRoman10-Regular /DescendantFonts [ 63 0 R ] /ToUnicode 62 0 R >>
+endobj
+63 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /XVZVYO+LMRoman10-Regular /FontDescriptor 60 0 R /W 59 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 64 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /XVZVYO+LMRoman10-Regular /FontDescriptor 61 0 R /W 60 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-65 0 obj
 [693.3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 406.4 0 0 0 249.6 0 0 249.6 0 0 0 0 0 0 0 354.1 ]
 endobj
-67 0 obj
+66 0 obj
 << /Length1 1387 /Length2 5943 /Length3 0 /Length 7330 >>       
 [BINARY STREAM]
 endobj
-66 0 obj
-<< /Type /FontDescriptor /FontName /SDXKYB+CMR10 /Flags 4 /FontBBox [ -40 -250 1009 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 69 /XHeight 431 /FontFile 67 0 R >>
+65 0 obj
+<< /Type /FontDescriptor /FontName /SDXKYB+CMR10 /Flags 4 /FontBBox [ -40 -250 1009 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 69 /XHeight 431 /FontFile 66 0 R >>
 endobj
-69 0 obj
+68 0 obj
 << /Length1 1599 /Length2 8302 /Length3 0 /Length 9901 >>       
 [BINARY STREAM]
 endobj
-68 0 obj
-<< /Type /FontDescriptor /FontName /VBFROV+CMR12 /Flags 4 /FontBBox [ -34 -251 988 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 65 /XHeight 431 /FontFile 69 0 R >>
+67 0 obj
+<< /Type /FontDescriptor /FontName /VBFROV+CMR12 /Flags 4 /FontBBox [ -34 -251 988 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 65 /XHeight 431 /FontFile 68 0 R >>
 endobj
-71 0 obj
+70 0 obj
 << /Length1 1444 /Length2 6633 /Length3 0 /Length 8077 >>       
 [BINARY STREAM]
 endobj
-70 0 obj
-<< /Type /FontDescriptor /FontName /PXLAWO+CMR17 /Flags 4 /FontBBox [ -33 -250 945 749 ] /Ascent 694 /CapHeight 683 /Descent -195 /ItalicAngle 0 /StemV 53 /XHeight 430 /FontFile 71 0 R >>
+69 0 obj
+<< /Type /FontDescriptor /FontName /PXLAWO+CMR17 /Flags 4 /FontBBox [ -33 -250 945 749 ] /Ascent 694 /CapHeight 683 /Descent -195 /ItalicAngle 0 /StemV 53 /XHeight 430 /FontFile 70 0 R >>
 endobj
-73 0 obj
+72 0 obj
 << /Length1 1422 /Length2 6395 /Length3 0 /Length 7817 >>       
 [BINARY STREAM]
 endobj
-72 0 obj
-<< /Type /FontDescriptor /FontName /FRWMVG+CMR8 /Flags 4 /FontBBox [ -36 -250 1070 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 76 /XHeight 431 /FontFile 73 0 R >>
+71 0 obj
+<< /Type /FontDescriptor /FontName /FRWMVG+CMR8 /Flags 4 /FontBBox [ -36 -250 1070 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 76 /XHeight 431 /FontFile 72 0 R >>
 endobj
-75 0 obj
+74 0 obj
 << /Length1 1511 /Length2 8440 /Length3 0 /Length 9951 >>       
 [BINARY STREAM]
 endobj
-74 0 obj
-<< /Type /FontDescriptor /FontName /BSXKTW+CMR9 /Flags 4 /FontBBox [ -39 -250 1036 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 74 /XHeight 431 /FontFile 75 0 R >>
+73 0 obj
+<< /Type /FontDescriptor /FontName /BSXKTW+CMR9 /Flags 4 /FontBBox [ -39 -250 1036 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 74 /XHeight 431 /FontFile 74 0 R >>
 endobj
-77 0 obj
+76 0 obj
 << /Length1 721 /Length2 1124 /Length3 0 /Length 1845 >>       
 [BINARY STREAM]
 endobj
-76 0 obj
-<< /Type /FontDescriptor /FontName /YIGRIT+SFRM0600 /Flags 4 /FontBBox [ -210 -320 1719 944 ] /Ascent 0 /CapHeight 0 /Descent 0 /ItalicAngle 0 /StemV 50 /XHeight 430 /FontFile 77 0 R >>
+75 0 obj
+<< /Type /FontDescriptor /FontName /YIGRIT+SFRM0600 /Flags 4 /FontBBox [ -210 -320 1719 944 ] /Ascent 0 /CapHeight 0 /Descent 0 /ItalicAngle 0 /StemV 50 /XHeight 430 /FontFile 76 0 R >>
 endobj
-79 0 obj
+78 0 obj
 << /Length1 721 /Length2 5420 /Length3 0 /Length 6141 >>       
 [BINARY STREAM]
 endobj
-78 0 obj
-<< /Type /FontDescriptor /FontName /RYQARY+SFRM1200 /Flags 4 /FontBBox [ -185 -320 1420 942 ] /Ascent 0 /CapHeight 0 /Descent 0 /ItalicAngle 0 /StemV 50 /XHeight 430 /FontFile 79 0 R >>
+77 0 obj
+<< /Type /FontDescriptor /FontName /RYQARY+SFRM1200 /Flags 4 /FontBBox [ -185 -320 1420 942 ] /Ascent 0 /CapHeight 0 /Descent 0 /ItalicAngle 0 /StemV 50 /XHeight 430 /FontFile 78 0 R >>
 endobj
-55 0 obj
+54 0 obj
 << /Type /Encoding /Differences [ 42 /asteriskmath ] >>
 endobj
-80 0 obj
+79 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -698,10 +695,10 @@ end
 %%EOF
 endstream
 endobj
-47 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /SDXKYB+CMR10 /FontDescriptor 66 0 R /FirstChar 49 /LastChar 49 /Widths 53 0 R /ToUnicode 80 0 R >>
+46 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /SDXKYB+CMR10 /FontDescriptor 65 0 R /FirstChar 49 /LastChar 49 /Widths 52 0 R /ToUnicode 79 0 R >>
 endobj
-81 0 obj
+80 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -821,10 +818,10 @@ end
 %%EOF
 endstream
 endobj
-44 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /VBFROV+CMR12 /FontDescriptor 68 0 R /FirstChar 44 /LastChar 121 /Widths 57 0 R /ToUnicode 81 0 R >>
+43 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /VBFROV+CMR12 /FontDescriptor 67 0 R /FirstChar 44 /LastChar 121 /Widths 56 0 R /ToUnicode 80 0 R >>
 endobj
-82 0 obj
+81 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -944,10 +941,10 @@ end
 %%EOF
 endstream
 endobj
-40 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /PXLAWO+CMR17 /FontDescriptor 70 0 R /FirstChar 65 /LastChar 116 /Widths 65 0 R /ToUnicode 82 0 R >>
+39 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /PXLAWO+CMR17 /FontDescriptor 69 0 R /FirstChar 65 /LastChar 116 /Widths 64 0 R /ToUnicode 81 0 R >>
 endobj
-83 0 obj
+82 0 obj
 << /Length 1719 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -1067,10 +1064,10 @@ end
 %%EOF
 endstream
 endobj
-46 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /FRWMVG+CMR8 /FontDescriptor 72 0 R /FirstChar 78 /LastChar 116 /Widths 54 0 R /ToUnicode 83 0 R >>
+45 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /FRWMVG+CMR8 /FontDescriptor 71 0 R /FirstChar 78 /LastChar 116 /Widths 53 0 R /ToUnicode 82 0 R >>
 endobj
-84 0 obj
+83 0 obj
 << /Length 1719 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -1190,8 +1187,119 @@ end
 %%EOF
 endstream
 endobj
-43 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /BSXKTW+CMR9 /FontDescriptor 74 0 R /FirstChar 97 /LastChar 119 /Widths 58 0 R /ToUnicode 84 0 R >>
+42 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /BSXKTW+CMR9 /FontDescriptor 73 0 R /FirstChar 97 /LastChar 119 /Widths 57 0 R /ToUnicode 83 0 R >>
+endobj
+84 0 obj
+<< /Length 1523 >>       
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: ProcSet (CIDInit)
+%%IncludeResource: ProcSet (CIDInit)
+%%BeginResource: CMap (TeX-cm-super-ts1-0)
+%%Title: (TeX-cm-super-ts1-0 TeX cm-super-ts1 0)
+%%Version: 1.000
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<< /Registry (TeX)
+/Ordering (cm-super-ts1)
+/Supplement 0
+>> def
+/CMapName /TeX-cm-super-ts1-0 def
+/CMapType 2 def
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+7 beginbfrange
+<30> <39> <0030>
+<84> <85> <2020>
+<A0> <A1> <2045>
+<A2> <AA> <00A2>
+<AE> <B7> <00AE>
+<B9> <BA> <00B9>
+<BC> <BE> <00BC>
+endbfrange
+66 beginbfchar
+<00> <0060>
+<01> <00B4>
+<04> <00A8>
+<05> <02DD>
+<07> <02C7>
+<09> <00AF>
+<0B> <00B8>
+<0C> <02DB>
+<0D> <201A>
+<12> <201E>
+<16> <F6DE>
+<17> <200C>
+<18> <2190>
+<19> <2192>
+<1F> <200C>
+<20> <2422>
+<24> <0024>
+<27> <0027>
+<2A> <2217>
+<2C> <002C>
+<2E> <002E>
+<2F> <2044>
+<3C> <2329>
+<3D> <2212>
+<3E> <232A>
+<4D> <2127>
+<4F> <25CB>
+<57> <2126>
+<5B> <301A>
+<5D> <301B>
+<5E> <2191>
+<5F> <2193>
+<60> <0060>
+<6E> <266A>
+<80> <02D8>
+<81> <02C7>
+<82> <02DD>
+<83> <00A0030F>
+<86> <2016>
+<87> <2030>
+<88> <2022>
+<89> <2103>
+<8A> <0024>
+<8B> <00A2>
+<8C> <0192>
+<8D> <20A1>
+<8E> <20A9>
+<8F> <20A6>
+<92> <20A4>
+<94> <203D>
+<96> <20AB>
+<97> <2122>
+<98> <2031>
+<99> <00B6>
+<9A> <0E3F>
+<9B> <2116>
+<9D> <212E>
+<9E> <25E6>
+<9F> <2120>
+<AC> <00AC>
+<AD> <2117>
+<B8> <203B>
+<BB> <221A>
+<BF> <20AC>
+<D6> <00D7>
+<F6> <00F7>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+44 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /YIGRIT+SFRM0600 /FontDescriptor 75 0 R /FirstChar 42 /LastChar 42 /Widths 55 0 R /Encoding 54 0 R /ToUnicode 84 0 R >>
 endobj
 85 0 obj
 << /Length 1523 >>       
@@ -1301,222 +1409,110 @@ end
 %%EOF
 endstream
 endobj
-45 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /YIGRIT+SFRM0600 /FontDescriptor 76 0 R /FirstChar 42 /LastChar 42 /Widths 56 0 R /Encoding 55 0 R /ToUnicode 85 0 R >>
+41 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /RYQARY+SFRM1200 /FontDescriptor 77 0 R /FirstChar 42 /LastChar 42 /Widths 58 0 R /Encoding 54 0 R /ToUnicode 85 0 R >>
+endobj
+47 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 37 0 R ] >>
 endobj
 86 0 obj
-<< /Length 1523 >>       
-stream
-%!PS-Adobe-3.0 Resource-CMap
-%%DocumentNeededResources: ProcSet (CIDInit)
-%%IncludeResource: ProcSet (CIDInit)
-%%BeginResource: CMap (TeX-cm-super-ts1-0)
-%%Title: (TeX-cm-super-ts1-0 TeX cm-super-ts1 0)
-%%Version: 1.000
-%%EndComments
-/CIDInit /ProcSet findresource begin
-12 dict begin
-begincmap
-/CIDSystemInfo
-<< /Registry (TeX)
-/Ordering (cm-super-ts1)
-/Supplement 0
->> def
-/CMapName /TeX-cm-super-ts1-0 def
-/CMapType 2 def
-1 begincodespacerange
-<00> <FF>
-endcodespacerange
-7 beginbfrange
-<30> <39> <0030>
-<84> <85> <2020>
-<A0> <A1> <2045>
-<A2> <AA> <00A2>
-<AE> <B7> <00AE>
-<B9> <BA> <00B9>
-<BC> <BE> <00BC>
-endbfrange
-66 beginbfchar
-<00> <0060>
-<01> <00B4>
-<04> <00A8>
-<05> <02DD>
-<07> <02C7>
-<09> <00AF>
-<0B> <00B8>
-<0C> <02DB>
-<0D> <201A>
-<12> <201E>
-<16> <F6DE>
-<17> <200C>
-<18> <2190>
-<19> <2192>
-<1F> <200C>
-<20> <2422>
-<24> <0024>
-<27> <0027>
-<2A> <2217>
-<2C> <002C>
-<2E> <002E>
-<2F> <2044>
-<3C> <2329>
-<3D> <2212>
-<3E> <232A>
-<4D> <2127>
-<4F> <25CB>
-<57> <2126>
-<5B> <301A>
-<5D> <301B>
-<5E> <2191>
-<5F> <2193>
-<60> <0060>
-<6E> <266A>
-<80> <02D8>
-<81> <02C7>
-<82> <02DD>
-<83> <00A0030F>
-<86> <2016>
-<87> <2030>
-<88> <2022>
-<89> <2103>
-<8A> <0024>
-<8B> <00A2>
-<8C> <0192>
-<8D> <20A1>
-<8E> <20A9>
-<8F> <20A6>
-<92> <20A4>
-<94> <203D>
-<96> <20AB>
-<97> <2122>
-<98> <2031>
-<99> <00B6>
-<9A> <0E3F>
-<9B> <2116>
-<9D> <212E>
-<9E> <25E6>
-<9F> <2120>
-<AC> <00AC>
-<AD> <2117>
-<B8> <203B>
-<BB> <221A>
-<BF> <20AC>
-<D6> <00D7>
-<F6> <00F7>
-endbfchar
-endcmap
-CMapName currentdict /CMap defineresource pop
-end
-end
-%%EndResource
-%%EOF
-endstream
-endobj
-42 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /RYQARY+SFRM1200 /FontDescriptor 78 0 R /FirstChar 42 /LastChar 42 /Widths 59 0 R /Encoding 55 0 R /ToUnicode 86 0 R >>
-endobj
-48 0 obj
-<< /Type /Pages  /Count 1 /Kids [ 38 0 R ] >>
+<< /Type /Catalog /Pages 47 0 R /MarkInfo 48 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 35 0 R >>
 endobj
 87 0 obj
-<< /Type /Catalog /Pages 48 0 R /MarkInfo 49 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 36 0 R >>
-endobj
-88 0 obj
 << /Producer (LuaTeX)/Creator (TeX)/Title <FEFF00410020007400690074006C0065005B00310063006D005D00200077006900740068002000610020007300750062007400690074006C0065>/Author <FEFF0061007500740068006F0072002000410020002C0061007500740068006F007200200042>/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 89
+0 88
 0000000002 65535 f 
 0000014173 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000010 00000 f 
-0000018684 00000 n 
+0000018568 00000 n 
 0000014256 00000 n 
-0000014677 00000 n 
-0000016830 00000 n 
-0000015457 00000 n 
+0000014661 00000 n 
+0000016814 00000 n 
+0000015441 00000 n 
 0000000012 00000 f 
-0000015525 00000 n 
+0000015509 00000 n 
 0000000014 00000 f 
-0000015595 00000 n 
+0000015579 00000 n 
 0000000020 00000 f 
-0000016358 00000 n 
-0000015676 00000 n 
-0000016636 00000 n 
-0000016465 00000 n 
-0000016743 00000 n 
+0000016342 00000 n 
+0000015660 00000 n 
+0000016620 00000 n 
+0000016449 00000 n 
+0000016727 00000 n 
 0000000000 00000 f 
-0000016891 00000 n 
-0000016998 00000 n 
-0000017086 00000 n 
-0000017174 00000 n 
-0000017290 00000 n 
-0000017395 00000 n 
-0000017539 00000 n 
-0000017686 00000 n 
-0000017820 00000 n 
-0000017954 00000 n 
-0000018088 00000 n 
-0000018212 00000 n 
-0000018316 00000 n 
-0000018416 00000 n 
-0000018556 00000 n 
+0000016875 00000 n 
+0000016982 00000 n 
+0000017070 00000 n 
+0000017158 00000 n 
+0000017274 00000 n 
+0000017379 00000 n 
+0000017523 00000 n 
+0000017670 00000 n 
+0000017804 00000 n 
+0000017938 00000 n 
+0000018072 00000 n 
+0000018196 00000 n 
+0000018296 00000 n 
+0000018436 00000 n 
 0000000020 00000 n 
 0000014026 00000 n 
 0000013891 00000 n 
 0000012097 00000 n 
-0000080340 00000 n 
-0000020926 00000 n 
-0000087713 00000 n 
-0000084213 00000 n 
-0000078398 00000 n 
-0000085953 00000 n 
-0000082277 00000 n 
-0000076457 00000 n 
-0000087890 00000 n 
+0000080224 00000 n 
+0000020810 00000 n 
+0000087597 00000 n 
+0000084097 00000 n 
+0000078282 00000 n 
+0000085837 00000 n 
+0000082161 00000 n 
+0000076341 00000 n 
+0000087774 00000 n 
 0000014220 00000 n 
 0000014341 00000 n 
-0000014640 00000 n 
-0000015256 00000 n 
-0000018821 00000 n 
-0000018844 00000 n 
-0000074601 00000 n 
-0000018957 00000 n 
-0000018980 00000 n 
-0000019207 00000 n 
-0000019306 00000 n 
-0000019331 00000 n 
-0000019953 00000 n 
-0000019363 00000 n 
-0000020174 00000 n 
-0000021080 00000 n 
-0000021280 00000 n 
-0000028852 00000 n 
-0000021423 00000 n 
-0000039057 00000 n 
-0000029057 00000 n 
-0000047437 00000 n 
-0000039261 00000 n 
-0000055557 00000 n 
-0000047641 00000 n 
-0000065811 00000 n 
-0000055761 00000 n 
-0000067958 00000 n 
-0000066015 00000 n 
-0000074399 00000 n 
-0000068160 00000 n 
-0000074673 00000 n 
-0000076614 00000 n 
-0000078556 00000 n 
-0000080498 00000 n 
-0000082434 00000 n 
-0000084370 00000 n 
-0000086130 00000 n 
-0000087952 00000 n 
-0000088067 00000 n 
+0000014624 00000 n 
+0000015240 00000 n 
+0000018705 00000 n 
+0000018728 00000 n 
+0000074485 00000 n 
+0000018841 00000 n 
+0000018864 00000 n 
+0000019091 00000 n 
+0000019190 00000 n 
+0000019215 00000 n 
+0000019837 00000 n 
+0000019247 00000 n 
+0000020058 00000 n 
+0000020964 00000 n 
+0000021164 00000 n 
+0000028736 00000 n 
+0000021307 00000 n 
+0000038941 00000 n 
+0000028941 00000 n 
+0000047321 00000 n 
+0000039145 00000 n 
+0000055441 00000 n 
+0000047525 00000 n 
+0000065695 00000 n 
+0000055645 00000 n 
+0000067842 00000 n 
+0000065899 00000 n 
+0000074283 00000 n 
+0000068044 00000 n 
+0000074557 00000 n 
+0000076498 00000 n 
+0000078440 00000 n 
+0000080382 00000 n 
+0000082318 00000 n 
+0000084254 00000 n 
+0000086014 00000 n 
+0000087836 00000 n 
+0000087951 00000 n 
 trailer
-<< /Size 89 /Root 87 0 R /Info 88 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 88 /Root 86 0 R /Info 87 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-88410
+88294
 %%EOF

--- a/required/latex-lab/testfiles-title/title-007.tpf
+++ b/required/latex-lab/testfiles-title/title-007.tpf
@@ -1,6 +1,6 @@
 %PDF-2.0
 %ÐÔÅØ
-37 0 obj
+36 0 obj
 <<
 /Type /Metadata /Subtype /XML
 /Length 11985     
@@ -248,7 +248,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-39 0 obj
+38 0 obj
 <<
 /Length 1266      
 >>
@@ -313,39 +313,39 @@ endobj
 27 0 obj
 <<
 /Type /Page
-/Contents 39 0 R
-/Resources 38 0 R
+/Contents 38 0 R
+/Resources 37 0 R
 /MediaBox [0 0 612 792]
 /Tabs /S /StructParents 0 
-/Parent 48 0 R
+/Parent 47 0 R
 >>
 endobj
-38 0 obj
+37 0 obj
 <<
 /ExtGState 1 0 R 
-/Font << /F40 40 0 R /F64 41 0 R /F50 42 0 R /F51 43 0 R /F49 44 0 R /F63 45 0 R /F60 46 0 R /F39 47 0 R >>
+/Font << /F40 39 0 R /F64 40 0 R /F50 41 0 R /F51 42 0 R /F49 43 0 R /F63 44 0 R /F60 45 0 R /F39 46 0 R >>
 >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-49 0 obj
+48 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 26 0 R 28 0 R 26 0 R 29 0 R 30 0 R 31 0 R 35 0 R 36 0 R 35 0 R 35 0 R 35 0 R ]
+<< /Nums [0 [ 26 0 R 28 0 R 26 0 R 29 0 R 30 0 R 31 0 R 34 0 R 35 0 R 34 0 R 34 0 R 34 0 R ]
 ] >>
 endobj
-50 0 obj
-<< /Limits [(ID.002) (ID.016)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 28 0 R (ID.009) 29 0 R (ID.010) 30 0 R (ID.011) 31 0 R (ID.012) 32 0 R (ID.013) 33 0 R (ID.014) 34 0 R (ID.015) 35 0 R (ID.016) 36 0 R ] >>
+49 0 obj
+<< /Limits [(ID.002) (ID.015)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 28 0 R (ID.009) 29 0 R (ID.010) 30 0 R (ID.011) 31 0 R (ID.012) 32 0 R (ID.013) 33 0 R (ID.014) 34 0 R (ID.015) 35 0 R ] >>
 endobj
-51 0 obj
-<< /Kids [50 0 R] >>
+50 0 obj
+<< /Kids [49 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
 endobj
-52 0 obj
+51 0 obj
 << /center <</O/Layout/TextAlign/Center>>
 /justify <</O/Layout/TextAlign/Justify>>
 /TH-both <</O/Table/Scope/Both>>
@@ -411,48 +411,45 @@ endobj
 <<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 24 0 R /K <</Type /MCR /Pg 27 0 R/MCID 5>> /ID (ID.011) >>
 endobj
 32 0 obj
-<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 21 0 R /Ref [ 28 0 R ] /K [33 0 R 34 0 R] /ID (ID.012) >>
+<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 21 0 R /Ref [ 28 0 R ] /K [35 0 R 33 0 R] /ID (ID.012) >>
 endobj
 33 0 obj
-<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 32 0 R /K 36 0 R /ID (ID.013) >>
+<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 32 0 R /K 34 0 R /ID (ID.013) >>
 endobj
 34 0 obj
-<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 32 0 R /K 35 0 R /ID (ID.014) >>
+<<  /Type /StructElem /C /justify /S /text /NS 15 0 R  /P 33 0 R /K [<</Type /MCR /Pg 27 0 R/MCID 6>> <</Type /MCR /Pg 27 0 R/MCID 8>> <</Type /MCR /Pg 27 0 R/MCID 9>> <</Type /MCR /Pg 27 0 R/MCID 10>>] /ID (ID.014) >>
 endobj
 35 0 obj
-<<  /Type /StructElem /C /justify /S /text /NS 15 0 R  /P 34 0 R /K [<</Type /MCR /Pg 27 0 R/MCID 6>> <</Type /MCR /Pg 27 0 R/MCID 8>> <</Type /MCR /Pg 27 0 R/MCID 9>> <</Type /MCR /Pg 27 0 R/MCID 10>>] /ID (ID.015) >>
-endobj
-36 0 obj
-<<  /Type /StructElem /S /NonStruct /NS 11 0 R  /P 33 0 R /K <</Type /MCR /Pg 27 0 R/MCID 7>> /ID (ID.016) >>
+<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 32 0 R /K <</Type /MCR /Pg 27 0 R/MCID 7>> /ID (ID.015) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 51 0 R /ClassMap 52 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
+<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 50 0 R /ClassMap 51 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
 endobj
-54 0 obj
+53 0 obj
 [499.9]
 endobj
-55 0 obj
+54 0 obj
 [795.6 826.2 722.4 826.2 781.4 590.1 767.2 795.6 795.6 1090.7 795.6 795.6 649.1 295.1 531.1 295.1 649.1 826.2 295.1 531.1 590.1 472.1 590.1 472.1 324.6 531.1 590.1 295.1 324.6 560.6 295.1 885.2 590.1 531.1 590.1 560.6 414 419 413.1]
 endobj
-57 0 obj
+56 0 obj
 [611]
 endobj
-58 0 obj
+57 0 obj
 [271.9 326.3 271.9 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 271.9 271.9 761.4 761.4 761.4 462.3 761.4 733.8 693.2 707 747.6 666 638.8 768.1 733.8 353.2 502.9 761 611.7 897 733.8 761.4 666 761.4 720.4 543.8 707 733.8 733.8 1005.8 733.8 733.8 598.2 271.9 489.5 271.9 598.2 761.4 271.9 489.5 543.8 435.1 543.8 435.1 299.1 489.5 543.8 271.9 299.1 516.7 271.9 815.8 543.8 489.5 543.8 516.7 380.7 386.1 380.7 543.8 516.7 707 516.7 516.7]
 endobj
-59 0 obj
+58 0 obj
 [513.8 570.8 456.7 570.8 457.1 314 513.8 570.8 285.4 314 542.3 285.4 856.3 570.8 513.8 570.8 542.3 401.9 405.3 399.6 570.8 542.3 742.1]
 endobj
-60 0 obj
+59 0 obj
 [489.5]
 endobj
-61 0 obj
+60 0 obj
 [333]
 endobj
-62 0 obj
+61 0 obj
 [704.4 665.4 678.7 717.7 639.3 613.2 737.3 704.4 338.8 482.6 730.5 587.1 861.1 704.4 730.9 639.3 730.9 691.5 522 678.7 704.4 704.4 965.6 704.4 704.4 574.2 260.8 469.8 260.8 574.2 730.9 260.8 469.8 522 417.5 522 417.5 287 469.8 522 260.8 287 495.9 260.8 783.1 522 469.8 522 495.9 365.3 370.5 365.3]
 endobj
-63 0 obj
+62 0 obj
 <<
 /Length1 1144
 /Length2 1422
@@ -461,7 +458,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-64 0 obj
+63 0 obj
 <<
 /Type /FontDescriptor
 /FontName /MUQHVU+PdfTeX-Space
@@ -474,10 +471,10 @@ endobj
 /StemV 0
 /XHeight 500
 /CharSet (/space)
-/FontFile 63 0 R
+/FontFile 62 0 R
 >>
 endobj
-65 0 obj
+64 0 obj
 <<
 /Length1 721
 /Length2 1124
@@ -486,7 +483,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-66 0 obj
+65 0 obj
 <<
 /Type /FontDescriptor
 /FontName /YIGRIT+SFRM0600
@@ -499,10 +496,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/asteriskmath)
-/FontFile 65 0 R
+/FontFile 64 0 R
 >>
 endobj
-67 0 obj
+66 0 obj
 <<
 /Length1 721
 /Length2 16768
@@ -511,7 +508,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-68 0 obj
+67 0 obj
 <<
 /Type /FontDescriptor
 /FontName /MMWKYX+SFRM0800
@@ -524,10 +521,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/N/e/o/t)
-/FontFile 67 0 R
+/FontFile 66 0 R
 >>
 endobj
-69 0 obj
+68 0 obj
 <<
 /Length1 721
 /Length2 13820
@@ -536,7 +533,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-70 0 obj
+69 0 obj
 <<
 /Type /FontDescriptor
 /FontName /WLWXUF+SFRM0900
@@ -549,10 +546,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/a/b/e/h/i/l/s/t/u/w)
-/FontFile 69 0 R
+/FontFile 68 0 R
 >>
 endobj
-71 0 obj
+70 0 obj
 <<
 /Length1 721
 /Length2 981
@@ -561,7 +558,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-72 0 obj
+71 0 obj
 <<
 /Type /FontDescriptor
 /FontName /VZMLCI+SFRM1000
@@ -574,10 +571,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/one)
-/FontFile 71 0 R
+/FontFile 70 0 R
 >>
 endobj
-73 0 obj
+72 0 obj
 <<
 /Length1 721
 /Length2 12358
@@ -586,7 +583,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-74 0 obj
+73 0 obj
 <<
 /Type /FontDescriptor
 /FontName /VVUPRB+SFRM1200
@@ -599,10 +596,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/A/B/M/a/asteriskmath/comma/h/o/one/r/six/t/two/u/y/zero)
-/FontFile 73 0 R
+/FontFile 72 0 R
 >>
 endobj
-75 0 obj
+74 0 obj
 <<
 /Length1 721
 /Length2 6947
@@ -611,7 +608,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-76 0 obj
+75 0 obj
 <<
 /Type /FontDescriptor
 /FontName /EMNKTC+SFRM1728
@@ -624,22 +621,22 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/A/e/i/l/t)
-/FontFile 75 0 R
+/FontFile 74 0 R
 >>
 endobj
-53 0 obj
+52 0 obj
 <<
 /Type /Encoding
 /Differences [44/comma 48/zero/one/two 54/six 65/A/B 77/M/N 97/a/b 101/e 104/h/i 108/l 111/o 114/r/s/t/u 119/w 121/y]
 >>
 endobj
-56 0 obj
+55 0 obj
 <<
 /Type /Encoding
 /Differences [42/asteriskmath]
 >>
 endobj
-77 0 obj
+76 0 obj
 <<
 /Length 2030      
 >>
@@ -783,20 +780,20 @@ end
 %%EOF
 endstream
 endobj
-46 0 obj
+45 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /MMWKYX+SFRM0800
-/FontDescriptor 68 0 R
+/FontDescriptor 67 0 R
 /FirstChar 78
 /LastChar 116
-/Widths 55 0 R
-/Encoding 53 0 R
-/ToUnicode 77 0 R
+/Widths 54 0 R
+/Encoding 52 0 R
+/ToUnicode 76 0 R
 >>
 endobj
-78 0 obj
+77 0 obj
 <<
 /Length 2030      
 >>
@@ -940,20 +937,20 @@ end
 %%EOF
 endstream
 endobj
-43 0 obj
+42 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /WLWXUF+SFRM0900
-/FontDescriptor 70 0 R
+/FontDescriptor 69 0 R
 /FirstChar 97
 /LastChar 119
-/Widths 59 0 R
-/Encoding 53 0 R
-/ToUnicode 78 0 R
+/Widths 58 0 R
+/Encoding 52 0 R
+/ToUnicode 77 0 R
 >>
 endobj
-79 0 obj
+78 0 obj
 <<
 /Length 2030      
 >>
@@ -1097,20 +1094,20 @@ end
 %%EOF
 endstream
 endobj
-47 0 obj
+46 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /VZMLCI+SFRM1000
-/FontDescriptor 72 0 R
+/FontDescriptor 71 0 R
 /FirstChar 49
 /LastChar 49
-/Widths 54 0 R
-/Encoding 53 0 R
-/ToUnicode 79 0 R
+/Widths 53 0 R
+/Encoding 52 0 R
+/ToUnicode 78 0 R
 >>
 endobj
-80 0 obj
+79 0 obj
 <<
 /Length 2030      
 >>
@@ -1254,20 +1251,20 @@ end
 %%EOF
 endstream
 endobj
-44 0 obj
+43 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /VVUPRB+SFRM1200
-/FontDescriptor 74 0 R
+/FontDescriptor 73 0 R
 /FirstChar 44
 /LastChar 121
-/Widths 58 0 R
-/Encoding 53 0 R
-/ToUnicode 80 0 R
+/Widths 57 0 R
+/Encoding 52 0 R
+/ToUnicode 79 0 R
 >>
 endobj
-81 0 obj
+80 0 obj
 <<
 /Length 2030      
 >>
@@ -1411,20 +1408,20 @@ end
 %%EOF
 endstream
 endobj
-40 0 obj
+39 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /EMNKTC+SFRM1728
-/FontDescriptor 76 0 R
+/FontDescriptor 75 0 R
 /FirstChar 65
 /LastChar 116
-/Widths 62 0 R
-/Encoding 53 0 R
-/ToUnicode 81 0 R
+/Widths 61 0 R
+/Encoding 52 0 R
+/ToUnicode 80 0 R
 >>
 endobj
-82 0 obj
+81 0 obj
 <<
 /Length 654       
 >>
@@ -1462,19 +1459,19 @@ end
 %%EOF
 endstream
 endobj
-41 0 obj
+40 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /MUQHVU+PdfTeX-Space
-/FontDescriptor 64 0 R
+/FontDescriptor 63 0 R
 /FirstChar 32
 /LastChar 32
-/Widths 61 0 R
-/ToUnicode 82 0 R
+/Widths 60 0 R
+/ToUnicode 81 0 R
 >>
 endobj
-83 0 obj
+82 0 obj
 <<
 /Length 1568      
 >>
@@ -1584,20 +1581,20 @@ end
 %%EOF
 endstream
 endobj
-45 0 obj
+44 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /YIGRIT+SFRM0600
-/FontDescriptor 66 0 R
+/FontDescriptor 65 0 R
 /FirstChar 42
 /LastChar 42
-/Widths 57 0 R
-/Encoding 56 0 R
-/ToUnicode 83 0 R
+/Widths 56 0 R
+/Encoding 55 0 R
+/ToUnicode 82 0 R
 >>
 endobj
-84 0 obj
+83 0 obj
 <<
 /Length 1568      
 >>
@@ -1707,133 +1704,132 @@ end
 %%EOF
 endstream
 endobj
-42 0 obj
+41 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /VVUPRB+SFRM1200
-/FontDescriptor 74 0 R
+/FontDescriptor 73 0 R
 /FirstChar 42
 /LastChar 42
-/Widths 60 0 R
-/Encoding 56 0 R
-/ToUnicode 84 0 R
+/Widths 59 0 R
+/Encoding 55 0 R
+/ToUnicode 83 0 R
 >>
 endobj
-48 0 obj
+47 0 obj
 <<
 /Type /Pages
 /Count 1
 /Kids [27 0 R]
 >>
 endobj
-85 0 obj
+84 0 obj
 <<
 /Type /Catalog
-/Pages 48 0 R
-/MarkInfo 49 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 37 0 R
+/Pages 47 0 R
+/MarkInfo 48 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 36 0 R
 >>
 endobj
-86 0 obj
+85 0 obj
 <<
 /Producer (pdfTeX)/Creator (TeX)/Title <FEFF00410020007400690074006C0065005B00310063006D005D00200077006900740068002000610020007300750062007400690074006C0065>/Author <FEFF0061007500740068006F0072002000410020002C0061007500740068006F007200200042>/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z)
 /Trapped /False
 >>
 endobj
 xref
-0 87
+0 86
 0000000002 65535 f 
 0000013697 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000010 00000 f 
-0000018351 00000 n 
+0000018235 00000 n 
 0000013780 00000 n 
-0000014229 00000 n 
-0000016382 00000 n 
-0000015009 00000 n 
+0000014213 00000 n 
+0000016366 00000 n 
+0000014993 00000 n 
 0000000012 00000 f 
-0000015077 00000 n 
+0000015061 00000 n 
 0000000014 00000 f 
-0000015147 00000 n 
+0000015131 00000 n 
 0000000020 00000 f 
-0000015910 00000 n 
-0000015228 00000 n 
-0000016188 00000 n 
-0000016017 00000 n 
-0000016295 00000 n 
+0000015894 00000 n 
+0000015212 00000 n 
+0000016172 00000 n 
+0000016001 00000 n 
+0000016279 00000 n 
 0000000000 00000 f 
-0000016443 00000 n 
-0000016550 00000 n 
-0000016638 00000 n 
-0000016726 00000 n 
-0000016842 00000 n 
-0000016947 00000 n 
+0000016427 00000 n 
+0000016534 00000 n 
+0000016622 00000 n 
+0000016710 00000 n 
+0000016826 00000 n 
+0000016931 00000 n 
 0000013414 00000 n 
-0000017121 00000 n 
-0000017266 00000 n 
-0000017398 00000 n 
-0000017530 00000 n 
-0000017662 00000 n 
-0000017786 00000 n 
-0000017890 00000 n 
-0000017990 00000 n 
-0000018225 00000 n 
+0000017105 00000 n 
+0000017250 00000 n 
+0000017382 00000 n 
+0000017514 00000 n 
+0000017646 00000 n 
+0000017770 00000 n 
+0000017870 00000 n 
+0000018105 00000 n 
 0000000015 00000 n 
 0000013549 00000 n 
 0000012089 00000 n 
-0000092357 00000 n 
-0000093248 00000 n 
-0000096843 00000 n 
-0000085557 00000 n 
-0000090090 00000 n 
-0000095039 00000 n 
-0000083290 00000 n 
-0000087824 00000 n 
-0000097020 00000 n 
+0000092241 00000 n 
+0000093132 00000 n 
+0000096727 00000 n 
+0000085441 00000 n 
+0000089974 00000 n 
+0000094923 00000 n 
+0000083174 00000 n 
+0000087708 00000 n 
+0000096904 00000 n 
 0000013744 00000 n 
 0000013893 00000 n 
-0000014192 00000 n 
-0000014808 00000 n 
-0000080976 00000 n 
-0000018488 00000 n 
-0000018512 00000 n 
-0000081132 00000 n 
-0000018761 00000 n 
-0000018783 00000 n 
-0000019256 00000 n 
-0000019408 00000 n 
-0000019432 00000 n 
-0000019454 00000 n 
-0000019768 00000 n 
-0000022432 00000 n 
-0000022650 00000 n 
-0000024592 00000 n 
-0000024817 00000 n 
-0000042404 00000 n 
-0000042631 00000 n 
-0000057270 00000 n 
-0000057509 00000 n 
-0000059307 00000 n 
-0000059530 00000 n 
-0000072707 00000 n 
-0000072982 00000 n 
-0000080747 00000 n 
-0000081201 00000 n 
-0000083468 00000 n 
-0000085735 00000 n 
-0000088001 00000 n 
-0000090268 00000 n 
-0000092535 00000 n 
-0000093412 00000 n 
-0000095216 00000 n 
-0000097079 00000 n 
-0000097194 00000 n 
+0000014176 00000 n 
+0000014792 00000 n 
+0000080860 00000 n 
+0000018372 00000 n 
+0000018396 00000 n 
+0000081016 00000 n 
+0000018645 00000 n 
+0000018667 00000 n 
+0000019140 00000 n 
+0000019292 00000 n 
+0000019316 00000 n 
+0000019338 00000 n 
+0000019652 00000 n 
+0000022316 00000 n 
+0000022534 00000 n 
+0000024476 00000 n 
+0000024701 00000 n 
+0000042288 00000 n 
+0000042515 00000 n 
+0000057154 00000 n 
+0000057393 00000 n 
+0000059191 00000 n 
+0000059414 00000 n 
+0000072591 00000 n 
+0000072866 00000 n 
+0000080631 00000 n 
+0000081085 00000 n 
+0000083352 00000 n 
+0000085619 00000 n 
+0000087885 00000 n 
+0000090152 00000 n 
+0000092419 00000 n 
+0000093296 00000 n 
+0000095100 00000 n 
+0000096963 00000 n 
+0000097078 00000 n 
 trailer
-<< /Size 87
-/Root 85 0 R
-/Info 86 0 R
+<< /Size 86
+/Root 84 0 R
+/Info 85 0 R
 /ID [<9BD18DF3359C1216B83ADB4AA401CC9A> <9BD18DF3359C1216B83ADB4AA401CC9A>] >>
 startxref
-97537
+97421
 %%EOF

--- a/required/latex-lab/testfiles-title/title-008.luatex.tpf
+++ b/required/latex-lab/testfiles-title/title-008.luatex.tpf
@@ -1,6 +1,6 @@
 %PDF-2.0
 %Ã’¡‘≈ÿ–ƒ∆
-36 0 obj
+35 0 obj
 << /Type /Metadata /Subtype /XML /Length 11987 >>      
 stream
 <?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
@@ -245,7 +245,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-39 0 obj
+38 0 obj
 << /Length 1561 >>       
 stream
 /opacity1 gs
@@ -331,32 +331,32 @@ EMC
 EMC
 endstream
 endobj
-38 0 obj
-<< /Type /Page /Contents 39 0 R /Resources 37 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 45 0 R >>
-endobj
 37 0 obj
-<< /ExtGState 1 0 R /Font << /F17 40 0 R /F15 41 0 R /F18 42 0 R /F28 43 0 R /F30 44 0 R >> >>
+<< /Type /Page /Contents 38 0 R /Resources 36 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 44 0 R >>
+endobj
+36 0 obj
+<< /ExtGState 1 0 R /Font << /F17 39 0 R /F15 40 0 R /F18 41 0 R /F28 42 0 R /F30 43 0 R >> >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-46 0 obj
+45 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 35 0 R 34 0 R] 
+<< /Nums [0 [ 26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 34 0 R 33 0 R] 
 ] >>
 endobj
-47 0 obj
-<< /Limits [(ID.002) (ID.016)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 27 0 R (ID.009) 28 0 R (ID.010) 29 0 R (ID.011) 30 0 R (ID.012) 31 0 R (ID.013) 32 0 R (ID.014) 33 0 R (ID.015) 34 0 R (ID.016) 35 0 R ] >>
+46 0 obj
+<< /Limits [(ID.002) (ID.015)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 27 0 R (ID.009) 28 0 R (ID.010) 29 0 R (ID.011) 30 0 R (ID.012) 31 0 R (ID.013) 32 0 R (ID.014) 33 0 R (ID.015) 34 0 R ] >>
 endobj
-48 0 obj
-<< /Kids [47 0 R] >>
+47 0 obj
+<< /Kids [46 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
 endobj
-49 0 obj
+48 0 obj
 << /center <</O/Layout/TextAlign/Center>>
 /justify <</O/Layout/TextAlign/Justify>>
 /TH-both <</O/Table/Scope/Both>>
@@ -407,58 +407,55 @@ endobj
 <<  /Type /StructElem /S /Title /NS 11 0 R  /P 24 0 R /K [26 0 R 28 0 R] /ID (ID.006) >>
 endobj
 26 0 obj
-<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 25 0 R /K [<</Type /MCR /Pg 38 0 R /MCID 0>>  27 0 R ] /ID (ID.007) >>
+<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 25 0 R /K [<</Type /MCR /Pg 37 0 R /MCID 0>>  27 0 R ] /ID (ID.007) >>
 endobj
 27 0 obj
-<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 26 0 R /Ref [ 31 0 R ] /K <</Type /MCR /Pg 38 0 R /MCID 1>>  /ID (ID.008) >>
+<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 26 0 R /Ref [ 31 0 R ] /K <</Type /MCR /Pg 37 0 R /MCID 1>>  /ID (ID.008) >>
 endobj
 28 0 obj
-<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 25 0 R /K <</Type /MCR /Pg 38 0 R /MCID 2>>  /ID (ID.009) >>
+<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 25 0 R /K <</Type /MCR /Pg 37 0 R /MCID 2>>  /ID (ID.009) >>
 endobj
 29 0 obj
-<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 24 0 R /K <</Type /MCR /Pg 38 0 R /MCID 3>>  /ID (ID.010) >>
+<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 24 0 R /K <</Type /MCR /Pg 37 0 R /MCID 3>>  /ID (ID.010) >>
 endobj
 30 0 obj
-<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 24 0 R /K <</Type /MCR /Pg 38 0 R /MCID 4>>  /ID (ID.011) >>
+<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 24 0 R /K <</Type /MCR /Pg 37 0 R /MCID 4>>  /ID (ID.011) >>
 endobj
 31 0 obj
-<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 21 0 R /Ref [ 27 0 R ] /K [32 0 R 33 0 R] /ID (ID.012) >>
+<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 21 0 R /Ref [ 27 0 R ] /K [34 0 R 32 0 R] /ID (ID.012) >>
 endobj
 32 0 obj
-<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 31 0 R /K 35 0 R /ID (ID.013) >>
+<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 31 0 R /K 33 0 R /ID (ID.013) >>
 endobj
 33 0 obj
-<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 31 0 R /K 34 0 R /ID (ID.014) >>
+<<  /Type /StructElem /C /justify /S /text /NS 15 0 R  /P 32 0 R /K [  <</Type /MCR /Pg 37 0 R /MCID 6>>  ] /ID (ID.014) >>
 endobj
 34 0 obj
-<<  /Type /StructElem /C /justify /S /text /NS 15 0 R  /P 33 0 R /K [  <</Type /MCR /Pg 38 0 R /MCID 6>>  ] /ID (ID.015) >>
-endobj
-35 0 obj
-<<  /Type /StructElem /S /NonStruct /NS 11 0 R  /P 32 0 R /K <</Type /MCR /Pg 38 0 R /MCID 5>>  /ID (ID.016) >>
+<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 31 0 R /K <</Type /MCR /Pg 37 0 R /MCID 5>>  /ID (ID.015) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 48 0 R /ClassMap 49 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
+<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 47 0 R /ClassMap 48 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
 endobj
-50 0 obj
+49 0 obj
 [611.1 ]
 endobj
-51 0 obj
+50 0 obj
 [770.7 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 513.9 571 0 0 457.2 0 0 571 285.5 0 0 285.5 0 0 513.9 0 0 0 405.4 399.7 571 0 742.3 ]
 endobj
-52 0 obj
+51 0 obj
 [272 0 0 0 489.6 489.6 489.6 0 0 0 489.6 0 0 0 0 0 0 0 0 0 0 734 693.4 0 0 0 0 0 0 0 0 0 0 897.2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 489.6 0 0 0 0 0 0 544 0 0 0 0 0 0 489.6 0 0 380.8 0 380.8 544 0 0 0 516.8 ]
 endobj
-53 0 obj
+52 0 obj
 [ 103 [ 333 ] ]
 endobj
-55 0 obj
+54 0 obj
 << /Subtype /CIDFontType0C /Length 506 >>        
 [BINARY STREAM]
 endobj
-54 0 obj
-<< /Type /FontDescriptor /FontName /XVZVYO+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 55 0 R >>
+53 0 obj
+<< /Type /FontDescriptor /FontName /XVZVYO+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 54 0 R >>
 endobj
-56 0 obj
+55 0 obj
 << /Length 692 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -494,44 +491,44 @@ end
 %%EOF
 endstream
 endobj
-41 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /XVZVYO+LMRoman10-Regular /DescendantFonts [ 57 0 R ] /ToUnicode 56 0 R >>
+40 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /XVZVYO+LMRoman10-Regular /DescendantFonts [ 56 0 R ] /ToUnicode 55 0 R >>
+endobj
+56 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /XVZVYO+LMRoman10-Regular /FontDescriptor 53 0 R /W 52 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 57 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /XVZVYO+LMRoman10-Regular /FontDescriptor 54 0 R /W 53 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-58 0 obj
 [693.3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 406.4 0 0 0 249.6 0 0 249.6 0 0 0 0 0 0 0 354.1 ]
 endobj
-60 0 obj
+59 0 obj
 << /Length1 1599 /Length2 8302 /Length3 0 /Length 9901 >>       
 [BINARY STREAM]
 endobj
-59 0 obj
-<< /Type /FontDescriptor /FontName /VBFROV+CMR12 /Flags 4 /FontBBox [ -34 -251 988 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 65 /XHeight 431 /FontFile 60 0 R >>
+58 0 obj
+<< /Type /FontDescriptor /FontName /VBFROV+CMR12 /Flags 4 /FontBBox [ -34 -251 988 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 65 /XHeight 431 /FontFile 59 0 R >>
 endobj
-62 0 obj
+61 0 obj
 << /Length1 1444 /Length2 6633 /Length3 0 /Length 8077 >>       
 [BINARY STREAM]
 endobj
-61 0 obj
-<< /Type /FontDescriptor /FontName /PXLAWO+CMR17 /Flags 4 /FontBBox [ -33 -250 945 749 ] /Ascent 694 /CapHeight 683 /Descent -195 /ItalicAngle 0 /StemV 53 /XHeight 430 /FontFile 62 0 R >>
+60 0 obj
+<< /Type /FontDescriptor /FontName /PXLAWO+CMR17 /Flags 4 /FontBBox [ -33 -250 945 749 ] /Ascent 694 /CapHeight 683 /Descent -195 /ItalicAngle 0 /StemV 53 /XHeight 430 /FontFile 61 0 R >>
 endobj
-64 0 obj
+63 0 obj
 << /Length1 1379 /Length2 5945 /Length3 0 /Length 7324 >>       
 [BINARY STREAM]
 endobj
-63 0 obj
-<< /Type /FontDescriptor /FontName /WIRDCL+CMR6 /Flags 4 /FontBBox [ -20 -250 1193 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 83 /XHeight 431 /FontFile 64 0 R >>
+62 0 obj
+<< /Type /FontDescriptor /FontName /WIRDCL+CMR6 /Flags 4 /FontBBox [ -20 -250 1193 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 83 /XHeight 431 /FontFile 63 0 R >>
 endobj
-66 0 obj
+65 0 obj
 << /Length1 1540 /Length2 8783 /Length3 0 /Length 10323 >>      
 [BINARY STREAM]
 endobj
-65 0 obj
-<< /Type /FontDescriptor /FontName /DTRHJH+CMR9 /Flags 4 /FontBBox [ -39 -250 1036 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 74 /XHeight 431 /FontFile 66 0 R >>
+64 0 obj
+<< /Type /FontDescriptor /FontName /DTRHJH+CMR9 /Flags 4 /FontBBox [ -39 -250 1036 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 74 /XHeight 431 /FontFile 65 0 R >>
 endobj
-67 0 obj
+66 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -651,10 +648,10 @@ end
 %%EOF
 endstream
 endobj
-42 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /VBFROV+CMR12 /FontDescriptor 59 0 R /FirstChar 44 /LastChar 121 /Widths 52 0 R /ToUnicode 67 0 R >>
+41 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /VBFROV+CMR12 /FontDescriptor 58 0 R /FirstChar 44 /LastChar 121 /Widths 51 0 R /ToUnicode 66 0 R >>
 endobj
-68 0 obj
+67 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -774,10 +771,10 @@ end
 %%EOF
 endstream
 endobj
-40 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /PXLAWO+CMR17 /FontDescriptor 61 0 R /FirstChar 65 /LastChar 116 /Widths 58 0 R /ToUnicode 68 0 R >>
+39 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /PXLAWO+CMR17 /FontDescriptor 60 0 R /FirstChar 65 /LastChar 116 /Widths 57 0 R /ToUnicode 67 0 R >>
 endobj
-69 0 obj
+68 0 obj
 << /Length 1719 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -897,10 +894,10 @@ end
 %%EOF
 endstream
 endobj
-44 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /WIRDCL+CMR6 /FontDescriptor 63 0 R /FirstChar 49 /LastChar 49 /Widths 50 0 R /ToUnicode 69 0 R >>
+43 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /WIRDCL+CMR6 /FontDescriptor 62 0 R /FirstChar 49 /LastChar 49 /Widths 49 0 R /ToUnicode 68 0 R >>
 endobj
-70 0 obj
+69 0 obj
 << /Length 1719 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -1020,95 +1017,94 @@ end
 %%EOF
 endstream
 endobj
-43 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /DTRHJH+CMR9 /FontDescriptor 65 0 R /FirstChar 78 /LastChar 119 /Widths 51 0 R /ToUnicode 70 0 R >>
+42 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /DTRHJH+CMR9 /FontDescriptor 64 0 R /FirstChar 78 /LastChar 119 /Widths 50 0 R /ToUnicode 69 0 R >>
 endobj
-45 0 obj
-<< /Type /Pages  /Count 1 /Kids [ 38 0 R ] >>
+44 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 37 0 R ] >>
+endobj
+70 0 obj
+<< /Type /Catalog /Pages 44 0 R /MarkInfo 45 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 35 0 R >>
 endobj
 71 0 obj
-<< /Type /Catalog /Pages 45 0 R /MarkInfo 46 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 36 0 R >>
-endobj
-72 0 obj
 << /Producer (LuaTeX)/Creator (TeX)/Title <FEFF00410020007400690074006C0065005B00310063006D005D00200077006900740068002000610020007300750062007400690074006C0065>/Author <FEFF0061007500740068006F0072002000410020002C0061007500740068006F007200200042>/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 73
+0 72
 0000000002 65535 f 
 0000013964 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000010 00000 f 
-0000018475 00000 n 
+0000018359 00000 n 
 0000014047 00000 n 
-0000014468 00000 n 
-0000016621 00000 n 
-0000015248 00000 n 
+0000014452 00000 n 
+0000016605 00000 n 
+0000015232 00000 n 
 0000000012 00000 f 
-0000015316 00000 n 
+0000015300 00000 n 
 0000000014 00000 f 
-0000015386 00000 n 
+0000015370 00000 n 
 0000000020 00000 f 
-0000016149 00000 n 
-0000015467 00000 n 
-0000016427 00000 n 
-0000016256 00000 n 
-0000016534 00000 n 
+0000016133 00000 n 
+0000015451 00000 n 
+0000016411 00000 n 
+0000016240 00000 n 
+0000016518 00000 n 
 0000000000 00000 f 
-0000016682 00000 n 
-0000016789 00000 n 
-0000016877 00000 n 
-0000016965 00000 n 
-0000017081 00000 n 
-0000017186 00000 n 
-0000017330 00000 n 
-0000017477 00000 n 
-0000017611 00000 n 
-0000017745 00000 n 
-0000017879 00000 n 
-0000018003 00000 n 
-0000018107 00000 n 
-0000018207 00000 n 
-0000018347 00000 n 
+0000016666 00000 n 
+0000016773 00000 n 
+0000016861 00000 n 
+0000016949 00000 n 
+0000017065 00000 n 
+0000017170 00000 n 
+0000017314 00000 n 
+0000017461 00000 n 
+0000017595 00000 n 
+0000017729 00000 n 
+0000017863 00000 n 
+0000017987 00000 n 
+0000018087 00000 n 
+0000018227 00000 n 
 0000000020 00000 n 
 0000013853 00000 n 
 0000013718 00000 n 
 0000012097 00000 n 
-0000061664 00000 n 
-0000020604 00000 n 
-0000059722 00000 n 
-0000065536 00000 n 
-0000063601 00000 n 
-0000065693 00000 n 
+0000061548 00000 n 
+0000020488 00000 n 
+0000059606 00000 n 
+0000065420 00000 n 
+0000063485 00000 n 
+0000065577 00000 n 
 0000014011 00000 n 
 0000014132 00000 n 
-0000014431 00000 n 
-0000015047 00000 n 
-0000018612 00000 n 
-0000018637 00000 n 
-0000018782 00000 n 
-0000019009 00000 n 
-0000019631 00000 n 
-0000019041 00000 n 
-0000019852 00000 n 
-0000020758 00000 n 
-0000020958 00000 n 
-0000031101 00000 n 
-0000021101 00000 n 
-0000039481 00000 n 
-0000031305 00000 n 
-0000047108 00000 n 
-0000039685 00000 n 
-0000057734 00000 n 
-0000047312 00000 n 
-0000057938 00000 n 
-0000059880 00000 n 
-0000061822 00000 n 
-0000063757 00000 n 
-0000065755 00000 n 
-0000065870 00000 n 
+0000014415 00000 n 
+0000015031 00000 n 
+0000018496 00000 n 
+0000018521 00000 n 
+0000018666 00000 n 
+0000018893 00000 n 
+0000019515 00000 n 
+0000018925 00000 n 
+0000019736 00000 n 
+0000020642 00000 n 
+0000020842 00000 n 
+0000030985 00000 n 
+0000020985 00000 n 
+0000039365 00000 n 
+0000031189 00000 n 
+0000046992 00000 n 
+0000039569 00000 n 
+0000057618 00000 n 
+0000047196 00000 n 
+0000057822 00000 n 
+0000059764 00000 n 
+0000061706 00000 n 
+0000063641 00000 n 
+0000065639 00000 n 
+0000065754 00000 n 
 trailer
-<< /Size 73 /Root 71 0 R /Info 72 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 72 /Root 70 0 R /Info 71 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-66213
+66097
 %%EOF

--- a/required/latex-lab/testfiles-title/title-008.tpf
+++ b/required/latex-lab/testfiles-title/title-008.tpf
@@ -1,6 +1,6 @@
 %PDF-2.0
 %ÐÔÅØ
-37 0 obj
+36 0 obj
 <<
 /Type /Metadata /Subtype /XML
 /Length 11985     
@@ -248,7 +248,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-39 0 obj
+38 0 obj
 <<
 /Length 1149      
 >>
@@ -306,39 +306,39 @@ endobj
 27 0 obj
 <<
 /Type /Page
-/Contents 39 0 R
-/Resources 38 0 R
+/Contents 38 0 R
+/Resources 37 0 R
 /MediaBox [0 0 612 792]
 /Tabs /S /StructParents 0 
-/Parent 45 0 R
+/Parent 44 0 R
 >>
 endobj
-38 0 obj
+37 0 obj
 <<
 /ExtGState 1 0 R 
-/Font << /F40 40 0 R /F65 41 0 R /F49 42 0 R /F50 43 0 R /F64 44 0 R >>
+/Font << /F40 39 0 R /F65 40 0 R /F49 41 0 R /F50 42 0 R /F64 43 0 R >>
 >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-46 0 obj
+45 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 26 0 R 28 0 R 26 0 R 29 0 R 30 0 R 31 0 R 35 0 R 36 0 R 35 0 R 35 0 R 35 0 R ]
+<< /Nums [0 [ 26 0 R 28 0 R 26 0 R 29 0 R 30 0 R 31 0 R 34 0 R 35 0 R 34 0 R 34 0 R 34 0 R ]
 ] >>
 endobj
-47 0 obj
-<< /Limits [(ID.002) (ID.016)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 28 0 R (ID.009) 29 0 R (ID.010) 30 0 R (ID.011) 31 0 R (ID.012) 32 0 R (ID.013) 33 0 R (ID.014) 34 0 R (ID.015) 35 0 R (ID.016) 36 0 R ] >>
+46 0 obj
+<< /Limits [(ID.002) (ID.015)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 28 0 R (ID.009) 29 0 R (ID.010) 30 0 R (ID.011) 31 0 R (ID.012) 32 0 R (ID.013) 33 0 R (ID.014) 34 0 R (ID.015) 35 0 R ] >>
 endobj
-48 0 obj
-<< /Kids [47 0 R] >>
+47 0 obj
+<< /Kids [46 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
 endobj
-49 0 obj
+48 0 obj
 << /center <</O/Layout/TextAlign/Center>>
 /justify <</O/Layout/TextAlign/Justify>>
 /TH-both <</O/Table/Scope/Both>>
@@ -404,39 +404,36 @@ endobj
 <<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 24 0 R /K <</Type /MCR /Pg 27 0 R/MCID 5>> /ID (ID.011) >>
 endobj
 32 0 obj
-<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 21 0 R /Ref [ 28 0 R ] /K [33 0 R 34 0 R] /ID (ID.012) >>
+<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 21 0 R /Ref [ 28 0 R ] /K [35 0 R 33 0 R] /ID (ID.012) >>
 endobj
 33 0 obj
-<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 32 0 R /K 36 0 R /ID (ID.013) >>
+<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 32 0 R /K 34 0 R /ID (ID.013) >>
 endobj
 34 0 obj
-<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 32 0 R /K 35 0 R /ID (ID.014) >>
+<<  /Type /StructElem /C /justify /S /text /NS 15 0 R  /P 33 0 R /K [<</Type /MCR /Pg 27 0 R/MCID 6>> <</Type /MCR /Pg 27 0 R/MCID 8>> <</Type /MCR /Pg 27 0 R/MCID 9>> <</Type /MCR /Pg 27 0 R/MCID 10>>] /ID (ID.014) >>
 endobj
 35 0 obj
-<<  /Type /StructElem /C /justify /S /text /NS 15 0 R  /P 34 0 R /K [<</Type /MCR /Pg 27 0 R/MCID 6>> <</Type /MCR /Pg 27 0 R/MCID 8>> <</Type /MCR /Pg 27 0 R/MCID 9>> <</Type /MCR /Pg 27 0 R/MCID 10>>] /ID (ID.015) >>
-endobj
-36 0 obj
-<<  /Type /StructElem /S /NonStruct /NS 11 0 R  /P 33 0 R /K <</Type /MCR /Pg 27 0 R/MCID 7>> /ID (ID.016) >>
+<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 32 0 R /K <</Type /MCR /Pg 27 0 R/MCID 7>> /ID (ID.015) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 48 0 R /ClassMap 49 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
+<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 47 0 R /ClassMap 48 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
 endobj
-51 0 obj
+50 0 obj
 [611]
 endobj
-52 0 obj
+51 0 obj
 [770.5 799.2 699.2 799.2 756.3 570.8 742.1 770.5 770.5 1055.9 770.5 770.5 627.9 285.4 513.8 285.4 627.9 799.2 285.4 513.8 570.8 456.7 570.8 457.1 314 513.8 570.8 285.4 314 542.3 285.4 856.3 570.8 513.8 570.8 542.3 401.9 405.3 399.6 570.8 542.3 742.1]
 endobj
-53 0 obj
+52 0 obj
 [271.9 326.3 271.9 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 271.9 271.9 761.4 761.4 761.4 462.3 761.4 733.8 693.2 707 747.6 666 638.8 768.1 733.8 353.2 502.9 761 611.7 897 733.8 761.4 666 761.4 720.4 543.8 707 733.8 733.8 1005.8 733.8 733.8 598.2 271.9 489.5 271.9 598.2 761.4 271.9 489.5 543.8 435.1 543.8 435.1 299.1 489.5 543.8 271.9 299.1 516.7 271.9 815.8 543.8 489.5 543.8 516.7 380.7 386.1 380.7 543.8 516.7 707 516.7 516.7]
 endobj
-54 0 obj
+53 0 obj
 [333]
 endobj
-55 0 obj
+54 0 obj
 [704.4 665.4 678.7 717.7 639.3 613.2 737.3 704.4 338.8 482.6 730.5 587.1 861.1 704.4 730.9 639.3 730.9 691.5 522 678.7 704.4 704.4 965.6 704.4 704.4 574.2 260.8 469.8 260.8 574.2 730.9 260.8 469.8 522 417.5 522 417.5 287 469.8 522 260.8 287 495.9 260.8 783.1 522 469.8 522 495.9 365.3 370.5 365.3]
 endobj
-56 0 obj
+55 0 obj
 <<
 /Length1 1144
 /Length2 1422
@@ -445,7 +442,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-57 0 obj
+56 0 obj
 <<
 /Type /FontDescriptor
 /FontName /MUQHVU+PdfTeX-Space
@@ -458,10 +455,10 @@ endobj
 /StemV 0
 /XHeight 500
 /CharSet (/space)
-/FontFile 56 0 R
+/FontFile 55 0 R
 >>
 endobj
-58 0 obj
+57 0 obj
 <<
 /Length1 721
 /Length2 13847
@@ -470,7 +467,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-59 0 obj
+58 0 obj
 <<
 /Type /FontDescriptor
 /FontName /WMNOAL+SFRM0600
@@ -483,10 +480,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/one)
-/FontFile 58 0 R
+/FontFile 57 0 R
 >>
 endobj
-60 0 obj
+59 0 obj
 <<
 /Length1 721
 /Length2 14175
@@ -495,7 +492,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-61 0 obj
+60 0 obj
 <<
 /Type /FontDescriptor
 /FontName /ZEXONM+SFRM0900
@@ -508,10 +505,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/N/a/b/e/h/i/l/o/s/t/u/w)
-/FontFile 60 0 R
+/FontFile 59 0 R
 >>
 endobj
-62 0 obj
+61 0 obj
 <<
 /Length1 721
 /Length2 11987
@@ -520,7 +517,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-63 0 obj
+62 0 obj
 <<
 /Type /FontDescriptor
 /FontName /XGEWRW+SFRM1200
@@ -533,10 +530,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/A/B/M/a/comma/h/o/one/r/six/t/two/u/y/zero)
-/FontFile 62 0 R
+/FontFile 61 0 R
 >>
 endobj
-64 0 obj
+63 0 obj
 <<
 /Length1 721
 /Length2 6947
@@ -545,7 +542,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-65 0 obj
+64 0 obj
 <<
 /Type /FontDescriptor
 /FontName /EMNKTC+SFRM1728
@@ -558,16 +555,16 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/A/e/i/l/t)
-/FontFile 64 0 R
+/FontFile 63 0 R
 >>
 endobj
-50 0 obj
+49 0 obj
 <<
 /Type /Encoding
 /Differences [44/comma 48/zero/one/two 54/six 65/A/B 77/M/N 97/a/b 101/e 104/h/i 108/l 111/o 114/r/s/t/u 119/w 121/y]
 >>
 endobj
-66 0 obj
+65 0 obj
 <<
 /Length 2030      
 >>
@@ -711,20 +708,20 @@ end
 %%EOF
 endstream
 endobj
-44 0 obj
+43 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /WMNOAL+SFRM0600
-/FontDescriptor 59 0 R
+/FontDescriptor 58 0 R
 /FirstChar 49
 /LastChar 49
-/Widths 51 0 R
-/Encoding 50 0 R
-/ToUnicode 66 0 R
+/Widths 50 0 R
+/Encoding 49 0 R
+/ToUnicode 65 0 R
 >>
 endobj
-67 0 obj
+66 0 obj
 <<
 /Length 2030      
 >>
@@ -868,20 +865,20 @@ end
 %%EOF
 endstream
 endobj
-43 0 obj
+42 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /ZEXONM+SFRM0900
-/FontDescriptor 61 0 R
+/FontDescriptor 60 0 R
 /FirstChar 78
 /LastChar 119
-/Widths 52 0 R
-/Encoding 50 0 R
-/ToUnicode 67 0 R
+/Widths 51 0 R
+/Encoding 49 0 R
+/ToUnicode 66 0 R
 >>
 endobj
-68 0 obj
+67 0 obj
 <<
 /Length 2030      
 >>
@@ -1025,20 +1022,20 @@ end
 %%EOF
 endstream
 endobj
-42 0 obj
+41 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /XGEWRW+SFRM1200
-/FontDescriptor 63 0 R
+/FontDescriptor 62 0 R
 /FirstChar 44
 /LastChar 121
-/Widths 53 0 R
-/Encoding 50 0 R
-/ToUnicode 68 0 R
+/Widths 52 0 R
+/Encoding 49 0 R
+/ToUnicode 67 0 R
 >>
 endobj
-69 0 obj
+68 0 obj
 <<
 /Length 2030      
 >>
@@ -1182,20 +1179,20 @@ end
 %%EOF
 endstream
 endobj
-40 0 obj
+39 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /EMNKTC+SFRM1728
-/FontDescriptor 65 0 R
+/FontDescriptor 64 0 R
 /FirstChar 65
 /LastChar 116
-/Widths 55 0 R
-/Encoding 50 0 R
-/ToUnicode 69 0 R
+/Widths 54 0 R
+/Encoding 49 0 R
+/ToUnicode 68 0 R
 >>
 endobj
-70 0 obj
+69 0 obj
 <<
 /Length 654       
 >>
@@ -1233,118 +1230,117 @@ end
 %%EOF
 endstream
 endobj
-41 0 obj
+40 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /MUQHVU+PdfTeX-Space
-/FontDescriptor 57 0 R
+/FontDescriptor 56 0 R
 /FirstChar 32
 /LastChar 32
-/Widths 54 0 R
-/ToUnicode 70 0 R
+/Widths 53 0 R
+/ToUnicode 69 0 R
 >>
 endobj
-45 0 obj
+44 0 obj
 <<
 /Type /Pages
 /Count 1
 /Kids [27 0 R]
 >>
 endobj
-71 0 obj
+70 0 obj
 <<
 /Type /Catalog
-/Pages 45 0 R
-/MarkInfo 46 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 37 0 R
+/Pages 44 0 R
+/MarkInfo 45 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 36 0 R
 >>
 endobj
-72 0 obj
+71 0 obj
 <<
 /Producer (pdfTeX)/Creator (TeX)/Title <FEFF00410020007400690074006C0065005B00310063006D005D00200077006900740068002000610020007300750062007400690074006C0065>/Author <FEFF0061007500740068006F0072002000410020002C0061007500740068006F007200200042>/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z)
 /Trapped /False
 >>
 endobj
 xref
-0 73
+0 72
 0000000002 65535 f 
 0000013544 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000010 00000 f 
-0000018198 00000 n 
+0000018082 00000 n 
 0000013627 00000 n 
-0000014076 00000 n 
-0000016229 00000 n 
-0000014856 00000 n 
+0000014060 00000 n 
+0000016213 00000 n 
+0000014840 00000 n 
 0000000012 00000 f 
-0000014924 00000 n 
+0000014908 00000 n 
 0000000014 00000 f 
-0000014994 00000 n 
+0000014978 00000 n 
 0000000020 00000 f 
-0000015757 00000 n 
-0000015075 00000 n 
-0000016035 00000 n 
-0000015864 00000 n 
-0000016142 00000 n 
+0000015741 00000 n 
+0000015059 00000 n 
+0000016019 00000 n 
+0000015848 00000 n 
+0000016126 00000 n 
 0000000000 00000 f 
-0000016290 00000 n 
-0000016397 00000 n 
-0000016485 00000 n 
-0000016573 00000 n 
-0000016689 00000 n 
-0000016794 00000 n 
+0000016274 00000 n 
+0000016381 00000 n 
+0000016469 00000 n 
+0000016557 00000 n 
+0000016673 00000 n 
+0000016778 00000 n 
 0000013297 00000 n 
-0000016968 00000 n 
-0000017113 00000 n 
-0000017245 00000 n 
-0000017377 00000 n 
-0000017509 00000 n 
-0000017633 00000 n 
-0000017737 00000 n 
-0000017837 00000 n 
-0000018072 00000 n 
+0000016952 00000 n 
+0000017097 00000 n 
+0000017229 00000 n 
+0000017361 00000 n 
+0000017493 00000 n 
+0000017617 00000 n 
+0000017717 00000 n 
+0000017952 00000 n 
 0000000015 00000 n 
 0000013432 00000 n 
 0000012089 00000 n 
-0000082548 00000 n 
-0000083439 00000 n 
-0000080281 00000 n 
-0000078014 00000 n 
-0000075748 00000 n 
-0000083603 00000 n 
+0000082432 00000 n 
+0000083323 00000 n 
+0000080165 00000 n 
+0000077898 00000 n 
+0000075632 00000 n 
+0000083487 00000 n 
 0000013591 00000 n 
 0000013740 00000 n 
-0000014039 00000 n 
-0000014655 00000 n 
-0000073503 00000 n 
-0000018335 00000 n 
-0000018357 00000 n 
-0000018624 00000 n 
-0000019097 00000 n 
-0000019119 00000 n 
-0000019433 00000 n 
-0000022097 00000 n 
-0000022315 00000 n 
-0000036981 00000 n 
-0000037204 00000 n 
-0000052198 00000 n 
-0000052441 00000 n 
-0000065247 00000 n 
-0000065509 00000 n 
-0000073274 00000 n 
-0000073659 00000 n 
-0000075925 00000 n 
-0000078192 00000 n 
-0000080459 00000 n 
-0000082726 00000 n 
-0000083662 00000 n 
-0000083777 00000 n 
+0000014023 00000 n 
+0000014639 00000 n 
+0000073387 00000 n 
+0000018219 00000 n 
+0000018241 00000 n 
+0000018508 00000 n 
+0000018981 00000 n 
+0000019003 00000 n 
+0000019317 00000 n 
+0000021981 00000 n 
+0000022199 00000 n 
+0000036865 00000 n 
+0000037088 00000 n 
+0000052082 00000 n 
+0000052325 00000 n 
+0000065131 00000 n 
+0000065393 00000 n 
+0000073158 00000 n 
+0000073543 00000 n 
+0000075809 00000 n 
+0000078076 00000 n 
+0000080343 00000 n 
+0000082610 00000 n 
+0000083546 00000 n 
+0000083661 00000 n 
 trailer
-<< /Size 73
-/Root 71 0 R
-/Info 72 0 R
+<< /Size 72
+/Root 70 0 R
+/Info 71 0 R
 /ID [<9BD18DF3359C1216B83ADB4AA401CC9A> <9BD18DF3359C1216B83ADB4AA401CC9A>] >>
 startxref
-84120
+84004
 %%EOF

--- a/required/latex-lab/testfiles-title/title-009.luatex.tpf
+++ b/required/latex-lab/testfiles-title/title-009.luatex.tpf
@@ -1,6 +1,6 @@
 %PDF-2.0
 %Ã’¡‘≈ÿ–ƒ∆
-36 0 obj
+35 0 obj
 << /Type /Metadata /Subtype /XML /Length 11987 >>      
 stream
 <?xpacket begin="Ôªø" id="W5M0MpCehiHzreSzNTczkc9d"?>
@@ -245,7 +245,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-39 0 obj
+38 0 obj
 << /Length 1561 >>       
 stream
 /opacity1 gs
@@ -331,32 +331,32 @@ EMC
 EMC
 endstream
 endobj
-38 0 obj
-<< /Type /Page /Contents 39 0 R /Resources 37 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 45 0 R >>
-endobj
 37 0 obj
-<< /ExtGState 1 0 R /Font << /F17 40 0 R /F15 41 0 R /F18 42 0 R /F28 43 0 R /F30 44 0 R >> >>
+<< /Type /Page /Contents 38 0 R /Resources 36 0 R /MediaBox [ 0 0 612 792 ] /StructParents 0/Tabs /S /Parent 44 0 R >>
+endobj
+36 0 obj
+<< /ExtGState 1 0 R /Font << /F17 39 0 R /F15 40 0 R /F18 41 0 R /F28 42 0 R /F30 43 0 R >> >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-46 0 obj
+45 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 35 0 R 34 0 R] 
+<< /Nums [0 [ 26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 34 0 R 33 0 R] 
 ] >>
 endobj
-47 0 obj
-<< /Limits [(ID.002) (ID.016)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 27 0 R (ID.009) 28 0 R (ID.010) 29 0 R (ID.011) 30 0 R (ID.012) 31 0 R (ID.013) 32 0 R (ID.014) 33 0 R (ID.015) 34 0 R (ID.016) 35 0 R ] >>
+46 0 obj
+<< /Limits [(ID.002) (ID.015)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 27 0 R (ID.009) 28 0 R (ID.010) 29 0 R (ID.011) 30 0 R (ID.012) 31 0 R (ID.013) 32 0 R (ID.014) 33 0 R (ID.015) 34 0 R ] >>
 endobj
-48 0 obj
-<< /Kids [47 0 R] >>
+47 0 obj
+<< /Kids [46 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
 endobj
-49 0 obj
+48 0 obj
 << /center <</O/Layout/TextAlign/Center>>
 /justify <</O/Layout/TextAlign/Justify>>
 /TH-both <</O/Table/Scope/Both>>
@@ -407,58 +407,55 @@ endobj
 <<  /Type /StructElem /S /Title /NS 11 0 R  /P 24 0 R /K [26 0 R 28 0 R] /ID (ID.006) >>
 endobj
 26 0 obj
-<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 25 0 R /K [<</Type /MCR /Pg 38 0 R /MCID 0>>  27 0 R ] /ID (ID.007) >>
+<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 25 0 R /K [<</Type /MCR /Pg 37 0 R /MCID 0>>  27 0 R ] /ID (ID.007) >>
 endobj
 27 0 obj
-<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 26 0 R /Ref [ 31 0 R ] /K <</Type /MCR /Pg 38 0 R /MCID 1>>  /ID (ID.008) >>
+<<  /Type /StructElem /S /footnotemark /NS 15 0 R  /P 26 0 R /Ref [ 31 0 R ] /K <</Type /MCR /Pg 37 0 R /MCID 1>>  /ID (ID.008) >>
 endobj
 28 0 obj
-<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 25 0 R /K <</Type /MCR /Pg 38 0 R /MCID 2>>  /ID (ID.009) >>
+<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 25 0 R /K <</Type /MCR /Pg 37 0 R /MCID 2>>  /ID (ID.009) >>
 endobj
 29 0 obj
-<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 24 0 R /K <</Type /MCR /Pg 38 0 R /MCID 3>>  /ID (ID.010) >>
+<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 24 0 R /K <</Type /MCR /Pg 37 0 R /MCID 3>>  /ID (ID.010) >>
 endobj
 30 0 obj
-<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 24 0 R /K <</Type /MCR /Pg 38 0 R /MCID 4>>  /ID (ID.011) >>
+<<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 24 0 R /K <</Type /MCR /Pg 37 0 R /MCID 4>>  /ID (ID.011) >>
 endobj
 31 0 obj
-<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 21 0 R /Ref [ 27 0 R ] /K [32 0 R 33 0 R] /ID (ID.012) >>
+<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 21 0 R /Ref [ 27 0 R ] /K [34 0 R 32 0 R] /ID (ID.012) >>
 endobj
 32 0 obj
-<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 31 0 R /K 35 0 R /ID (ID.013) >>
+<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 31 0 R /K 33 0 R /ID (ID.013) >>
 endobj
 33 0 obj
-<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 31 0 R /K 34 0 R /ID (ID.014) >>
+<<  /Type /StructElem /C /justify /S /text /NS 15 0 R  /P 32 0 R /K [  <</Type /MCR /Pg 37 0 R /MCID 6>>  ] /ID (ID.014) >>
 endobj
 34 0 obj
-<<  /Type /StructElem /C /justify /S /text /NS 15 0 R  /P 33 0 R /K [  <</Type /MCR /Pg 38 0 R /MCID 6>>  ] /ID (ID.015) >>
-endobj
-35 0 obj
-<<  /Type /StructElem /S /NonStruct /NS 11 0 R  /P 32 0 R /K <</Type /MCR /Pg 38 0 R /MCID 5>>  /ID (ID.016) >>
+<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 31 0 R /K <</Type /MCR /Pg 37 0 R /MCID 5>>  /ID (ID.015) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 48 0 R /ClassMap 49 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
+<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 47 0 R /ClassMap 48 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
 endobj
-50 0 obj
+49 0 obj
 [611.1 ]
 endobj
-51 0 obj
+50 0 obj
 [770.7 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 513.9 571 0 0 457.2 0 0 571 285.5 0 0 285.5 0 0 513.9 0 0 0 405.4 399.7 571 0 742.3 ]
 endobj
-52 0 obj
+51 0 obj
 [272 0 0 0 489.6 489.6 489.6 0 0 0 489.6 0 0 0 0 0 0 0 0 0 0 734 693.4 0 0 0 0 0 0 0 0 0 0 897.2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 489.6 0 0 0 0 0 0 544 0 0 0 0 0 0 489.6 0 0 380.8 0 380.8 544 0 0 0 516.8 ]
 endobj
-53 0 obj
+52 0 obj
 [ 103 [ 333 ] ]
 endobj
-55 0 obj
+54 0 obj
 << /Subtype /CIDFontType0C /Length 506 >>        
 [BINARY STREAM]
 endobj
-54 0 obj
-<< /Type /FontDescriptor /FontName /XVZVYO+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 55 0 R >>
+53 0 obj
+<< /Type /FontDescriptor /FontName /XVZVYO+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 54 0 R >>
 endobj
-56 0 obj
+55 0 obj
 << /Length 692 >>        
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -494,44 +491,44 @@ end
 %%EOF
 endstream
 endobj
-41 0 obj
-<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /XVZVYO+LMRoman10-Regular /DescendantFonts [ 57 0 R ] /ToUnicode 56 0 R >>
+40 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /XVZVYO+LMRoman10-Regular /DescendantFonts [ 56 0 R ] /ToUnicode 55 0 R >>
+endobj
+56 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /XVZVYO+LMRoman10-Regular /FontDescriptor 53 0 R /W 52 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
 endobj
 57 0 obj
-<< /Type /Font /Subtype /CIDFontType0 /BaseFont /XVZVYO+LMRoman10-Regular /FontDescriptor 54 0 R /W 53 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
-endobj
-58 0 obj
 [693.3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 406.4 0 0 0 249.6 0 0 249.6 0 0 0 0 0 0 0 354.1 ]
 endobj
-60 0 obj
+59 0 obj
 << /Length1 1599 /Length2 8302 /Length3 0 /Length 9901 >>       
 [BINARY STREAM]
 endobj
-59 0 obj
-<< /Type /FontDescriptor /FontName /VBFROV+CMR12 /Flags 4 /FontBBox [ -34 -251 988 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 65 /XHeight 431 /FontFile 60 0 R >>
+58 0 obj
+<< /Type /FontDescriptor /FontName /VBFROV+CMR12 /Flags 4 /FontBBox [ -34 -251 988 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 65 /XHeight 431 /FontFile 59 0 R >>
 endobj
-62 0 obj
+61 0 obj
 << /Length1 1444 /Length2 6633 /Length3 0 /Length 8077 >>       
 [BINARY STREAM]
 endobj
-61 0 obj
-<< /Type /FontDescriptor /FontName /PXLAWO+CMR17 /Flags 4 /FontBBox [ -33 -250 945 749 ] /Ascent 694 /CapHeight 683 /Descent -195 /ItalicAngle 0 /StemV 53 /XHeight 430 /FontFile 62 0 R >>
+60 0 obj
+<< /Type /FontDescriptor /FontName /PXLAWO+CMR17 /Flags 4 /FontBBox [ -33 -250 945 749 ] /Ascent 694 /CapHeight 683 /Descent -195 /ItalicAngle 0 /StemV 53 /XHeight 430 /FontFile 61 0 R >>
 endobj
-64 0 obj
+63 0 obj
 << /Length1 1379 /Length2 5945 /Length3 0 /Length 7324 >>       
 [BINARY STREAM]
 endobj
-63 0 obj
-<< /Type /FontDescriptor /FontName /WIRDCL+CMR6 /Flags 4 /FontBBox [ -20 -250 1193 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 83 /XHeight 431 /FontFile 64 0 R >>
+62 0 obj
+<< /Type /FontDescriptor /FontName /WIRDCL+CMR6 /Flags 4 /FontBBox [ -20 -250 1193 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 83 /XHeight 431 /FontFile 63 0 R >>
 endobj
-66 0 obj
+65 0 obj
 << /Length1 1540 /Length2 8783 /Length3 0 /Length 10323 >>      
 [BINARY STREAM]
 endobj
-65 0 obj
-<< /Type /FontDescriptor /FontName /DTRHJH+CMR9 /Flags 4 /FontBBox [ -39 -250 1036 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 74 /XHeight 431 /FontFile 66 0 R >>
+64 0 obj
+<< /Type /FontDescriptor /FontName /DTRHJH+CMR9 /Flags 4 /FontBBox [ -39 -250 1036 750 ] /Ascent 694 /CapHeight 683 /Descent -194 /ItalicAngle 0 /StemV 74 /XHeight 431 /FontFile 65 0 R >>
 endobj
-67 0 obj
+66 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -651,10 +648,10 @@ end
 %%EOF
 endstream
 endobj
-42 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /VBFROV+CMR12 /FontDescriptor 59 0 R /FirstChar 44 /LastChar 121 /Widths 52 0 R /ToUnicode 67 0 R >>
+41 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /VBFROV+CMR12 /FontDescriptor 58 0 R /FirstChar 44 /LastChar 121 /Widths 51 0 R /ToUnicode 66 0 R >>
 endobj
-68 0 obj
+67 0 obj
 << /Length 1724 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -774,10 +771,10 @@ end
 %%EOF
 endstream
 endobj
-40 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /PXLAWO+CMR17 /FontDescriptor 61 0 R /FirstChar 65 /LastChar 116 /Widths 58 0 R /ToUnicode 68 0 R >>
+39 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /PXLAWO+CMR17 /FontDescriptor 60 0 R /FirstChar 65 /LastChar 116 /Widths 57 0 R /ToUnicode 67 0 R >>
 endobj
-69 0 obj
+68 0 obj
 << /Length 1719 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -897,10 +894,10 @@ end
 %%EOF
 endstream
 endobj
-44 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /WIRDCL+CMR6 /FontDescriptor 63 0 R /FirstChar 49 /LastChar 49 /Widths 50 0 R /ToUnicode 69 0 R >>
+43 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /WIRDCL+CMR6 /FontDescriptor 62 0 R /FirstChar 49 /LastChar 49 /Widths 49 0 R /ToUnicode 68 0 R >>
 endobj
-70 0 obj
+69 0 obj
 << /Length 1719 >>       
 stream
 %!PS-Adobe-3.0 Resource-CMap
@@ -1020,95 +1017,94 @@ end
 %%EOF
 endstream
 endobj
-43 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /DTRHJH+CMR9 /FontDescriptor 65 0 R /FirstChar 78 /LastChar 119 /Widths 51 0 R /ToUnicode 70 0 R >>
+42 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /DTRHJH+CMR9 /FontDescriptor 64 0 R /FirstChar 78 /LastChar 119 /Widths 50 0 R /ToUnicode 69 0 R >>
 endobj
-45 0 obj
-<< /Type /Pages  /Count 1 /Kids [ 38 0 R ] >>
+44 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 37 0 R ] >>
+endobj
+70 0 obj
+<< /Type /Catalog /Pages 44 0 R /MarkInfo 45 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 35 0 R >>
 endobj
 71 0 obj
-<< /Type /Catalog /Pages 45 0 R /MarkInfo 46 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 36 0 R >>
-endobj
-72 0 obj
 << /Producer (LuaTeX)/Creator (TeX)/Author <FEFF0061007500740068006F007200200043002C00200061007500740068006F007200200044>/Title <FEFF00410020007400690074006C0065005B00310063006D005D00200077006900740068002000610020007300750062007400690074006C0065>/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z) /Trapped /False >>
 endobj
 xref
-0 73
+0 72
 0000000002 65535 f 
 0000013964 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000010 00000 f 
-0000018475 00000 n 
+0000018359 00000 n 
 0000014047 00000 n 
-0000014468 00000 n 
-0000016621 00000 n 
-0000015248 00000 n 
+0000014452 00000 n 
+0000016605 00000 n 
+0000015232 00000 n 
 0000000012 00000 f 
-0000015316 00000 n 
+0000015300 00000 n 
 0000000014 00000 f 
-0000015386 00000 n 
+0000015370 00000 n 
 0000000020 00000 f 
-0000016149 00000 n 
-0000015467 00000 n 
-0000016427 00000 n 
-0000016256 00000 n 
-0000016534 00000 n 
+0000016133 00000 n 
+0000015451 00000 n 
+0000016411 00000 n 
+0000016240 00000 n 
+0000016518 00000 n 
 0000000000 00000 f 
-0000016682 00000 n 
-0000016789 00000 n 
-0000016877 00000 n 
-0000016965 00000 n 
-0000017081 00000 n 
-0000017186 00000 n 
-0000017330 00000 n 
-0000017477 00000 n 
-0000017611 00000 n 
-0000017745 00000 n 
-0000017879 00000 n 
-0000018003 00000 n 
-0000018107 00000 n 
-0000018207 00000 n 
-0000018347 00000 n 
+0000016666 00000 n 
+0000016773 00000 n 
+0000016861 00000 n 
+0000016949 00000 n 
+0000017065 00000 n 
+0000017170 00000 n 
+0000017314 00000 n 
+0000017461 00000 n 
+0000017595 00000 n 
+0000017729 00000 n 
+0000017863 00000 n 
+0000017987 00000 n 
+0000018087 00000 n 
+0000018227 00000 n 
 0000000020 00000 n 
 0000013853 00000 n 
 0000013718 00000 n 
 0000012097 00000 n 
-0000061664 00000 n 
-0000020604 00000 n 
-0000059722 00000 n 
-0000065536 00000 n 
-0000063601 00000 n 
-0000065693 00000 n 
+0000061548 00000 n 
+0000020488 00000 n 
+0000059606 00000 n 
+0000065420 00000 n 
+0000063485 00000 n 
+0000065577 00000 n 
 0000014011 00000 n 
 0000014132 00000 n 
-0000014431 00000 n 
-0000015047 00000 n 
-0000018612 00000 n 
-0000018637 00000 n 
-0000018782 00000 n 
-0000019009 00000 n 
-0000019631 00000 n 
-0000019041 00000 n 
-0000019852 00000 n 
-0000020758 00000 n 
-0000020958 00000 n 
-0000031101 00000 n 
-0000021101 00000 n 
-0000039481 00000 n 
-0000031305 00000 n 
-0000047108 00000 n 
-0000039685 00000 n 
-0000057734 00000 n 
-0000047312 00000 n 
-0000057938 00000 n 
-0000059880 00000 n 
-0000061822 00000 n 
-0000063757 00000 n 
-0000065755 00000 n 
-0000065870 00000 n 
+0000014415 00000 n 
+0000015031 00000 n 
+0000018496 00000 n 
+0000018521 00000 n 
+0000018666 00000 n 
+0000018893 00000 n 
+0000019515 00000 n 
+0000018925 00000 n 
+0000019736 00000 n 
+0000020642 00000 n 
+0000020842 00000 n 
+0000030985 00000 n 
+0000020985 00000 n 
+0000039365 00000 n 
+0000031189 00000 n 
+0000046992 00000 n 
+0000039569 00000 n 
+0000057618 00000 n 
+0000047196 00000 n 
+0000057822 00000 n 
+0000059764 00000 n 
+0000061706 00000 n 
+0000063641 00000 n 
+0000065639 00000 n 
+0000065754 00000 n 
 trailer
-<< /Size 73 /Root 71 0 R /Info 72 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
+<< /Size 72 /Root 70 0 R /Info 71 0 R /ID [ <2350CAD05F8A7AF0AA4058486855344F> <2350CAD05F8A7AF0AA4058486855344F> ] >>
 startxref
-66213
+66097
 %%EOF

--- a/required/latex-lab/testfiles-title/title-009.tpf
+++ b/required/latex-lab/testfiles-title/title-009.tpf
@@ -1,6 +1,6 @@
 %PDF-2.0
 %ÐÔÅØ
-37 0 obj
+36 0 obj
 <<
 /Type /Metadata /Subtype /XML
 /Length 11985     
@@ -248,7 +248,7 @@ stream
 <?xpacket end="w"?>
 endstream
 endobj
-39 0 obj
+38 0 obj
 <<
 /Length 1149      
 >>
@@ -306,39 +306,39 @@ endobj
 27 0 obj
 <<
 /Type /Page
-/Contents 39 0 R
-/Resources 38 0 R
+/Contents 38 0 R
+/Resources 37 0 R
 /MediaBox [0 0 612 792]
 /Tabs /S /StructParents 0 
-/Parent 45 0 R
+/Parent 44 0 R
 >>
 endobj
-38 0 obj
+37 0 obj
 <<
 /ExtGState 1 0 R 
-/Font << /F40 40 0 R /F65 41 0 R /F49 42 0 R /F50 43 0 R /F64 44 0 R >>
+/Font << /F40 39 0 R /F65 40 0 R /F49 41 0 R /F50 42 0 R /F64 43 0 R >>
 >>
 endobj
 1 0 obj
 << /opacity1 <</ca 1/CA 1>>  >>
 endobj
-46 0 obj
+45 0 obj
 << /Marked true  >>
 endobj
 6 0 obj
-<< /Nums [0 [ 26 0 R 28 0 R 26 0 R 29 0 R 30 0 R 31 0 R 35 0 R 36 0 R 35 0 R 35 0 R 35 0 R ]
+<< /Nums [0 [ 26 0 R 28 0 R 26 0 R 29 0 R 30 0 R 31 0 R 34 0 R 35 0 R 34 0 R 34 0 R 34 0 R ]
 ] >>
 endobj
-47 0 obj
-<< /Limits [(ID.002) (ID.016)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 28 0 R (ID.009) 29 0 R (ID.010) 30 0 R (ID.011) 31 0 R (ID.012) 32 0 R (ID.013) 33 0 R (ID.014) 34 0 R (ID.015) 35 0 R (ID.016) 36 0 R ] >>
+46 0 obj
+<< /Limits [(ID.002) (ID.015)]/Names [(ID.002) 21 0 R (ID.003) 22 0 R (ID.004) 23 0 R (ID.005) 24 0 R (ID.006) 25 0 R (ID.007) 26 0 R (ID.008) 28 0 R (ID.009) 29 0 R (ID.010) 30 0 R (ID.011) 31 0 R (ID.012) 32 0 R (ID.013) 33 0 R (ID.014) 34 0 R (ID.015) 35 0 R ] >>
 endobj
-48 0 obj
-<< /Kids [47 0 R] >>
+47 0 obj
+<< /Kids [46 0 R] >>
 endobj
 7 0 obj
 << /Artifact /NonStruct /DocumentFragment /Art /Aside /Note /H7 /H6 /H8 /H6 /H9 /H6 /H10 /H6 /Title /P /FENote /Note /Sub /Span /Em /Span /Strong /Span /title /P /part /P /section /H1 /subsection /H2 /subsubsection /H3 /paragraph /H4 /subparagraph /H5 /list /L /itemize /L /enumerate /L /description /L /quote /BlockQuote /quotation /BlockQuote /verbatim /P /item /LI /itemlabel /Lbl /itembody /LBody /footnote /Note /footnotemark /Lbl /footnotelabel /Lbl /text-unit /Part /text /P /theorem-like /Sect /codeline /Span /float /Note /figures /Sect /tables /Sect  >>
 endobj
-49 0 obj
+48 0 obj
 << /center <</O/Layout/TextAlign/Center>>
 /justify <</O/Layout/TextAlign/Justify>>
 /TH-both <</O/Table/Scope/Both>>
@@ -404,39 +404,36 @@ endobj
 <<  /Type /StructElem /C /center /S /text /NS 15 0 R  /P 24 0 R /K <</Type /MCR /Pg 27 0 R/MCID 5>> /ID (ID.011) >>
 endobj
 32 0 obj
-<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 21 0 R /Ref [ 28 0 R ] /K [33 0 R 34 0 R] /ID (ID.012) >>
+<<  /Type /StructElem /S /footnote /NS 15 0 R  /P 21 0 R /Ref [ 28 0 R ] /K [35 0 R 33 0 R] /ID (ID.012) >>
 endobj
 33 0 obj
-<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 32 0 R /K 36 0 R /ID (ID.013) >>
+<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 32 0 R /K 34 0 R /ID (ID.013) >>
 endobj
 34 0 obj
-<<  /Type /StructElem /S /text-unit /NS 15 0 R  /P 32 0 R /K 35 0 R /ID (ID.014) >>
+<<  /Type /StructElem /C /justify /S /text /NS 15 0 R  /P 33 0 R /K [<</Type /MCR /Pg 27 0 R/MCID 6>> <</Type /MCR /Pg 27 0 R/MCID 8>> <</Type /MCR /Pg 27 0 R/MCID 9>> <</Type /MCR /Pg 27 0 R/MCID 10>>] /ID (ID.014) >>
 endobj
 35 0 obj
-<<  /Type /StructElem /C /justify /S /text /NS 15 0 R  /P 34 0 R /K [<</Type /MCR /Pg 27 0 R/MCID 6>> <</Type /MCR /Pg 27 0 R/MCID 8>> <</Type /MCR /Pg 27 0 R/MCID 9>> <</Type /MCR /Pg 27 0 R/MCID 10>>] /ID (ID.015) >>
-endobj
-36 0 obj
-<<  /Type /StructElem /S /NonStruct /NS 11 0 R  /P 33 0 R /K <</Type /MCR /Pg 27 0 R/MCID 7>> /ID (ID.016) >>
+<<  /Type /StructElem /S /footnotelabel /NS 15 0 R  /P 32 0 R /K <</Type /MCR /Pg 27 0 R/MCID 7>> /ID (ID.015) >>
 endobj
 5 0 obj
-<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 48 0 R /ClassMap 49 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
+<<  /Type /StructTreeRoot /Namespaces 8 0 R /IDTree 47 0 R /ClassMap 48 0 R /ParentTree 6 0 R /RoleMap 7 0 R /K 21 0 R >>
 endobj
-51 0 obj
+50 0 obj
 [611]
 endobj
-52 0 obj
+51 0 obj
 [770.5 799.2 699.2 799.2 756.3 570.8 742.1 770.5 770.5 1055.9 770.5 770.5 627.9 285.4 513.8 285.4 627.9 799.2 285.4 513.8 570.8 456.7 570.8 457.1 314 513.8 570.8 285.4 314 542.3 285.4 856.3 570.8 513.8 570.8 542.3 401.9 405.3 399.6 570.8 542.3 742.1]
 endobj
-53 0 obj
+52 0 obj
 [271.9 326.3 271.9 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 489.5 271.9 271.9 761.4 761.4 761.4 462.3 761.4 733.8 693.2 707 747.6 666 638.8 768.1 733.8 353.2 502.9 761 611.7 897 733.8 761.4 666 761.4 720.4 543.8 707 733.8 733.8 1005.8 733.8 733.8 598.2 271.9 489.5 271.9 598.2 761.4 271.9 489.5 543.8 435.1 543.8 435.1 299.1 489.5 543.8 271.9 299.1 516.7 271.9 815.8 543.8 489.5 543.8 516.7 380.7 386.1 380.7 543.8 516.7 707 516.7 516.7]
 endobj
-54 0 obj
+53 0 obj
 [333]
 endobj
-55 0 obj
+54 0 obj
 [704.4 665.4 678.7 717.7 639.3 613.2 737.3 704.4 338.8 482.6 730.5 587.1 861.1 704.4 730.9 639.3 730.9 691.5 522 678.7 704.4 704.4 965.6 704.4 704.4 574.2 260.8 469.8 260.8 574.2 730.9 260.8 469.8 522 417.5 522 417.5 287 469.8 522 260.8 287 495.9 260.8 783.1 522 469.8 522 495.9 365.3 370.5 365.3]
 endobj
-56 0 obj
+55 0 obj
 <<
 /Length1 1144
 /Length2 1422
@@ -445,7 +442,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-57 0 obj
+56 0 obj
 <<
 /Type /FontDescriptor
 /FontName /MUQHVU+PdfTeX-Space
@@ -458,10 +455,10 @@ endobj
 /StemV 0
 /XHeight 500
 /CharSet (/space)
-/FontFile 56 0 R
+/FontFile 55 0 R
 >>
 endobj
-58 0 obj
+57 0 obj
 <<
 /Length1 721
 /Length2 13847
@@ -470,7 +467,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-59 0 obj
+58 0 obj
 <<
 /Type /FontDescriptor
 /FontName /WMNOAL+SFRM0600
@@ -483,10 +480,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/one)
-/FontFile 58 0 R
+/FontFile 57 0 R
 >>
 endobj
-60 0 obj
+59 0 obj
 <<
 /Length1 721
 /Length2 14175
@@ -495,7 +492,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-61 0 obj
+60 0 obj
 <<
 /Type /FontDescriptor
 /FontName /ZEXONM+SFRM0900
@@ -508,10 +505,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/N/a/b/e/h/i/l/o/s/t/u/w)
-/FontFile 60 0 R
+/FontFile 59 0 R
 >>
 endobj
-62 0 obj
+61 0 obj
 <<
 /Length1 721
 /Length2 11987
@@ -520,7 +517,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-63 0 obj
+62 0 obj
 <<
 /Type /FontDescriptor
 /FontName /XGEWRW+SFRM1200
@@ -533,10 +530,10 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/A/B/M/a/comma/h/o/one/r/six/t/two/u/y/zero)
-/FontFile 62 0 R
+/FontFile 61 0 R
 >>
 endobj
-64 0 obj
+63 0 obj
 <<
 /Length1 721
 /Length2 6947
@@ -545,7 +542,7 @@ endobj
 >>
 [BINARY STREAM]
 endobj
-65 0 obj
+64 0 obj
 <<
 /Type /FontDescriptor
 /FontName /EMNKTC+SFRM1728
@@ -558,16 +555,16 @@ endobj
 /StemV 50
 /XHeight 430
 /CharSet (/A/e/i/l/t)
-/FontFile 64 0 R
+/FontFile 63 0 R
 >>
 endobj
-50 0 obj
+49 0 obj
 <<
 /Type /Encoding
 /Differences [44/comma 48/zero/one/two 54/six 65/A/B 77/M/N 97/a/b 101/e 104/h/i 108/l 111/o 114/r/s/t/u 119/w 121/y]
 >>
 endobj
-66 0 obj
+65 0 obj
 <<
 /Length 2030      
 >>
@@ -711,20 +708,20 @@ end
 %%EOF
 endstream
 endobj
-44 0 obj
+43 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /WMNOAL+SFRM0600
-/FontDescriptor 59 0 R
+/FontDescriptor 58 0 R
 /FirstChar 49
 /LastChar 49
-/Widths 51 0 R
-/Encoding 50 0 R
-/ToUnicode 66 0 R
+/Widths 50 0 R
+/Encoding 49 0 R
+/ToUnicode 65 0 R
 >>
 endobj
-67 0 obj
+66 0 obj
 <<
 /Length 2030      
 >>
@@ -868,20 +865,20 @@ end
 %%EOF
 endstream
 endobj
-43 0 obj
+42 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /ZEXONM+SFRM0900
-/FontDescriptor 61 0 R
+/FontDescriptor 60 0 R
 /FirstChar 78
 /LastChar 119
-/Widths 52 0 R
-/Encoding 50 0 R
-/ToUnicode 67 0 R
+/Widths 51 0 R
+/Encoding 49 0 R
+/ToUnicode 66 0 R
 >>
 endobj
-68 0 obj
+67 0 obj
 <<
 /Length 2030      
 >>
@@ -1025,20 +1022,20 @@ end
 %%EOF
 endstream
 endobj
-42 0 obj
+41 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /XGEWRW+SFRM1200
-/FontDescriptor 63 0 R
+/FontDescriptor 62 0 R
 /FirstChar 44
 /LastChar 121
-/Widths 53 0 R
-/Encoding 50 0 R
-/ToUnicode 68 0 R
+/Widths 52 0 R
+/Encoding 49 0 R
+/ToUnicode 67 0 R
 >>
 endobj
-69 0 obj
+68 0 obj
 <<
 /Length 2030      
 >>
@@ -1182,20 +1179,20 @@ end
 %%EOF
 endstream
 endobj
-40 0 obj
+39 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /EMNKTC+SFRM1728
-/FontDescriptor 65 0 R
+/FontDescriptor 64 0 R
 /FirstChar 65
 /LastChar 116
-/Widths 55 0 R
-/Encoding 50 0 R
-/ToUnicode 69 0 R
+/Widths 54 0 R
+/Encoding 49 0 R
+/ToUnicode 68 0 R
 >>
 endobj
-70 0 obj
+69 0 obj
 <<
 /Length 654       
 >>
@@ -1233,118 +1230,117 @@ end
 %%EOF
 endstream
 endobj
-41 0 obj
+40 0 obj
 <<
 /Type /Font
 /Subtype /Type1
 /BaseFont /MUQHVU+PdfTeX-Space
-/FontDescriptor 57 0 R
+/FontDescriptor 56 0 R
 /FirstChar 32
 /LastChar 32
-/Widths 54 0 R
-/ToUnicode 70 0 R
+/Widths 53 0 R
+/ToUnicode 69 0 R
 >>
 endobj
-45 0 obj
+44 0 obj
 <<
 /Type /Pages
 /Count 1
 /Kids [27 0 R]
 >>
 endobj
-71 0 obj
+70 0 obj
 <<
 /Type /Catalog
-/Pages 45 0 R
-/MarkInfo 46 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 37 0 R
+/Pages 44 0 R
+/MarkInfo 45 0 R/Lang (en)/StructTreeRoot 5 0 R/Metadata 36 0 R
 >>
 endobj
-72 0 obj
+71 0 obj
 <<
 /Producer (pdfTeX)/Creator (TeX)/Author <FEFF0061007500740068006F007200200043002C00200061007500740068006F007200200044>/Title <FEFF00410020007400690074006C0065005B00310063006D005D00200077006900740068002000610020007300750062007400690074006C0065>/CreationDate (D:20160520090000Z)/ModDate (D:20160520090000Z)
 /Trapped /False
 >>
 endobj
 xref
-0 73
+0 72
 0000000002 65535 f 
 0000013544 00000 n 
 0000000003 00000 f 
 0000000004 00000 f 
 0000000010 00000 f 
-0000018198 00000 n 
+0000018082 00000 n 
 0000013627 00000 n 
-0000014076 00000 n 
-0000016229 00000 n 
-0000014856 00000 n 
+0000014060 00000 n 
+0000016213 00000 n 
+0000014840 00000 n 
 0000000012 00000 f 
-0000014924 00000 n 
+0000014908 00000 n 
 0000000014 00000 f 
-0000014994 00000 n 
+0000014978 00000 n 
 0000000020 00000 f 
-0000015757 00000 n 
-0000015075 00000 n 
-0000016035 00000 n 
-0000015864 00000 n 
-0000016142 00000 n 
+0000015741 00000 n 
+0000015059 00000 n 
+0000016019 00000 n 
+0000015848 00000 n 
+0000016126 00000 n 
 0000000000 00000 f 
-0000016290 00000 n 
-0000016397 00000 n 
-0000016485 00000 n 
-0000016573 00000 n 
-0000016689 00000 n 
-0000016794 00000 n 
+0000016274 00000 n 
+0000016381 00000 n 
+0000016469 00000 n 
+0000016557 00000 n 
+0000016673 00000 n 
+0000016778 00000 n 
 0000013297 00000 n 
-0000016968 00000 n 
-0000017113 00000 n 
-0000017245 00000 n 
-0000017377 00000 n 
-0000017509 00000 n 
-0000017633 00000 n 
-0000017737 00000 n 
-0000017837 00000 n 
-0000018072 00000 n 
+0000016952 00000 n 
+0000017097 00000 n 
+0000017229 00000 n 
+0000017361 00000 n 
+0000017493 00000 n 
+0000017617 00000 n 
+0000017717 00000 n 
+0000017952 00000 n 
 0000000015 00000 n 
 0000013432 00000 n 
 0000012089 00000 n 
-0000082548 00000 n 
-0000083439 00000 n 
-0000080281 00000 n 
-0000078014 00000 n 
-0000075748 00000 n 
-0000083603 00000 n 
+0000082432 00000 n 
+0000083323 00000 n 
+0000080165 00000 n 
+0000077898 00000 n 
+0000075632 00000 n 
+0000083487 00000 n 
 0000013591 00000 n 
 0000013740 00000 n 
-0000014039 00000 n 
-0000014655 00000 n 
-0000073503 00000 n 
-0000018335 00000 n 
-0000018357 00000 n 
-0000018624 00000 n 
-0000019097 00000 n 
-0000019119 00000 n 
-0000019433 00000 n 
-0000022097 00000 n 
-0000022315 00000 n 
-0000036981 00000 n 
-0000037204 00000 n 
-0000052198 00000 n 
-0000052441 00000 n 
-0000065247 00000 n 
-0000065509 00000 n 
-0000073274 00000 n 
-0000073659 00000 n 
-0000075925 00000 n 
-0000078192 00000 n 
-0000080459 00000 n 
-0000082726 00000 n 
-0000083662 00000 n 
-0000083777 00000 n 
+0000014023 00000 n 
+0000014639 00000 n 
+0000073387 00000 n 
+0000018219 00000 n 
+0000018241 00000 n 
+0000018508 00000 n 
+0000018981 00000 n 
+0000019003 00000 n 
+0000019317 00000 n 
+0000021981 00000 n 
+0000022199 00000 n 
+0000036865 00000 n 
+0000037088 00000 n 
+0000052082 00000 n 
+0000052325 00000 n 
+0000065131 00000 n 
+0000065393 00000 n 
+0000073158 00000 n 
+0000073543 00000 n 
+0000075809 00000 n 
+0000078076 00000 n 
+0000080343 00000 n 
+0000082610 00000 n 
+0000083546 00000 n 
+0000083661 00000 n 
 trailer
-<< /Size 73
-/Root 71 0 R
-/Info 72 0 R
+<< /Size 72
+/Root 70 0 R
+/Info 71 0 R
 /ID [<9BD18DF3359C1216B83ADB4AA401CC9A> <9BD18DF3359C1216B83ADB4AA401CC9A>] >>
 startxref
-84120
+84004
 %%EOF


### PR DESCRIPTION
Currently footnote labels contain a NonStruct element which was used as a helper structure to move the label to the begin of the footnote structure

![image](https://github.com/user-attachments/assets/ed1a0bdf-f64e-4017-9ab6-b86cfc531a1f)

with the new tagpdf this is no longer needed and with the change here the structure  looks nice.

![image](https://github.com/user-attachments/assets/189c43fb-feec-4635-91ae-f4c6b0bcce29)

(The PR contains also a few docu changes and additions.)

## Status of pull request

x Ready to merge

## Checklist of required changes before merge will be approved
- [n/a] Test file(s) added
- [x] Version and date string updated in changed source files
- [n/a] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [n/a] Rollback provided (if necessary)?
- [n/a] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
