### PR TITLE
Make two argument tagging sockets preserve the second arg when suspended and add expandable variants

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,10 +6,12 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
-2024-10-21  Marcel Krüger  <Marcel.Krueger@latex-project.org>
+2024-10-27  Marcel Krüger  <Marcel.Krueger@latex-project.org>
 	* lttagging.dtx
 	Adapt two argument tagging sockets to preserve second argument when the socket is disabled.
 	Add expandable versions of tagging socket use commands.
+	* ltsocket.dtx
+	Add expandable versions of \socket_use_expandable:n
 
 2024-10-26  Yukai Chou <muzimuzhi@gmail.com>
 	* ltcounts.dtx (subsection{Environment Counter Macros}):

--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,10 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
+2024-10-21  Marcel Krüger  <Marcel.Krueger@latex-project.org>
+	* lttagging.dtx
+	Adapt two argument tagging sockets to preserve second argument when the socket is disabled.
+
 2024-10-26  Yukai Chou <muzimuzhi@gmail.com>
 	* ltcounts.dtx (subsection{Environment Counter Macros}):
 	Fully expand counter name in \theH<counter> commands (gh/1508)

--- a/base/changes.txt
+++ b/base/changes.txt
@@ -8,7 +8,8 @@ not part of the distribution.
 
 2024-10-27  Marcel Krüger  <Marcel.Krueger@latex-project.org>
 	* lttagging.dtx
-	Adapt two argument tagging sockets to preserve second argument when the socket is disabled.
+	Change tagging sockets with two arguments to drop the first argument
+	but return the second argument when the socket is disabled with \SuspendTagging.
 	Add expandable versions of tagging socket use commands.
 	* ltsocket.dtx
 	Add expandable versions of \socket_use_expandable:n.

--- a/base/changes.txt
+++ b/base/changes.txt
@@ -11,7 +11,8 @@ not part of the distribution.
 	Adapt two argument tagging sockets to preserve second argument when the socket is disabled.
 	Add expandable versions of tagging socket use commands.
 	* ltsocket.dtx
-	Add expandable versions of \socket_use_expandable:n
+	Add expandable versions of \socket_use_expandable:n.
+	Make internal plug definitions non-protected to allow expandable use.
 
 2024-10-26  Yukai Chou <muzimuzhi@gmail.com>
 	* ltcounts.dtx (subsection{Environment Counter Macros}):

--- a/base/changes.txt
+++ b/base/changes.txt
@@ -9,6 +9,7 @@ not part of the distribution.
 2024-10-21  Marcel Krüger  <Marcel.Krueger@latex-project.org>
 	* lttagging.dtx
 	Adapt two argument tagging sockets to preserve second argument when the socket is disabled.
+	Add expandable versions of tagging socket use commands.
 
 2024-10-26  Yukai Chou <muzimuzhi@gmail.com>
 	* ltcounts.dtx (subsection{Environment Counter Macros}):

--- a/base/doc/ltnews40.tex
+++ b/base/doc/ltnews40.tex
@@ -282,6 +282,21 @@ up if there is indeed a missing \cs{item}.
 %
 \githubissue{1460}
 
+\subsection{Change behavior of tagging sockets with two arguments}
+
+When calling tagging sockets with two arguments using \cs{UseTaggingSocket}
+when tagging is suspended previous versions of \LaTeXe{} dropped both arguments.
+This behavior has been changed to drop the first argument and preserve the second
+one instead, thereby allowing tagging sockets to be used to wrap existing content
+which should still appear in a non-tagging context.
+
+Since no tagging sockets currently provided by \LaTeXe{} use two arguments
+we do not expect this change to affect any existing documents, but if a custom
+tagging socket has been defined outside of the kernel it might need to be adapted
+be compatible with the new behavior.
+%
+\githubissue{1500}
+
 
 \section{Code improvements}
 

--- a/base/ltsockets.dtx
+++ b/base/ltsockets.dtx
@@ -836,6 +836,7 @@
 %  
 %  
 %  \begin{macro}{\socket_new_plug:nnn,\socket_set_plug:nnn}
+%    \changes{v0.9b}{2024/10/27}{Make plug definition non-protected}
 %    
 %    Declaring a code for a socket is just making a definition, taking
 %    the number of arguments from the saved int.
