### PR TITLE
guard for #1495

### DIFF
--- a/base/doc/ltnews40.tex
+++ b/base/doc/ltnews40.tex
@@ -535,6 +535,11 @@ unnumbered variant of longtable:
   {\endlongtable}
 \end{verbatim}
 
+\subsection{\pkg{longtable}: Prevent \cs{pagegoal} exceeding maximum value}
+An internal guard has been added to avoid \TeX\ errors if \verb=\pagegoal= is increased
+beyond the maximum value for a \TeX\ dimension.
+%
+\githubissue{1495}
 
 \subsection{\pkg{array}: Improve \texttt{>\{...\}} specifier}
 

--- a/required/tools/changes.txt
+++ b/required/tools/changes.txt
@@ -5,6 +5,11 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 =======================================================================
 
+2024-10-27  David Carlisle  <David.Carlisle@latex-project.org>
+
+	* longtable.dtx Guard against increasing \pagegoal past \maxdimen (gh/1495)
+
+
 2024-10-12  Joseph Wright  <Joseph.Wright@latex-project.org>
 
 	* array.dtx (section{The insertion of declarations ...}):

--- a/required/tools/longtable.dtx
+++ b/required/tools/longtable.dtx
@@ -38,7 +38,7 @@
 %<driver> \ProvidesFile{longtable.drv}
 % \fi
 %         \ProvidesFile{longtable.dtx}
-          [2024-07-06 v4.21 Multi-page Table package (DPC)]
+          [2024-10-27 v4.22 Multi-page Table package (DPC)]
 %
 % \iffalse
 %<*driver>
@@ -1639,15 +1639,20 @@
     \LT@final@warn
   \fi
 %    \end{macrocode}
-% Force one more go with the \env{longtable} output routine.
+%   Force one more go with the \env{longtable} output routine.
+% Guard the special start of page value of "\pagegoal".
 % \changes{v4.14}{2020/02/07}
 %      {Rearrange vertical space tests for tools/3512 (floats on same page)}
+% \changes{v4.22}{2024/10/27}
+%    {Keep \cs{pagegoal} below \cs{maxdimen} gh1495}
 %    \begin{macrocode}
   \endgraf\penalty -\LT@end@pen
   \ifvoid\LT@foot\else
     \global\advance\vsize\ht\LT@foot
     \global\advance\@colroom\ht\LT@foot
-    \dimen@\pagegoal\advance\dimen@\ht\LT@foot\pagegoal\dimen@
+    \ifdim\pagegoal<\maxdimen
+      \dimen@\pagegoal\advance\dimen@\ht\LT@foot\pagegoal\dimen@
+    \fi
   \fi
 %    \end{macrocode}
 % Now close the group to return to the standard routine.


### PR DESCRIPTION

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [X] Version and date string updated in changed source files
- [X] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated

The issue  #1495 did not provide a test file, and I failed to generate one,  however the existing code could clearly, if called at a bad time, hit TeX's ` `\maxdimen` marker for `\pagegoal` at the start of a page and lead to a dimension too large error,

It's possible this is a symptom of a logical flaw in the code, but this code has been widely publicised as a patch since around 2002 before being incorporated into the main release, so I do not want to do major changes without any test files.

This change restricts to adding  a single guard to prevent `\pagegoal` being increased when it has the top of page value, so will have no effect except in cases that currently error. As such no rollback or test cases are added.