@@ -850,7 +851,7 @@
           {
             \cs_generate_from_arg_count:cNnn
               { @@_#1_plug_#2:w }
-              \cs_new_protected:Npn
+              \cs_new:Npn
               { \int_use:c { c_@@_#1_args_int } }
               {#3}
 %    \end{macrocode}
@@ -878,7 +879,7 @@
           {
             \cs_generate_from_arg_count:cNnn
               { @@_#1_plug_#2:w }
-              \cs_set_protected:Npn
+              \cs_set:Npn
               { \int_use:c { c_@@_#1_args_int } }
               {#3}
             \@@_debug_term:n

--- a/base/ltsockets.dtx
+++ b/base/ltsockets.dtx
@@ -371,7 +371,7 @@
 %         number of inputs = 2
 %         available plugs = noop, plug-A, plug-B
 %         current plug = plug-B
-%         definition = \protected\long macro:#1#2->\begin {quote}\sffamily
+%         definition = \long macro:#1#2->\begin {quote}\sffamily
 %     foo-B: #2\textsuperscript {2}\end {quote}
 % \end{verbatim}
 % \LogSocket{foo}

--- a/base/ltsockets.dtx
+++ b/base/ltsockets.dtx
@@ -33,7 +33,7 @@
 %<*driver> 
 % \fi
 \ProvidesFile{ltsockets.dtx}
-             [2024/06/29 v0.9a LaTeX Kernel (Sockets)]
+             [2024/10/27 v0.9b LaTeX Kernel (Sockets)]
 % \iffalse
 %
 \documentclass{l3doc}
@@ -617,6 +617,22 @@
 % \end{function}
 %
 % 
+% \begin{function}[EXP]{\socket_use_expandable:nw,\socket_use_expandable:n}
+% \begin{syntax}
+% \cs{socket_use_expandable:n} \Arg{socket-name}
+% \end{syntax}
+%   Fully expandable variant of \cs{socket_use:n}. This can be used in macro code
+%   to retrieve code from sockets which need to appear in an expandable context.
+%
+%   This usually requires the plug to only contain expandable code and should therefore
+%   only be used for sockets which are clearly documented to be used in an expandable context.
+%   This command does not print any debugging info when \cs{DebugSocketsOn} is active
+%   and should therefore be avoided whenever possible.
+%
+%   For performance reasons there is no explicit check that the socket was declared!
+% \end{function}
+%
+%
 % \begin{function}{\ShowSocket,\LogSocket,\socket_show:n,\socket_log:n}
 % \begin{syntax}
 % \cs{ShowSocket}    \Arg{socket-name}
@@ -940,6 +956,17 @@
 %    the socket is declared with (for example, when checking is in
 %    force).
 %    \fmi{Implement?} 
+%  \end{macro}
+%
+%  \begin{macro}{\socket_use_expandable:nw,\socket_use_expandable:n}
+%    \changes{v0.9b}{2024/10/27}{Added \cs{socket_use_expandable:n}}
+%    The same as the non-expandable code, except for the missing debug output.
+%    \begin{macrocode}
+\cs_new:Npn \socket_use_expandable:nw #1 {
+  \use:c { @@_#1_plug_ \str_use:c { l_@@_#1_plug_str } :w }
+}
+\cs_new_eq:NN  \socket_use_expandable:n \socket_use_expandable:nw     % socket with no inputs
+%    \end{macrocode}
 %  \end{macro}
 %
 %

--- a/base/lttagging.dtx
+++ b/base/lttagging.dtx
@@ -104,9 +104,7 @@
 %  debugging strings\ldots
 %
 %
-% \DescribeMacro\UseExpandableTaggingSocket
 % \DescribeMacro\UseTaggingSocket
-% \DescribeMacro\tag_socket_use_expandable:n
 % \DescribeMacro\tag_socket_use:n
 % \DescribeMacro\tag_socket_use:nn
 % \DescribeMacro\tag_socket_use:nnn
@@ -141,6 +139,8 @@
 % if \cs{SuspendTagging} is in force. There may be reasons for doing
 % that but in general we expect to always use \cs{UseTaggingSocket}.
 %
+% \DescribeMacro\UseExpandableTaggingSocket
+% \DescribeMacro\tag_socket_use_expandable:n
 %  For special cases like in some \cs{halign} contexts we need a fully expandable
 %  version of the commend. For these cases, \cs{UseExpandableTaggingSocket} can be
 %  used. To allow being expandable, it does not output any debugging information
@@ -173,12 +173,12 @@
 %    \end{macrocode}
 %  \end{macro}
 %
-%  \begin{macro}{\tag_socket_use_expandable:n,
-%                \tag_socket_use:n,
+%  \begin{macro}{\tag_socket_use:n,
 %                \tag_socket_use:nn,
 %                \tag_socket_use:nnn,
-%                \UseExpandableTaggingSocket,
+%                \tag_socket_use_expandable:n,
 %                \UseTaggingSocket,
+%                \UseExpandableTaggingSocket,
 %               }
 %    Again this is not the final definition for the kernel; it is just
 %    a version to get going while some parts of the kernel support are

--- a/base/lttagging.dtx
+++ b/base/lttagging.dtx
@@ -104,7 +104,9 @@
 %  debugging strings\ldots
 %
 %
+% \DescribeMacro\UseExpandableTaggingSocket
 % \DescribeMacro\UseTaggingSocket
+% \DescribeMacro\tag_socket_use_expandable:n
 % \DescribeMacro\tag_socket_use:n
 % \DescribeMacro\tag_socket_use:nn
 % \DescribeMacro\tag_socket_use:nnn
@@ -141,8 +143,12 @@
 %  if e.g. \cs{SuspendTagging} is in force. There may be reasons for doing
 %  that but in general we expect to always use \cs{UseTaggingSocket}.
 %
-%  The L3 programming layer versions \cs{tag_socket_use:n}, and
-%  \cs{tag_socket_use:nn}, \cs{tag_socket_use:nnn}
+%  For special cases like in some \cs{halign} contexts we need a fully expandable
+%  version of the commend. For these cases, \cs{UseExpandableTaggingSocket} can be
+%  used.
+%
+%  The L3 programming layer versions \cs{tag_socket_use_expandable:n},
+%  \cs{tag_socket_use:n}, \cs{tag_socket_use:nn}, and \cs{tag_socket_use:nnn}
 %  are slightly more efficient than
 %  \cs{UseTaggingSocket} because they do not have to determine how
 %  many arguments the socket takes when disabling it.
@@ -168,9 +174,11 @@
 %    \end{macrocode}
 %  \end{macro}
 %
-%  \begin{macro}{\tag_socket_use:n,
+%  \begin{macro}{\tag_socket_use_expandable:n,
+%                \tag_socket_use:n,
 %                \tag_socket_use:nn,
 %                \tag_socket_use:nnn,
+%                \UseExpandableTaggingSocket,
 %                \UseTaggingSocket,
 %               }
 %    Again this is not the final definition for the kernel; it is just
@@ -190,7 +198,9 @@
 %    These definitions will get updated in \pkg{tagpdf}.
 %    The default in the kernel is just to get rid of the first argument, the second is preserved if present:
 % \changes{v1.0k}{2024/10/21}{Changed behavior of two argument tagging sockets when disabled.}
+% \changes{v1.0k}{2024/10/21}{Added expandable variants}
 %    \begin{macrocode}
+\cs_new:Npn \tag_socket_use_expandable:n #1 { }
 \cs_new_protected:Npn \tag_socket_use:n #1 { }
 \cs_new_protected:Npn \tag_socket_use:nn #1#2 { }
 \cs_new_protected:Npn \tag_socket_use:nnn #1#2#3 { #3 }
@@ -205,6 +215,19 @@
 %    We do not expect tagging sockets with more than one or two
 %    arguments, so for now we only provide those.
 %    \begin{macrocode}
+         }
+         \ERRORusetaggingsocket  % that should get a proper error message
+}
+%    \end{macrocode}
+%    The same as an expandable command:
+%    \begin{macrocode}
+\cs_new:Npn \UseExpandableTaggingSocket #1 {
+  \int_case:nnF
+      { \int_use:c { c__socket_tagsupport/#1_args_int } }
+         {
+           0 \prg_do_nothing:
+           1 \use_none:n
+           2 \use_ii:nn
          }
          \ERRORusetaggingsocket  % that should get a proper error message
 }

--- a/base/lttagging.dtx
+++ b/base/lttagging.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{lttagging.dtx}
-             [2024/10/11 v1.0j LaTeX Kernel (tagging support)]
+             [2024/10/21 v1.0k LaTeX Kernel (tagging support)]
 % \iffalse
 \documentclass{l3doc}
 \GetFileInfo{lttagging.dtx}
@@ -78,7 +78,7 @@
 %  \DescribeMacro\tag_suspend:n
 %  \DescribeMacro\tag_resume:n
 
-%  
+%
 %  The are places in code where it is import top stop any tagging
 %  activities, e.g., when we are doing trial typesetting that it is
 %  done several times. In such a case one must tag only the final
@@ -107,46 +107,46 @@
 % \DescribeMacro\UseTaggingSocket
 % \DescribeMacro\tag_socket_use:n
 % \DescribeMacro\tag_socket_use:nn
-%  To support tagging in packages we use sockets with names starting
-%  with \texttt{tagsupport/}. Usually, these sockets have exactly two
-%  plugs defined:
-%  \plug{noop} (when no tagging is requested or tagging is not wanted
-%  for some reason) and a second plug that enables the tagging. There
-%  may be more, e.g., tagging with special debugging, etc., but right
-%  now it is usually just on or off.
-%
-%  Given that we sometimes have to suspend tagging, it would be fairly
-%  inefficient to put different plugs into these sockets whenever that
-%  happens. We therefore offer \cs{UseTaggingSocket} which is like
-%  \cs{UseSocket} except that the socket name is specified without
-%  \texttt{tagsupport/}, i.e.,
+% \DescribeMacro\tag_socket_use:nnn
+% Given that we sometimes have to suspend tagging, it would be fairly
+% inefficient to put different plugs into these sockets whenever that
+% happens. We therefore offer \cs{UseTaggingSocket} which is like
+% \cs{UseSocket} except that is expects a socket starting with
+% \texttt{tagsupport/} but the socket name is specified without
+% this prefix, i.e.,
 % \begin{quote}
 %   \verb=\UseTaggingSocket{foo}=      $\to$
 %   \verb=\UseSocket{tagsupport/foo}=
-% \end{quote}
-%  Beside being slightly shorter, the big advantage is that this way
-%  we can change \cs{UseTaggingSocket} to do nothing when tagging is
-%  suspended with \cs{SuspendTagging} instead of changing the plugs of
-%  the tagging support sockets back and forth.
+% \end{quote}.
 %
-%  This means that with \cs{SuspendTagging} in force all socket
-%  arguments are ignored (including the case when there is a single
-%  one), i.e., all sockets used with \cs{UseTaggingSocket} behave as
-%  if the \text{noop} plug is assigned.
+%  Beside being slightly shorter, the big advantage is that this way
+%  we can change \cs{UseTaggingSocket} to do nothing by switching a boolean
+%  instead of changing the plugs of the tagging support sockets back and forth.
+%
+% Usually, these sockets have exactly two plugs defined.
+% When using \cs{UseTaggingSocket} the first plug is always
+% used if tagging is suspended.
+% For the sockets with zero and one argument
+% this is the \texttt{noop} plug, so they gobble the
+% argument in such a case. The assigned plug use when tagging is enable.
+% The socket with two arguments
+% will drop the first argument and pass the second unchanged if
+% tagging is not activated and when tagging is activated it
+% will process them as defined by the assigned plug.
+% There may be more plugs, e.g., tagging with special debugging, etc.,
+% but right now it is usually just on or off.
 %
 %  It is possible to use the tagging support sockets with
-%  \cs{UseSocket} instead of \cs{UseTaggingSocket}, but in this case
-%  the socket remains active if \cs{SuspendTagging} is in force. There
-%  may be reasons for doing that, but in general we expect to always
-%  use \cs{UseTaggingSocket}.
+%  \cs{UseSocket} directly, but in this case the socket remains active
+%  if e.g. \cs{SuspendTagging} is in force. There may be reasons for doing
+%  that but in general we expect to always use \cs{UseTaggingSocket}.
 %
-%  The L3 programming layer versions \cs{tag_socket_use:n} and
-%  \cs{tag_socket_use:nn} are slightly more efficient than
+%  The L3 programming layer versions \cs{tag_socket_use:n}, and
+%  \cs{tag_socket_use:nn}, \cs{tag_socket_use:nnn}
+%  are slightly more efficient than
 %  \cs{UseTaggingSocket} because they do not have to determine how
-%  many arguments the socket takes when disabling it, so in code that
-%  is using the L3 programming layer we recommend to use them instead
-%  of the CamelCase command.
-%                
+%  many arguments the socket takes when disabling it.
+%
 %
 % \MaybeStop{}
 %
@@ -156,12 +156,12 @@
 %
 %
 %  \begin{macro}{\tag_suspend:n,\tag_resume:n,\SuspendTagging,\ResumeTagging}
-%    
+%
 %    In the kernel, these commands get dummy definitions so that
 %    they can be used without harm in packages. The real definition is
 %    used when tagging gets enabled.
 %    \begin{macrocode}
-\cs_new_eq:NN \tag_suspend:n \use_none:n  
+\cs_new_eq:NN \tag_suspend:n \use_none:n
 \cs_new_eq:NN \tag_resume:n  \use_none:n
 \cs_new_protected:Npn \SuspendTagging #1 { \tag_suspend:n {#1} }
 \cs_new_protected:Npn \ResumeTagging #1  { \tag_resume:n {#1} }
@@ -170,6 +170,7 @@
 %
 %  \begin{macro}{\tag_socket_use:n,
 %                \tag_socket_use:nn,
+%                \tag_socket_use:nnn,
 %                \UseTaggingSocket,
 %               }
 %    Again this is not the final definition for the kernel; it is just
@@ -187,19 +188,19 @@
 %
 %    Dummy definitions in the kernel.
 %    These definitions will get updated in \pkg{tagpdf}.
+%    The default in the kernel is just to get rid of the first argument, the second is preserved if present:
+% \changes{v1.0k}{2024/10/21}{Changed behavior of two argument tagging sockets when disabled.}
 %    \begin{macrocode}
 \cs_new_protected:Npn \tag_socket_use:n #1 { }
 \cs_new_protected:Npn \tag_socket_use:nn #1#2 { }
-%    \end{macrocode}
-%    The default in the kernel is just to get rid of the argument:
-%    \begin{macrocode}
+\cs_new_protected:Npn \tag_socket_use:nnn #1#2#3 { #3 }
 \cs_new_protected:Npn \UseTaggingSocket #1 {
   \int_case:nnF
       { \int_use:c { c__socket_tagsupport/#1_args_int } }
          {
            0 \prg_do_nothing:
            1 \use_none:n
-           2 \use_none:nn
+           2 \use_ii:nn
 %    \end{macrocode}
 %    We do not expect tagging sockets with more than one or two
 %    arguments, so for now we only provide those.
@@ -213,10 +214,10 @@
 %
 % \subsection{Tagging sockets}
 % This collects tagging sockets that should be generally available
-% so that they can also be used even if the tagging code is not loaded. 
-% 
+% so that they can also be used even if the tagging code is not loaded.
+%
 % \subsubsection{Tagging support for paragraph setup}
-% 
+%
 % Paragraphs are tagged through the code in the para/hooks. This code is sometimes
 % adjusted, e.g. to produce a \enquote{flattened} paragraph or to use a different tag.
 % Sockets related to such code parts are collected here.
@@ -225,22 +226,22 @@
 %    The block code needs to know if they are nested blockenvs inside
 %    a flattened environment. For this it uses a counter. Inside some contexts,
 %    e.g. at the begin of a minipage or a footnote this counter must be reset.
-%    We therefore define the counter here so that we can use it in the following 
-%    socket. 
+%    We therefore define the counter here so that we can use it in the following
+%    socket.
 %    \begin{macrocode}
 \int_new:N \l__tag_block_flattened_level_int
 %    \end{macrocode}
 %  \end{macro}
-%  
+%
 % \begin{socketdecl}{tagsupport/para/restore}
 % This socket restores the para related settings to their default. It
 % should be used in places where ``normal'' paragraph tagging must be ensured, for example
-% at the begin of a footnote. 
+% at the begin of a footnote.
 %    \begin{macrocode}
 \NewSocket{tagsupport/para/restore}{0}
 %    \end{macrocode}
 % \end{socketdecl}
-% 
+%
 % \begin{plugdecl}{default}
 % \changes{v1.0i}{2024/10/10}{Restore also paratagging (tagging/723)}
 %    \begin{macrocode}
@@ -255,7 +256,7 @@
 \AssignSocketPlug{tagsupport/para/restore}{default}
 %    \end{macrocode}
 % \end{plugdecl}
-% 
+%
 % \begin{socketdecl}{tagsupport/para/begin,tagsupport/para/end}
 % These sockets are currently defined in tagpdf. They overwrite
 % definitions in the latex-lab-block code. There is also a simpler
@@ -273,22 +274,22 @@
 \NewSocket{tagsupport/recordtarget}{0}
 %    \end{macrocode}
 % \end{socketdecl}
-% 
+%
 % \begin{plugdecl}{kernel (tagsupport/recordtarget)}
 %    \begin{macrocode}
-% 
+%
 \NewSocketPlug{tagsupport/recordtarget}{kernel}
   {
     \tl_if_blank:VF \@currentHref
     {
-      \prop_gput:Nee 
-        \g__tag_struct_dest_num_prop 
+      \prop_gput:Nee
+        \g__tag_struct_dest_num_prop
         {\@currentHref}
-        {\tag_get:n{struct_num}}      
+        {\tag_get:n{struct_num}}
     }
   }
-\AssignSocketPlug{tagsupport/recordtarget}{kernel} 
-\ExplSyntaxOff 
+\AssignSocketPlug{tagsupport/recordtarget}{kernel}
+\ExplSyntaxOff
 %    \end{macrocode}
 % \end{plugdecl}
 % \subsubsection{Tagging sockets for toc}
@@ -307,28 +308,28 @@
 % \begin{socketdecl}{tagsupport/toc/starttoc/before,
 %                    tagsupport/toc/starttoc/after}
 % Tagging sockets for the begin and end of start of \cs{@starttoc}.
-% They take one argument, the extension.                   
+% They take one argument, the extension.
 %    \begin{macrocode}
 \NewSocket{tagsupport/toc/starttoc/before}{1}
 \NewSocket{tagsupport/toc/starttoc/after}{1}
 %    \end{macrocode}
 % \end{socketdecl}
-% 
+%
 % \begin{socketdecl}{tagsupport/toc/leaders/before,
 %                    tagsupport/toc/leaders/after}
 % Tagging sockets to make the dot leaders an artifact.
-% They do not take an argument.                    
+% They do not take an argument.
 %    \begin{macrocode}
 \NewSocket{tagsupport/toc/leaders/before}{0}
 \NewSocket{tagsupport/toc/leaders/after}{0}
 %    \end{macrocode}
 % \end{socketdecl}
-% 
+%
 % \subsubsection{Tagging support for table/tabular packages}
 %
 % The code uses a number of sockets to inject the tagging
 % commands. These can be easily set to a noop-plug in case the
-% automated tagging is not wanted. 
+% automated tagging is not wanted.
 %
 % \begin{socketdecl}{tagsupport/tbl/cell/begin,
 %                    tagsupport/tbl/cell/end,
@@ -463,10 +464,10 @@
 % \end{socketdecl}
 %
 % \subsubsection{Tagging Support for floats}
-% 
+%
 % \begin{socketdecl}{tagsupport/float/hmode/begin,
 %                    tagsupport/float/hmode/end}
-%  These sockets are used if the float is called in 
+%  These sockets are used if the float is called in
 %  hmode.
 % \changes{v1.0h}{2024/09/13}{Sockets for floats added}
 %    \begin{macrocode}
@@ -484,38 +485,38 @@
 %    \end{macrocode}
 % \end{socketdecl}
 %
-% 
+%
 % \begin{socketdecl}{tagsupport/caption/begin,
 %                    tagsupport/caption/end}
 %  These sockets are used in \cs{@makecaption}.
 %  They open and close the \texttt{Caption} structure.
-%  Their default plugs assume that they are used in 
+%  Their default plugs assume that they are used in
 %  vmode. The argument of the begin socket is
 %  the structure number of the parent float. If it is
-%  empty the current structure number is used. 
+%  empty the current structure number is used.
 %    \begin{macrocode}
 \NewSocket{tagsupport/caption/begin}{1}
 \NewSocket{tagsupport/caption/end}{0}
 %    \end{macrocode}
 % \end{socketdecl}
-% 
+%
 % \begin{socketdecl}{tagsupport/caption/label/begin,
 %                    tagsupport/caption/label/end}
 %  These sockets are used in \cs{@makecaption} around the
-%  label. Their default plugs ensure that 
-%  the label is outside the paragraph and that 
+%  label. Their default plugs ensure that
+%  the label is outside the paragraph and that
 %  the rest of the caption uses flattened para mode. If the
-%  caption is not in a hbox, the \texttt{para/begin} 
-%  socket should follow to properly start the paragraph. 
+%  caption is not in a hbox, the \texttt{para/begin}
+%  socket should follow to properly start the paragraph.
 %    \begin{macrocode}
 \NewSocket{tagsupport/caption/label/begin}{0}
-\NewSocket{tagsupport/caption/label/end}{0} 
+\NewSocket{tagsupport/caption/label/end}{0}
 %    \end{macrocode}
 % \end{socketdecl}
-% 
+%
 % \section{For lttab.dtx parked here for now}
 %
-%    
+%
 %    \begin{macrocode}
 %<@@=tbl>
 \ExplSyntaxOn
@@ -536,7 +537,7 @@
 %     \g_@@_row_int,
 %     \g_@@_span_tl,
 %     \g_@@_table_cols_tl}
-%    
+%
 %    \cs{g_@@_row_int} holds the current row number in the table. The
 %    value \texttt{0} means we haven't yet processed the table
 %    preamble (or in case of longtable are just in front of the next
@@ -606,14 +607,14 @@
 % \subsection{Tracing/debugging}
 %
 %  \begin{macro}{\DebugTablesOn,\DebugTablesOff}
-%    
+%
 %    \begin{macrocode}
 \def\DebugTablesOn{
   \cs_set_eq:NN \@@_trace:n \typeout
-}  
+}
 \def\DebugTablesOff{
   \cs_set_eq:NN \@@_trace:n \use_none:n
-}  
+}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
@@ -663,7 +664,7 @@
 %
 %
 %  \begin{macro}{\l_@@_tmpa_seq}
-%    
+%
 %    \begin{macrocode}
 \seq_new:N \l_@@_tmpa_seq
 %    \end{macrocode}
@@ -672,7 +673,7 @@
 %
 %
 %  \begin{macro}{\tbl_count_missing_cells:n}
-%    
+%
 %    We might have the situation that some table package has not
 %    implemented the \cs{tbl_count_table_cols:} in which case
 %    \cs{g_@@_table_cols_tl} would always be zero and we would get an
@@ -708,7 +709,7 @@
 %
 %
 %  \begin{macro}{\tbl_save_outer_table_cols:}
-%    
+%
 %    \begin{macrocode}
 \cs_new_protected:Npn \tbl_save_outer_table_cols: {
   \tl_set_eq:NN \l_@@_saved_table_cols_tl  \g_@@_table_cols_tl
@@ -718,7 +719,7 @@
 %
 %
 %  \begin{macro}{\tbl_init_cell_data_for_table:}
-%    
+%
 %    \begin{macrocode}
 \cs_new_protected:Npn \tbl_init_cell_data_for_table: {
   \tl_set:No \l_@@_saved_col_tl {\int_use:N \g_@@_col_int }
@@ -832,14 +833,14 @@
 %
 %
 %  \begin{macro}{\tbl_restore_outer_cell_data:}
-%    
+%
 %    \begin{macrocode}
 \cs_new_protected:Npn \tbl_restore_outer_cell_data: {
   \int_gset:Nn \g_@@_col_int { \l_@@_saved_col_tl }
   \int_gset:Nn \g_@@_row_int { \l_@@_saved_row_tl }
   \tl_gset_eq:NN \g_@@_span_tl \l_@@_saved_span_tl
   \tl_gset_eq:NN \g_@@_table_cols_tl   \l_@@_saved_table_cols_tl
-  \UseTaggingSocket{tbl/restore/celldata} 
+  \UseTaggingSocket{tbl/restore/celldata}
   \@@_trace:n { ==>~ restored~cell~data:~
                 \int_use:N \g_@@_row_int,
                 \int_use:N \g_@@_col_int,
@@ -901,7 +902,7 @@
 %    the macro \cs{tbl_count_missing_cells:n} is executed and
 %    then the row is finished with a final \cs{cr}.
 %    \begin{macrocode}
-\cs_new:Npn \tbl_crcr:n #1 {  
+\cs_new:Npn \tbl_crcr:n #1 {
     \int_compare:nNnT \g_@@_col_int > 0
         {
           \tbl_count_missing_cells:n {#1}
@@ -928,7 +929,7 @@
 % \changes{v1.0h}{2024/09/20}{moved \cs{@kernel@refstepcounter} into ltxref}
 %    This is needed for \pkg{longtable} because \cs{refstepcounter} is
 %    setting up a target when \pkg{hyperref} is loaded and we don't
-%    want that in \pkg{longtable}.%%    
+%    want that in \pkg{longtable}.%%
 %    Prevent longtable patching by hyperref until hyperref does so automatically:
 %    \begin{macrocode}
 \def\hyper@nopatch@longtable{}

--- a/base/lttagging.dtx
+++ b/base/lttagging.dtx
@@ -138,11 +138,16 @@
 %
 % It is possible to use the tagging support sockets with
 % \cs{UseSocket} directly, but in this case the socket remains active
-% if e.g. \cs{SuspendTagging} is in force. There may be reasons for doing
+% if \cs{SuspendTagging} is in force. There may be reasons for doing
 % that but in general we expect to always use \cs{UseTaggingSocket}.
 %
-%  The L3 programming layer versions \cs{tag_socket_use:n}, and
-%  \cs{tag_socket_use:nn}, \cs{tag_socket_use:nnn}
+%  For special cases like in some \cs{halign} contexts we need a fully expandable
+%  version of the commend. For these cases, \cs{UseExpandableTaggingSocket} can be
+%  used. To allow being expandable, it does not output any debugging information
+%  if \cs{DebugSocketsOn} is in effect and therefore should be avoided whenever possible.
+%
+%  The L3 programming layer versions \cs{tag_socket_use_expandable:n},
+%  \cs{tag_socket_use:n}, \cs{tag_socket_use:nn}, and \cs{tag_socket_use:nnn}
 %  are slightly more efficient than
 %  \cs{UseTaggingSocket} because they do not have to determine how
 %  many arguments the socket takes when disabling it.

--- a/base/lttagging.dtx
+++ b/base/lttagging.dtx
@@ -121,34 +121,28 @@
 %   \verb=\UseSocket{tagsupport/foo}=
 % \end{quote}.
 %
-%  Beside being slightly shorter, the big advantage is that this way
-%  we can change \cs{UseTaggingSocket} to do nothing by switching a boolean
-%  instead of changing the plugs of the tagging support sockets back and forth.
+% Beside being slightly shorter, the big advantage is that this way
+% we can change \cs{UseTaggingSocket} to do nothing by switching a boolean
+% instead of changing the plugs of the tagging support sockets back and forth.
 %
-% Usually, these sockets have exactly two plugs defined.
-% When using \cs{UseTaggingSocket} the first plug is always
-% used if tagging is suspended.
-% For the sockets with zero and one argument
-% this is the \texttt{noop} plug, so they gobble the
-% argument in such a case. The assigned plug use when tagging is enable.
-% The socket with two arguments
-% will drop the first argument and pass the second unchanged if
-% tagging is not activated and when tagging is activated it
-% will process them as defined by the assigned plug.
-% There may be more plugs, e.g., tagging with special debugging, etc.,
-% but right now it is usually just on or off.
+% Usually, these sockets have (beside the default plug defined for every socket)
+% one additional plug defined and directly assigned. This plug is used when
+% tagging is active.
+% There may be more plugs, e.g., tagging with special debugging or special behaviour
+% depending on the class or PDF version etc., but right now it is usually just on or off.
 %
-%  It is possible to use the tagging support sockets with
-%  \cs{UseSocket} directly, but in this case the socket remains active
-%  if e.g. \cs{SuspendTagging} is in force. There may be reasons for doing
-%  that but in general we expect to always use \cs{UseTaggingSocket}.
+% When tagging is suspended they all have the same predefined behaviour:
+% The sockets with zero arguments do nothing. The sockets with one argument
+% gobble their argument. The sockets with two arguments
+% will drop their first argument and pass the second unchanged.
 %
-%  For special cases like in some \cs{halign} contexts we need a fully expandable
-%  version of the commend. For these cases, \cs{UseExpandableTaggingSocket} can be
-%  used.
+% It is possible to use the tagging support sockets with
+% \cs{UseSocket} directly, but in this case the socket remains active
+% if e.g. \cs{SuspendTagging} is in force. There may be reasons for doing
+% that but in general we expect to always use \cs{UseTaggingSocket}.
 %
-%  The L3 programming layer versions \cs{tag_socket_use_expandable:n},
-%  \cs{tag_socket_use:n}, \cs{tag_socket_use:nn}, and \cs{tag_socket_use:nnn}
+%  The L3 programming layer versions \cs{tag_socket_use:n}, and
+%  \cs{tag_socket_use:nn}, \cs{tag_socket_use:nnn}
 %  are slightly more efficient than
 %  \cs{UseTaggingSocket} because they do not have to determine how
 %  many arguments the socket takes when disabling it.

--- a/base/testfiles/sockets-000.tlg
+++ b/base/testfiles/sockets-000.tlg
@@ -4,7 +4,7 @@ Socket foo0:
     number of inputs = 0
     available plugs = noop
     current plug = noop
-    definition = \protected\long macro:->
+    definition = \long macro:->
 ! .
 \ShowSocket #1->\socket_log:n {#1}\errmessage {}
 l. ...\ShowSocket {foo0}
@@ -16,7 +16,7 @@ Socket foo1:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 ! .
 \ShowSocket #1->\socket_log:n {#1}\errmessage {}
 l. ...\ShowSocket {foo1}
@@ -25,7 +25,7 @@ Socket foo2:
     number of inputs = 2
     available plugs = noop
     current plug = noop
-    definition = \protected\long macro:#1#2->
+    definition = \long macro:#1#2->
 ! .
 \ShowSocket #1->\socket_log:n {#1}\errmessage {}
 l. ...\ShowSocket {foo2}
@@ -34,7 +34,7 @@ Socket foo3:
     number of inputs = 3
     available plugs = noop
     current plug = noop
-    definition = \protected\long macro:#1#2#3->
+    definition = \long macro:#1#2#3->
 ! .
 \ShowSocket #1->\socket_log:n {#1}\errmessage {}
 l. ...\ShowSocket {foo3}
@@ -47,22 +47,22 @@ Socket bar0:
     number of inputs = 0
     available plugs = noop
     current plug = noop
-    definition = \protected\long macro:->
+    definition = \long macro:->
 Socket bar1:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket bar2:
     number of inputs = 2
     available plugs = noop
     current plug = noop
-    definition = \protected\long macro:#1#2->
+    definition = \long macro:#1#2->
 Socket bar3:
     number of inputs = 3
     available plugs = noop
     current plug = noop
-    definition = \protected\long macro:#1#2#3->
+    definition = \long macro:#1#2#3->
 AAA
 99=99?
 99=88?

--- a/base/testfiles/sockets-001.luatex.tlg
+++ b/base/testfiles/sockets-001.luatex.tlg
@@ -29,7 +29,7 @@ Socket foo:
     number of inputs = 0
     available plugs = noop, default
     current plug = noop
-    definition = \protected\long macro:->\typeout {modified noop}
+    definition = \long macro:->\typeout {modified noop}
 ! .
 \ShowSocket #1->\socket_log:n {#1}\errmessage {}
 l. ...\ShowSocket {foo}

--- a/base/testfiles/sockets-001.tlg
+++ b/base/testfiles/sockets-001.tlg
@@ -29,7 +29,7 @@ Socket foo:
     number of inputs = 0
     available plugs = noop, default
     current plug = noop
-    definition = \protected\long macro:->\typeout {modified noop}
+    definition = \long macro:->\typeout {modified noop}
 ! .
 \ShowSocket #1->\socket_log:n {#1}\errmessage {}
 l. ...\ShowSocket {foo}

--- a/base/testfiles/sockets-002.luatex.tlg
+++ b/base/testfiles/sockets-002.luatex.tlg
@@ -34,7 +34,7 @@ Socket foo:
     number of inputs = 0
     available plugs = noop, default
     current plug = noop
-    definition = \protected\long macro:->\typeout {modified noop}
+    definition = \long macro:->\typeout {modified noop}
 ! .
 \ShowSocket #1->\socket_log:n {#1}\errmessage {}
 l. ...\ShowSocket {foo}

--- a/base/testfiles/sockets-002.tlg
+++ b/base/testfiles/sockets-002.tlg
@@ -34,7 +34,7 @@ Socket foo:
     number of inputs = 0
     available plugs = noop, default
     current plug = noop
-    definition = \protected\long macro:->\typeout {modified noop}
+    definition = \long macro:->\typeout {modified noop}
 ! .
 \ShowSocket #1->\socket_log:n {#1}\errmessage {}
 l. ...\ShowSocket {foo}

--- a/required/latex-lab/testfiles-OR-luatex/footmisc-014-hang.tlg
+++ b/required/latex-lab/testfiles-OR-luatex/footmisc-014-hang.tlg
@@ -18,57 +18,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/check-declarations.tlg
+++ b/required/latex-lab/testfiles-OR/check-declarations.tlg
@@ -18,57 +18,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footmisc-002.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-002.tlg
@@ -18,57 +18,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footmisc-003.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-003.tlg
@@ -18,57 +18,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footmisc-004.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-004.tlg
@@ -18,57 +18,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footmisc-005.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-005.tlg
@@ -18,57 +18,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = para
-    definition = \protected\long macro:#1->\setbox \FN@tempboxa \hbox {\@makefntext {#1}}\dp \FN@tempboxa \z@ \ht \FN@tempboxa \dimexpr \wd \FN@tempboxa *\footnotebaselineskip /\columnwidth \relax \box \FN@tempboxa 
+    definition = \long macro:#1->\setbox \FN@tempboxa \hbox {\@makefntext {#1}}\dp \FN@tempboxa \z@ \ht \FN@tempboxa \dimexpr \wd \FN@tempboxa *\footnotebaselineskip /\columnwidth \relax \box \FN@tempboxa 
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = noop
-    definition = \protected\long macro:->
+    definition = \long macro:->
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = para
-    definition = \protected\long macro:->\strut \penalty -10\relax \hskip \footglue 
+    definition = \long macro:->\strut \penalty -10\relax \hskip \footglue 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footmisc-006.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-006.tlg
@@ -18,57 +18,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = para
-    definition = \protected\long macro:#1->\setbox \FN@tempboxa \hbox {\@makefntext {#1}}\dp \FN@tempboxa \z@ \ht \FN@tempboxa \dimexpr \wd \FN@tempboxa *\footnotebaselineskip /\columnwidth \relax \box \FN@tempboxa 
+    definition = \long macro:#1->\setbox \FN@tempboxa \hbox {\@makefntext {#1}}\dp \FN@tempboxa \z@ \ht \FN@tempboxa \dimexpr \wd \FN@tempboxa *\footnotebaselineskip /\columnwidth \relax \box \FN@tempboxa 
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = noop
-    definition = \protected\long macro:->
+    definition = \long macro:->
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = para
-    definition = \protected\long macro:->\strut \penalty -10\relax \hskip \footglue 
+    definition = \long macro:->\strut \penalty -10\relax \hskip \footglue 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footmisc-007-rollback.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-007-rollback.tlg
@@ -39,57 +39,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footmisc-009-multiple-tagging.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-009-multiple-tagging.tlg
@@ -36,57 +36,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footmisc-009-multiple.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-009-multiple.tlg
@@ -36,57 +36,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footmisc-010-setspace-tagging.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-010-setspace-tagging.tlg
@@ -31,57 +31,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footmisc-010-setspace.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-010-setspace.tlg
@@ -31,57 +31,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footmisc-011-para.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-011-para.tlg
@@ -18,57 +18,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = para
-    definition = \protected\long macro:#1->\setbox \FN@tempboxa \hbox {\@makefntext {#1}}\dp \FN@tempboxa \z@ \ht \FN@tempboxa \dimexpr \wd \FN@tempboxa *\footnotebaselineskip /\columnwidth \relax \box \FN@tempboxa 
+    definition = \long macro:#1->\setbox \FN@tempboxa \hbox {\@makefntext {#1}}\dp \FN@tempboxa \z@ \ht \FN@tempboxa \dimexpr \wd \FN@tempboxa *\footnotebaselineskip /\columnwidth \relax \box \FN@tempboxa 
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = noop
-    definition = \protected\long macro:->
+    definition = \long macro:->
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = para
-    definition = \protected\long macro:->\strut \penalty -10\relax \hskip \footglue 
+    definition = \long macro:->\strut \penalty -10\relax \hskip \footglue 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footmisc-012-side-hyperref.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-012-side-hyperref.tlg
@@ -18,57 +18,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = side
-    definition = \protected\long macro:#1->\marginpar {#1}
+    definition = \long macro:#1->\marginpar {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = noop
-    definition = \protected\long macro:->
+    definition = \long macro:->
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = noop
-    definition = \protected\long macro:->
+    definition = \long macro:->
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footmisc-012-side.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-012-side.tlg
@@ -18,57 +18,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = side
-    definition = \protected\long macro:#1->\marginpar {#1}
+    definition = \long macro:#1->\marginpar {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = noop
-    definition = \protected\long macro:->
+    definition = \long macro:->
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = noop
-    definition = \protected\long macro:->
+    definition = \long macro:->
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footmisc-013-scrartcl.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-013-scrartcl.tlg
@@ -25,57 +25,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footmisc-014-hang.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-014-hang.tlg
@@ -18,57 +18,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footmisc-floats-abovefloats-flushbottom.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-floats-abovefloats-flushbottom.tlg
@@ -18,57 +18,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footmisc-floats-abovefloats.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-floats-abovefloats.tlg
@@ -18,57 +18,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footmisc-floats-belowfloats-flushbottom.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-floats-belowfloats-flushbottom.tlg
@@ -18,57 +18,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footmisc-floats-latex.tlg
+++ b/required/latex-lab/testfiles-OR/footmisc-floats-latex.tlg
@@ -20,57 +20,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footnote-float-above.tlg
+++ b/required/latex-lab/testfiles-OR/footnote-float-above.tlg
@@ -18,57 +18,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footnote-hyperref-001.tlg
+++ b/required/latex-lab/testfiles-OR/footnote-hyperref-001.tlg
@@ -18,57 +18,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/footnote-par.tlg
+++ b/required/latex-lab/testfiles-OR/footnote-par.tlg
@@ -18,57 +18,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles-OR/tagging-001.tlg
+++ b/required/latex-lab/testfiles-OR/tagging-001.tlg
@@ -18,57 +18,57 @@ Socket fntext/process:
     number of inputs = 1
     available plugs = noop, identity, default, side, mp
     current plug = default
-    definition = \protected\long macro:#1->\insert \footins {#1}
+    definition = \long macro:#1->\insert \footins {#1}
 Socket fntext/make:
     number of inputs = 1
     available plugs = noop, identity, default, para
     current plug = default
-    definition = \protected\long macro:#1->\@makefntext {#1}
+    definition = \long macro:#1->\@makefntext {#1}
 Socket fntext/begin:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\rule \z@ \footnotesep 
+    definition = \long macro:->\rule \z@ \footnotesep 
 Socket fntext/end:
     number of inputs = 0
     available plugs = noop, default, para
     current plug = default
-    definition = \protected\long macro:->\@finalstrut \strutbox 
+    definition = \long macro:->\@finalstrut \strutbox 
 Socket fntext/mark:
     number of inputs = 0
     available plugs = noop, default
     current plug = default
-    definition = \protected\long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
+    definition = \long macro:->\ifdim \footnotemargin >\z@ \hb@xt@ \footnotemargin {\hss \@makefnmark }\else \ifdim \footnotemargin =\z@ \llap {\@makefnmark }\else \ifdim \footnotemargin =-\maxdimen \@makefnmark \else \llap {\hb@xt@ -\footnotemargin {\@makefnmark \hss }}\fi \fi \fi 
 Socket fntext/text:
     number of inputs = 1
     available plugs = noop, identity
     current plug = identity
-    definition = \protected\long macro:#1->#1
+    definition = \long macro:#1->#1
 Socket tagsupport/fnmark:
     number of inputs = 1
     available plugs = noop, identity, FEMark
     current plug = FEMark
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_struct_begin:n {tag=footnotemark}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gput:oo {\@thefnmark }{\l_fnote_type_tl }\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\tag_get:n {struct_num}}}{\hook_gput_code:nne {tagpdf/finish/before}{tagpdf/footnote}{\exp_not:N \fnote_gput_refs:ee {\tag_get:n {struct_num}}{\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tl_set:Ne \l__fnote_linktarget_tl {footnote*.\property_ref:ee {__fnote/\l__fnote_currentlabel_tl }{fnote/struct}}}\tag_mc_begin:n {tag=Lbl}\bool_if:NTF \l_fnote_link_bool {\exp_args:No \hyper@linkstart {\l_fnote_link_type_tl }{\l__fnote_linktarget_tl }#1\hyper@linkend }{#1}\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/begin:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
+    definition = \long macro:->\tag_mc_end_push: \tag_check_child:nnTF {FENote}{pdf2}{\tag_struct_begin:n {tag=footnote}}{\tag_struct_begin:n {tag=footnote,parent=\int_max:nn {2}{\tag_get:n {current_Sect}+0}}}\tl_set:Ne \l__fnote_currentstruct_tl {\tag_get:n {struct_num}}\bool_if:NTF \l__fnote_autodetect_bool {\fnote_mark_gpop_all:ooN {\@thefnmark }{\l_fnote_type_tl }\l__fnote_currentrefs_seq \seq_map_inline:Nn \l__fnote_currentrefs_seq {\fnote_gput_refs:ee {##1}{\l__fnote_currentstruct_tl }}}{}
 Socket tagsupport/fntext/end:
     number of inputs = 0
     available plugs = noop, FENote
     current plug = FENote
-    definition = \protected\long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:->\tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/mark:
     number of inputs = 1
     available plugs = noop, identity, FENoteLbl
     current plug = FENoteLbl
-    definition = \protected\long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \seq_map_inline:Nn \l__fnote_currentrefs_seq {\MakeLinkTarget *{footnote*.##1}}\MakeLinkTarget *{footnote*.\l__fnote_currentstruct_tl }\tag_struct_begin:n {tag=footnotelabel,parent=\l__fnote_currentstruct_tl ,firstkid}\tag_mc_begin:n {tag=Lbl}#1\tag_mc_end: \tag_struct_end: \tag_mc_begin_pop:n {}
 Socket tagsupport/fntext/text:
     number of inputs = 1
     available plugs = noop, identity, FENotetext
     current plug = FENotetext
-    definition = \protected\long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
+    definition = \long macro:#1->\tag_mc_end_push: \tag_mc_begin:n {}#1\tag_mc_end: \tag_mc_begin_pop:n {}
 -> The hook 'fntext/before':
 > The hook is empty.
 -> The hook 'fntext':

--- a/required/latex-lab/testfiles/new-or-001.tlg
+++ b/required/latex-lab/testfiles/new-or-001.tlg
@@ -9,7 +9,7 @@ Socket @makecol/outputbox:
     number of inputs = 0
     available plugs = noop, space-footnotes-floats, floats-footnotes-space, footnotes-space-floats, space-floats-footnotes, floats-footnotes, footnotes-floats
     current plug = footnotes-floats
-    definition = \protected\long macro:->\@outputbox@appendfootnotes \@outputbox@attachfloats \@outputbox@reinsertbskip 
+    definition = \long macro:->\@outputbox@appendfootnotes \@outputbox@attachfloats \@outputbox@reinsertbskip 
 ! .
 \ShowSocket #1->\socket_log:n {#1}\errmessage {}
 l. ...\ShowSocket {@makecol/outputbox}
@@ -21,7 +21,7 @@ Socket @makecol/footnotes:
     number of inputs = 0
     available plugs = noop
     current plug = noop
-    definition = \protected\long macro:->
+    definition = \long macro:->
 ! .
 \ShowSocket #1->\socket_log:n {#1}\errmessage {}
 l. ...\ShowSocket {@makecol/footnotes}


### PR DESCRIPTION
First part synchronized with 7a2b09d51edb7ee5619c45e33e126e48f1d3b406 in tagpdf.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- n/a Rollback provided (if necessary)?
- [x] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
