### PR TITLE
Ltnews40 intro, corrections and some reordering

### DIFF
--- a/base/doc/ltnews40.tex
+++ b/base/doc/ltnews40.tex
@@ -185,7 +185,7 @@ compatibility; however, over time it became apparent that keeping all
 developments confined to packages got more and more problematical.
 Features or bug fixes that should have been generally available, i.e.,
 being part of the kernel, were only available in packages, so a lot of
-dependencies between packages where introduced and resulted in
+dependencies between packages were introduced and resulted in
 convoluted code that was difficult to manage. For example,
 \pkg{hyperref} had to rewrite a lot of kernel (and package) macros, so
 the code and behavior of other packages had to change depending on
@@ -200,7 +200,7 @@ to successfully rerun a document produced at that time.
 
 As a consequence of this policy change the last decade saw a larger
 number of enhancements and corrections that were made part of the
-\LaTeX{} kernel. Overall, we can confidentially say that new
+\LaTeX{} kernel. Overall, we can confidentially say that the new
 approach worked well and enabled us to modernize \LaTeX{} and ensure
 that it remains relevant without compromising one of the cornerstones
 of \LaTeX{}: its outstanding ability to reprocess old documents
@@ -540,7 +540,7 @@ errors.  This has now been corrected.
 If the global (class) options contained spaces around key names,
 \cs{ProcessKeyOptions} would fail to remove known keys from the list
 of unused global options and \cs{OptionNotUsed} would mistakenly add
-space-surrounded key names to that list.  These has been corrected as
+space-surrounded key names to that list.  This has been corrected as
 a hotfix in patch level 1 of the November 2023 release (but
 unfortunately not mentioned in~\cite{40:ltnews38}) and the current
 release, respectively.

--- a/base/doc/ltnews40.tex
+++ b/base/doc/ltnews40.tex
@@ -486,8 +486,8 @@ have now been incorporated into the kernel.  Thus from now on every
 
 \subsection{Extending \cs{refstepcounter}}
 
-For many years, the package \pkg{hyperref} has redefined
-\verb+\refstepcounter+ and adds code that creates link targets. The
+For many years, the package \pkg{hyperref} had been redefining
+\verb+\refstepcounter+ and adding code that creates link targets.  The
 kernel definition has now been extended with socket interfaces that
 will allow \pkg{hyperref} to avoid the redefinitions. The new
 interfaces are also used by the Tagged PDF code that needs target
@@ -720,7 +720,7 @@ Leslie Lamport.
   \url{https://latex-project.org/news/latex2e-news/ltnews.pdf}
 
 \bibitem{40:ltnews22} \LaTeX{} Project Team.
-  \emph{\LaTeXe{} news 22}. Januar 2015.
+  \emph{\LaTeXe{} news 22}. January 2015.
   \url{https://latex-project.org/news/latex2e-news/ltnews22.pdf}
 
 \bibitem{40:ltnews28} \LaTeX{} Project Team.

--- a/base/doc/ltnews40.tex
+++ b/base/doc/ltnews40.tex
@@ -156,78 +156,88 @@
 
 \medskip
 
+
 \section{Thirty years of \LaTeXe{}}
 
 Summer 1994, i.e., thirty years ago, \LaTeXe{} saw its first public
 release. Back then it was meant to be a intermediate version (hence
 the $\epsilon$) on the way to a major new version (the mythical
 \LaTeX3) that we expected to take a couple of more years to reach
-maturity. It took more than that in the end and \LaTeXe{} is still
-with us today.
+maturity. It took more much than that in the end\Dash nominally,
+\LaTeXe{} is still with us today.
 
 However, under the hood, \LaTeXe{} changed a lot throughout these
 thirty years as one can see, for example, when looking through the
-fourty newletters that accompanied the \LaTeX{} releases that happened
-in the meantime~\cite{40:ltnews}.
+forty newsletters~\cite{40:ltnews} that accompanied the \LaTeX{}
+releases that happened in the meantime.
 
-During the first two decades, the \LaTeX{} kernel was kept stable with
-only minimal bug fix activities. During that period additional
-functionalities were mostly provided through new or extended packages
-that could be loaded in the document preamble. This included many of
-the ideas targeted for \LaTeX3{}, e.g., \pkg{expl3} (\LaTeX3
-progamming language), \pkg{xparse} (new document command interface),
-\pkg{xtemplate} (a configuration mechanism) and many others.
+During the first two decades, the \LaTeX{} kernel was kept largely
+stable with only minimal bug fix activities. During that period
+additional functionality was mostly provided through new or
+extended packages that could be loaded in the document preamble. This
+included many of the ideas targeted for \LaTeX3{}, e.g., \pkg{expl3}
+(\LaTeX3 programming language), \pkg{xparse} (new document command
+interface), \pkg{xtemplate} (a configuration mechanism), and many
+others.
 
+Initially, this approach worked well and provided good backward
+compatibility; however, over time it became apparent that keeping all
+developments confined to packages got more and more problematical.
+Features or bug fixes that should have been generally available, i.e.,
+being part of the kernel, were only available in packages, so a lot of
+dependencies between packages where introduced and resulted in
+convoluted code that was difficult to manage. For example,
+\pkg{hyperref} had to rewrite a lot of kernel (and package) macros, so
+the code and behavior of other packages had to change depending on
+whether or not \pkg{hyperref} was loaded or not.
 
+Thus, in 2015 the \LaTeX{} team decided to change the policy and
+(re)start active kernel development, see~\cite{40:ltnews22}. To ensure
+continuous backward compatibility we introduced at the same time the
+\pkg{latexrelease} package that enables users to roll back changes to
+the \LaTeX{} kernel to an earlier release, in case this is necessary
+to successfully rerun a document produced at that time.
+
+As a consequence of this policy change the last decade saw a larger
+number of enhancements and corrections that were made part of the
+\LaTeX{} kernel. Overall, we can confidentially say that new
+approach worked well and enabled us to modernize \LaTeX{} and ensure
+that it remains relevant without compromising one of the cornerstones
+of \LaTeX{}: its outstanding ability to reprocess old documents
+written many years ago.
+
+Being able to update and modernize the kernel sources allowed us to
+embark in 2019 on the multi-year \enquote{\LaTeX{} Tagged PDF} project
+with the goal of automatically providing accessible PDF documents with
+\LaTeX{}. While there are several more project phases to complete, the
+milestones already reached allow users to generate PDF/UA compliant
+documents if the input is restricted to a (growing) subset of packages
+and document classes; see next section and previous newsletters.
+
+ A big change happened on 2020-02-02 as part of the project activity,
+ albeit somewhat obfuscated by us as \enquote{Improved load-times for
+   \pkg{expl3}}. While technically correct, what it really meant is
+ that we had finally integrated the programming layer of \LaTeX3,
+ i.e., the ideas originally sketched out around 1992.  Or saying it
+ differently: with that date the original ideas for \LaTeX3 became a
+ reality as part of the standard \LaTeX{} kernel.
+
+ With the programming layer available under the hood we were then able to
+ provide new concepts and extensions as part of \LaTeX{},
+ e.g., the hook management system, a new mark mechanism, core
+ functionality for tagging and PDF resource management, a consistent
+ key/value interface, and more recently the socket and plug mechanism.
+
+ More will follow while we continue to work on modernizing \LaTeX{} and
+ bringing the Tagged PDF project to a truly successful completion\Dash so
+ stay tuned and watch this space for future announcements in the next
+ newsletters.
+
+ 
 
 \section{News from the \enquote{\LaTeX{} Tagged PDF} project}
 
-\subsection{Improved table tagging}
-
-The tagging of tabulars has been extended: it is now possible to tag
-row headers and to create cells that span more than one row.
-
-The interface to this functionality is not finalised but can be
-accessed in the current release by specifying the row and columns to
-be treated as headers.
-
-\begin{verbatim}
-\tagpdfsetup{
- table/header-rows={1,2},
- table/header-columns={1} }
-\end{verbatim}
-Would specify that in the following tables the first two rows and
-first column of each row should be tagged as heading entries.
-
-Similarly you may add a RowSpan attributes to tag a cell that spans
-two rows using:
-\begin{verbatim}
-\tagpdfsetup{table/multirow={2}}
-\end{verbatim}
-
-
-\subsection{Automatic MathML tagging}
-
-When lua\LaTeX{} is being used and the \pkg{luamml} package is
-available and if the document uses the \pkg{unicode-math} package,
-then the math module will automatically convert each math formula to
-MathML and use it to attach MathML associated files (or MathML
-Structure elements) to the tagged PDF. This new feature can be disabled
-with \verb+\tagpdfsetup{math/mathml/luamml=false}+ More details can be
-found in the documentation of \pkg{latex-lab-math}.
-
-\subsection{Tagging support for external packages}
-
-At \url{https://latex3.github.io/tagging-project/tagging-status/} we
-show the status of many \LaTeX{} Packages and Classes with respect to
-PDF tagging.  We also started to improve tagging support in external
-packages. If the \texttt{firstaid} key is used in addition to the
-\texttt{phase-III} key basic commands of packages including
-\pkg{amsthm} and \pkg{fancyvrb} can now be used.
-
-
-
-\section{Engine support: important update}
+\subsection{Engine support: An important update}
 
 As detailed below, work is progressing on the Tagged PDF
 project. There are many drivers for this work, including legal changes
@@ -259,30 +269,75 @@ be supported will remain to be seen. If relevant information becomes
 available to us we will provide an update in future editions of the
 \LaTeX{} newsletter.
 
-\section{Switch to T1 as default encoding in documents using \cs{DocumentMetadata}}
 
-As it is well known the font encoding \texttt{OT1} supports only 128
-characters and has various problems and quirks notably for languages
-different to English.  Nevertheless \texttt{OT1} is the default
-encoding in \LaTeX{} and this can not be easily changed without
-affecting many documents as the \texttt{T1} version of the fonts have
-slightly different metrics.
+\subsection{Tagging support for external packages}
 
-The introduction of the \cs{DocumentMetadata} command, which announces
-\emph{new} code and changes that can also affect the layout gives us
-now the opportunity to make this step. So with this version a use of
-\cs{DocumentMetadata} with (pdf)\LaTeX{} will setup \texttt{T1} as
-default font encoding\footnote{The Unicode engines will continue to
-use \texttt{TU} as encoding.}. To ensure that scalable fonts are used,
-the package \pkg{cm-super} has to be installed. Users who want to
-revert to the \texttt{OT1} encoding in their document can do so with
-\verb+\usepackage[OT1]{fontenc}+.
+At \url{https://latex3.github.io/tagging-project/tagging-status/} we
+show the status of many \LaTeX{} Packages and Classes with respect to
+PDF tagging.  We also started to improve tagging support in external
+packages. If the \texttt{firstaid} key is used in addition to the
+\texttt{phase-III} key basic commands of packages including
+\pkg{amsthm} and \pkg{fancyvrb} can now be used.
 
 
+\subsection{Improved table tagging}
+
+The tagging of tabulars has been extended: it is now possible to tag
+row headers and to create cells that span more than one row.
+
+The interface to this functionality is not finalized but can be
+accessed in the current release by specifying the row and columns to
+be treated as headers.
+
+\begin{verbatim}
+\tagpdfsetup{
+ table/header-rows={1,2},
+ table/header-columns={1} }
+\end{verbatim}
+Would specify that in the following tables the first two rows and
+first column of each row should be tagged as heading entries.
+
+Similarly you may add a RowSpan attributes to tag a cell that spans
+two rows using:
+\begin{verbatim}
+\tagpdfsetup{table/multirow={2}}
+\end{verbatim}
+
+
+\subsection{Automatic MathML tagging}
+
+When lua\LaTeX{} is being used and the \pkg{luamml} package is
+available and if the document uses the \pkg{unicode-math} package,
+then the math module will automatically convert each math formula to
+MathML and use it to attach MathML associated files (or MathML
+Structure elements) to the tagged PDF. This new feature can be disabled
+with \verb+\tagpdfsetup{math/mathml/luamml=false}+ More details can be
+found in the documentation of \pkg{latex-lab-math}.
+
+
+\subsection{Change behavior of tagging sockets with two arguments}
+
+When calling tagging sockets with two arguments using
+\cs{UseTaggingSocket} when tagging is suspended previous versions of
+\LaTeXe{} dropped both arguments.  This behavior has been changed to
+drop the first argument and preserve the second one instead, thereby
+allowing tagging sockets to be used to wrap existing content which
+should still appear in a non-tagging context.
+
+Since no tagging sockets currently provided by \LaTeXe{} use two
+arguments we do not expect this change to affect any existing
+documents, but if a custom tagging socket has been defined outside of
+the kernel it might need to be adapted be compatible with the new
+behavior.
+%
+\githubissue{1500}
 
 
 
-\section{Handling paragraph continuation}
+
+\section{Changes to the \LaTeX{} kernel}
+
+\subsection{Handling paragraph continuation}
 
 Already \LaTeX~2.09 offered some automatism to detect whether or not
 text after a list or some other display environment is meant to be a
@@ -292,7 +347,7 @@ environment signals to \LaTeX{} that it should start a new paragraph;
 whilst no blank line signals that there should be no new paragraph and
 the text should be considered a continuation.
 
-Unfortunately, there are a number of cases where the original 2.09
+Unfortunately, there were a number of cases where the original 2.09
 approach failed, e.g., with
 \begin{flushleft}
   \ttfamily
@@ -318,8 +373,6 @@ We therefore made a new attempt to resolve this problem in every
 situation and this new solution is rolled out in the current release.
 
 
-\section{New or improved commands}
-
 \subsection{Avoid bogus \enquote{no item} error}
 
 The commands \cs{addvspace} and \cs{addpenalty} generated the famous
@@ -337,22 +390,27 @@ show up if there is indeed a missing \cs{item}.
 %
 \githubissue{1460}
 
-\subsection{Change behavior of tagging sockets with two arguments}
 
-When calling tagging sockets with two arguments using
-\cs{UseTaggingSocket} when tagging is suspended previous versions of
-\LaTeXe{} dropped both arguments.  This behavior has been changed to
-drop the first argument and preserve the second one instead, thereby
-allowing tagging sockets to be used to wrap existing content which
-should still appear in a non-tagging context.
+\subsection{Switch to T1 as default encoding in documents using \cs{DocumentMetadata}}
 
-Since no tagging sockets currently provided by \LaTeXe{} use two
-arguments we do not expect this change to affect any existing
-documents, but if a custom tagging socket has been defined outside of
-the kernel it might need to be adapted be compatible with the new
-behavior.
-%
-\githubissue{1500}
+As it is well known, the font encoding \texttt{OT1} supports only 128
+characters and has various problems and quirks notably for languages
+different to English.  Nevertheless \texttt{OT1} is the default
+encoding in \LaTeX{} and this can not be easily changed without
+affecting many documents as the \texttt{T1} version of the fonts have
+slightly different metrics.
+
+The introduction of the \cs{DocumentMetadata} command, which announces
+\emph{new} code and changes that can also affect the layout gives us
+now the opportunity to make this step. So with this version a use of
+\cs{DocumentMetadata} with (pdf)\LaTeX{} will setup \texttt{T1} as
+default font encoding\footnote{The Unicode engines will continue to
+use \texttt{TU} as encoding.}. To ensure that scalable fonts are used,
+the package \pkg{cm-super} has to be installed. Users who want to
+revert to the \texttt{OT1} encoding in their document can do so with
+\verb+\usepackage[OT1]{fontenc}+.
+
+
 
 
 \section{Code improvements}
@@ -390,6 +448,14 @@ option: it is effectively marked as \enquote{private} to the class.
 \githubissue{1279}
 
 
+\subsection{Improvement to \XeTeX\ \cs{showhyphens}}
+
+When using \cs{showhyphens} with \XeTeX, missing character warnings
+would be generated for any character not in Latin Modern. This has
+been corrected and the warnings are suppressed.
+%
+\githubissue{1380}
+
 \subsection{Improved error raised by empty hook}
 
 When using the hook management, both hook and label names (if
@@ -426,6 +492,7 @@ kernel definition has now been extended with socket interfaces that
 will allow \pkg{hyperref} to avoid the redefinitions. The new
 interfaces are also used by the Tagged PDF code that needs target
 names to resolve references between structures.
+
 
 \section{Bug fixes}
 
@@ -504,16 +571,7 @@ preamble are possible again.
 \githubissue{1000}
 
 
-\section{Improvement to \XeTeX\ \cs{showhyphens}}
-
-When using \cs{showhyphens} with \XeTeX, missing character warnings
-would be generated for any character not in Latin Modern. This has
-been corrected and the warnings are suppressed.
-%
-\githubissue{1380}
-
-
-\section{Avoid code duplication in rollback}
+\subsection{Avoid code duplication in rollback}
 
 When the kernel uses \cs{AddToHook} in a region that might be rolled
 back (which happens in a few places) and a document requests a
@@ -525,7 +583,8 @@ errors. This has now been corrected by dropping any such code chunk
 %
 \githubissue{1407}
 
-\section{Passing template keys using \cs{KeyValue}}
+
+\subsection{Passing template keys using \cs{KeyValue}}
 
 With the move of the template code to the kernel, some internal
 efficiencies were also made. However, there was an oversight in how
@@ -535,9 +594,11 @@ loop. This has now been fixed.
 %
 \githubissue{1486}
 
+
+
 \section{Changes to packages in the \pkg{amsmath} category}
 
-\section{Extend support for \cs{dots}}
+\subsection{Extend support for \cs{dots}}
 
 The implementation of \cs{dots} in \pkg{amsmath} has the feature that
 it selects different dots depending on the symbol that follows: e.g.,
@@ -569,6 +630,17 @@ must now rename the file and install as \texttt{.tex}.
 %
 \githubissue{1412}
 
+
+\subsection{\pkg{array}: Improve \texttt{>\{...\}} specifier}
+
+If the argument of \texttt{>\{...\}} ended with a command accepting a
+trailing optional argument, e.g., defined for example with
+\verb=\NewDocumentCommand\foo{o}{...}=, one could get low-level
+parsing errors. This has now been corrected.
+%
+\githubissue{1468}
+
+
 \subsection{\pkg{array}: Tagging support for \cs{cline}}
 
 In the last release we added tagging support for \pkg{array},
@@ -584,6 +656,7 @@ these packages are now fully compatible with the tagging code if it is
 turned on.
 %
 \taggingissue{134}
+
 
 
 \subsection{\pkg{longtable}: Extend caption type}
@@ -611,14 +684,7 @@ An internal guard has been added to avoid \TeX\ errors if
 %
 \githubissue{1495}
 
-\subsection{\pkg{array}: Improve \texttt{>\{...\}} specifier}
 
-If the argument of \texttt{>\{...\}} ended with a command accepting a
-trailing optional argument, e.g., defined for example with
-\verb=\NewDocumentCommand\foo{o}{...}=, one could get low-level
-parsing errors. This has now been corrected.
-%
-\githubissue{1468}
 
 \section{Changes to \pkg{l3build}}
 
@@ -652,6 +718,10 @@ Leslie Lamport.
 \bibitem{40:ltnews} \LaTeX{} Project Team.
   \emph{\LaTeXe{} news 1--39}. June, 2024.
   \url{https://latex-project.org/news/latex2e-news/ltnews.pdf}
+
+\bibitem{40:ltnews22} \LaTeX{} Project Team.
+  \emph{\LaTeXe{} news 22}. Januar 2015.
+  \url{https://latex-project.org/news/latex2e-news/ltnews22.pdf}
 
 \bibitem{40:ltnews28} \LaTeX{} Project Team.
   \emph{\LaTeXe{} news 28}. April 2018.

--- a/base/doc/ltnews40.tex
+++ b/base/doc/ltnews40.tex
@@ -282,6 +282,21 @@ up if there is indeed a missing \cs{item}.
 %
 \githubissue{1460}
 
+\subsection{Change behavior of tagging sockets with two arguments}
+
+When calling tagging sockets with two arguments using \cs{UseTaggingSocket}
+when tagging is suspended previous versions of \LaTeXe{} dropped both arguments.
+This behavior has been changed to drop the first argument and preserve the second
+one instead, thereby allowing tagging sockets to be used to wrap existing content
+which should still appear in a non-tagging context.
+
+Since no tagging sockets currently provided by \LaTeXe{} use two arguments
+we do not expect this change to affect any existing documents, but if a custom
+tagging socket has been defined outside of the kernel it might need to be adapted
+be compatible with the new behavior.
+%
+\githubissue{1500}
+
 
 \section{Code improvements}
 

--- a/base/doc/ltnews40.tex
+++ b/base/doc/ltnews40.tex
@@ -160,10 +160,10 @@
 \section{Thirty years of \LaTeXe{}}
 
 Summer 1994, i.e., thirty years ago, \LaTeXe{} saw its first public
-release. Back then it was meant to be a intermediate version (hence
+release. Back then it was meant to be an intermediate version (hence
 the $\epsilon$) on the way to a major new version (the mythical
 \LaTeX3) that we expected to take a couple of more years to reach
-maturity. It took more much than that in the end\Dash nominally,
+maturity. It took much more than that in the end\Dash nominally,
 \LaTeXe{} is still with us today.
 
 However, under the hood, \LaTeXe{} changed a lot throughout these
@@ -214,7 +214,7 @@ milestones already reached allow users to generate PDF/UA compliant
 documents if the input is restricted to a (growing) subset of packages
 and document classes; see next section and previous newsletters.
 
- A big change happened on 2020-02-02 as part of the project activity,
+ A big change happened with the 2020-02-02 release as part of the project activity,
  albeit somewhat obfuscated by us as \enquote{Improved load-times for
    \pkg{expl3}}. While technically correct, what it really meant is
  that we had finally integrated the programming layer of \LaTeX3,
@@ -486,7 +486,7 @@ have now been incorporated into the kernel.  Thus from now on every
 
 \subsection{Extending \cs{refstepcounter}}
 
-The package \pkg{hyperref} redefines since many years
+For many years, the package \pkg{hyperref} has redefined
 \verb+\refstepcounter+ and adds code that creates link targets. The
 kernel definition has now been extended with socket interfaces that
 will allow \pkg{hyperref} to avoid the redefinitions. The new
@@ -661,7 +661,7 @@ turned on.
 
 \subsection{\pkg{longtable}: Extend caption type}
 
-The \pkg{longtable} has been extended and now provides the command
+The \pkg{longtable} package has been extended and now provides the command
 \cs{LTcaptype} (stemming from the \pkg{ltcaption} package) to change
 the counter and caption type used by the \cs{caption} command from
 longtable.  So with \verb+\renewcommand\LTcaptype{figure}+, a

--- a/base/doc/ltnews40.tex
+++ b/base/doc/ltnews40.tex
@@ -540,10 +540,10 @@ errors.  This has now been corrected.
 If the global (class) options contained spaces around key names,
 \cs{ProcessKeyOptions} would fail to remove known keys from the list
 of unused global options and \cs{OptionNotUsed} would mistakenly add
-space-surrounded key names to that list.  This has been corrected as
+space-surrounded key names to that list.  The first issue has been corrected as
 a hotfix in patch level 1 of the November 2023 release (but
-unfortunately not mentioned in~\cite{40:ltnews38}) and the current
-release, respectively.
+unfortunately not mentioned in~\cite{40:ltnews38}) and the second in the current
+release.
 %
 \githubissue{1238}
 

--- a/base/doc/ltnews40.tex
+++ b/base/doc/ltnews40.tex
@@ -158,7 +158,27 @@
 
 \section{Introduction}
 
-\emph{to write \ldots\ 30th anniversary of \LaTeXe{} this year btw}
+Summer 1994, i.e., thirty years ago, \LaTeXe{} saw its first public
+release. Back then it was meant to be a intermediate version (hence
+the $\epsilon$) on the way to a major new version (the mythical
+\LaTeX3) that we expected to take a couple of more years to reach
+maturity. It took more than that in the end and \LaTeXe{} is still
+with us today.
+
+However, under the hood, \LaTeXe{} changed a lot throughout these
+thirty years as one can see, for example, when looking through the
+fourty newletters that accompanied the \LaTeX{} releases that happened
+in the meantime~\cite{40:ltnews}.
+
+During the first two decades, the \LaTeX{} kernel was kept stable with
+only minimal bug fix activities. During that period additional
+functionalities were mostly provided through new or extended packages
+that could be loaded in the document preamble. This included many of
+the ideas targeted for \LaTeX3{}, e.g., \pkg{expl3} (\LaTeX3
+progamming language), \pkg{xparse} (new document command interface),
+\pkg{xtemplate} (a configuration mechanism) and many others.
+
+
 
 \section{Engine support: important update}
 

--- a/base/doc/ltnews40.tex
+++ b/base/doc/ltnews40.tex
@@ -306,7 +306,7 @@ two rows using:
 
 \subsection{Automatic MathML tagging}
 
-When lua\LaTeX{} is being used and the \pkg{luamml} package is
+When Lua\LaTeX{} is being used and the \pkg{luamml} package is
 available and if the document uses the \pkg{unicode-math} package,
 then the math module will automatically convert each math formula to
 MathML and use it to attach MathML associated files (or MathML
@@ -324,7 +324,7 @@ drop the first argument and preserve the second one instead, thereby
 allowing tagging sockets to be used to wrap existing content which
 should still appear in a non-tagging context.
 
-Since no tagging sockets currently provided by \LaTeXe{} use two
+Since no tagging sockets currently provided by \LaTeX{} use two
 arguments we do not expect this change to affect any existing
 documents, but if a custom tagging socket has been defined outside of
 the kernel it might need to be adapted be compatible with the new
@@ -540,7 +540,7 @@ errors.  This has now been corrected.
 If the global (class) options contained spaces around key names,
 \cs{ProcessKeyOptions} would fail to remove known keys from the list
 of unused global options and \cs{OptionNotUsed} would mistakenly add
-space-surrounded key names to that list.  The first issue has been corrected as
+space-surrounded key names to that list.  The first issue was corrected as
 a hotfix in patch level 1 of the November 2023 release (but
 unfortunately not mentioned in~\cite{40:ltnews38}) and the second in the current
 release.

--- a/base/doc/ltnews40.tex
+++ b/base/doc/ltnews40.tex
@@ -310,9 +310,10 @@ When Lua\LaTeX{} is being used and the \pkg{luamml} package is
 available and if the document uses the \pkg{unicode-math} package,
 then the math module will automatically convert each math formula to
 MathML and use it to attach MathML associated files (or MathML
-Structure elements) to the tagged PDF. This new feature can be disabled
-with \verb+\tagpdfsetup{math/mathml/luamml=false}+ More details can be
-found in the documentation of \pkg{latex-lab-math}.
+Structure elements) to the tagged PDF. This new feature can be
+disabled with \verb+\tagpdfsetup{math/mathml/luamml/load=false}+. More
+options to configure MathML tagging can be found in the documentation
+of \pkg{latex-lab-math}.
 
 
 \subsection{Change behavior of tagging sockets with two arguments}

--- a/base/doc/ltnews40.tex
+++ b/base/doc/ltnews40.tex
@@ -157,7 +157,7 @@
 
 \section{Introduction}
 
-\emph{to write \ldots\ 30th aniversary of \LaTeXe{} this year btw}
+\emph{to write \ldots\ 30th anniversary of \LaTeXe{} this year btw}
 
 \section{Engine support: important update}
 
@@ -309,7 +309,7 @@ every package. However, with keyvals, the likelihood of a name clash between a
 class-specific option and one used by a package is much higher than it is with
 simple strings. We have therefore refined the mechanism in the current release.
 
-When a class uses the kernel keyval processor, any options it recognises are
+When a class uses the kernel keyval processor, any options it recognizes are
 recorded and any packages using the keyval processor will then \emph{skip}
 these \enquote{global} options. To allow for the case where a class directly
 uses an option which should be global (for example \texttt{draft}), a new key
@@ -478,7 +478,7 @@ result in an infinite loop. This has now been fixed.
 The implementation of \cs{dots} in \pkg{amsmath} has the feature that
 it selects different dots depending on the symbol that follows: e.g.,
 dots between commas would normally be on the baseline, while dots
-between binary or relational symols would be raised. However, when symbols such
+between binary or relational symbols would be raised. However, when symbols such
 as \cs{cong} were protected from expansion in moving arguments (so
 that they worked in places such as headings) it had the unfortunate
 side-effect that the \cs{dots} magic stopped working for them. This

--- a/base/doc/ltnews40.tex
+++ b/base/doc/ltnews40.tex
@@ -141,7 +141,8 @@
 \tubcommand{\input{tubltmac}}
 
 \publicationmonth{November}
-\publicationyear{2024  --- DRAFT version for upcoming release}
+%\publicationyear{2024  --- DRAFT version for upcoming release}
+\publicationyear{2024}
 
 \publicationissue{40}
 
@@ -161,70 +162,78 @@
 
 \section{Engine support: important update}
 
-As detailed below, work is progressing on the Tagged PDF project. There are
-many drivers for this work, including legal changes in many places which will
-increasingly require well-tagged PDFs including full support for mathematics. As
-part of the work on this, we are looking at the technical abilities of the
-\TeX{} engines.
+As detailed below, work is progressing on the Tagged PDF
+project. There are many drivers for this work, including legal changes
+in many places which will increasingly require well-tagged PDFs
+including full support for mathematics. As part of the work on this,
+we are looking at the technical abilities of the \TeX{} engines.
 
 With \XeTeX{}, it is impossible to reliably produce tagged PDFs due to
-engine limitations. The increasing importance of tagged PDFs means that this
-requires a move away from \XeTeX{}. We will continue to address issues with
-\XeTeX{} support in team-maintained \LaTeX{} code on a best-effort basis.
-No \emph{new} functionality will be added for \XeTeX{} by the \LaTeX{} team. It
-is likely that over time functionality may become more restricted, and users
-are urged to migrate \XeTeX{} documents to \LuaTeX{}.
+engine limitations. The increasing importance of tagged PDFs means
+that this requires a move away from \XeTeX{}. We will continue to
+address issues with \XeTeX{} support in team-maintained \LaTeX{} code
+on a best-effort basis.  No \emph{new} functionality will be added for
+\XeTeX{} by the \LaTeX{} team. It is likely that over time
+functionality may become more restricted, and users are urged to
+migrate \XeTeX{} documents to \LuaTeX{}.
 
-For \pdfTeX{}, tagging is available and we are able to support mathematics by
-including relevant \TeX{} source or by using externally-generated MathML.
-Only \LuaTeX{} is capable of \emph{automatic} generation of MathML as part of a
-\LaTeX{} run. Thus \pdfTeX{} continues to be supported for existing material,
-but for new documents, moving to \LuaTeX{} is recommended.
+For \pdfTeX{}, tagging is available and we are able to support
+mathematics by including relevant \TeX{} source or by using
+externally-generated MathML.  Only \LuaTeX{} is capable of
+\emph{automatic} generation of MathML as part of a \LaTeX{} run. Thus
+\pdfTeX{} continues to be supported for existing material, but for new
+documents, moving to \LuaTeX{} is recommended.
 
 We cannot make statements about the support for other engines such as
-(u)p\TeX{}, as we don't use these programs nor have in depth knowledge of their
-functionalities. To the best of our knowledge, core \LaTeX{} works well with
-these engines, but if and to what extent tagging can be supported will remain
-to be seen. If relevant information becomes available to us we will provide an
-update in future editions of the \LaTeX{} newsletter.
+(u)p\TeX{}, as we don't use these programs nor have in depth knowledge
+of their functionalities. To the best of our knowledge, core \LaTeX{}
+works well with these engines, but if and to what extent tagging can
+be supported will remain to be seen. If relevant information becomes
+available to us we will provide an update in future editions of the
+\LaTeX{} newsletter.
 
 \section{Switch to T1 as default encoding in documents using \cs{DocumentMetadata}}
 
-As it is well known the font encoding \texttt{OT1} supports only 128 characters and 
-has various problems and quirks notably for languages different to English. 
-Nevertheless \texttt{OT1} is the default encoding in \LaTeX{} and this can not be easily 
-changed without affecting many documents as the \texttt{T1} version of the fonts have slightly different metrics. 
+As it is well known the font encoding \texttt{OT1} supports only 128
+characters and has various problems and quirks notably for languages
+different to English.  Nevertheless \texttt{OT1} is the default
+encoding in \LaTeX{} and this can not be easily changed without
+affecting many documents as the \texttt{T1} version of the fonts have
+slightly different metrics.
 
-The introduction of the \cs{DocumentMetadata} command, which announces 
-\emph{new} code and changes that can also affect the layout gives us now the 
-opportunity to make this step. So with this version a use of 
-\cs{DocumentMetadata} with (pdf)\LaTeX{} will setup  \texttt{T1} as default 
-font encoding\footnote{The Unicode engines will continue to use \texttt{TU} 
-as encoding.}. To ensure that scalable fonts are used, the package 
-\pkg{cm-super} has to be installed. Users who want to revert to the 
-\texttt{OT1} encoding in their document can do so with
-\verb+\usepackage[OT1]{fontenc}+. 
+The introduction of the \cs{DocumentMetadata} command, which announces
+\emph{new} code and changes that can also affect the layout gives us
+now the opportunity to make this step. So with this version a use of
+\cs{DocumentMetadata} with (pdf)\LaTeX{} will setup \texttt{T1} as
+default font encoding\footnote{The Unicode engines will continue to
+use \texttt{TU} as encoding.}. To ensure that scalable fonts are used,
+the package \pkg{cm-super} has to be installed. Users who want to
+revert to the \texttt{OT1} encoding in their document can do so with
+\verb+\usepackage[OT1]{fontenc}+.
 
 
 
 \section{News from the \enquote{\LaTeX{} Tagged PDF} project}
 
 The tagging of tabulars has been extended: it is now possible to tag
-also row headers and to create cells that span more than one row. 
+also row headers and to create cells that span more than one row.
 
 \emph{write more details ...}
 
 
-The math module will automatically generate a MathML file and use it to 
-attach MathML associated files to the structure if lua\LaTeX{} and 
+The math module will automatically generate a MathML file and use it
+to attach MathML associated files to the structure if lua\LaTeX{} and
 the \pkg{unicode-math} package are used and the \pkg{luamml} is found.
-This new feature can be disabled with \verb+\tagpdfsetup{math/mathml/luamml=false}+ 
-More details can be found in the documentation of \pkg{latex-lab-math}. 
+This new feature can be disabled with
+\verb+\tagpdfsetup{math/mathml/luamml=false}+ More details can be
+found in the documentation of \pkg{latex-lab-math}.
 
-At \url{https://latex3.github.io/tagging-project/tagging-status/} we show the status of many \LaTeX{} Packages and Classes with respect to PDF tagging. 
-We also started to improve tagging support in external packages. If the 
-\texttt{firstaid} key is used in addition to the \texttt{phase-III} key
-basic commands of packages like \pkg{amsthm} and \pkg{fancyvrb} can now be used. 
+At \url{https://latex3.github.io/tagging-project/tagging-status/} we
+show the status of many \LaTeX{} Packages and Classes with respect to
+PDF tagging.  We also started to improve tagging support in external
+packages. If the \texttt{firstaid} key is used in addition to the
+\texttt{phase-III} key basic commands of packages like \pkg{amsthm}
+and \pkg{fancyvrb} can now be used.
 
 \section{Handling paragraph continuation}
 
@@ -232,9 +241,9 @@ Already \LaTeX~2.09 offered some automatism to detect whether or not
 text after a list or some other display environment is meant to be a
 continuation of the current paragraph or should start a new one.  The
 document-level syntax for this is that a blank line after such an
-environment signals to \LaTeX{} that it should start a new paragraph; whilst
-no blank line signals that there should be no new paragraph and the
-text should be considered a continuation.
+environment signals to \LaTeX{} that it should start a new paragraph;
+whilst no blank line signals that there should be no new paragraph and
+the text should be considered a continuation.
 
 Unfortunately, there are a number of cases where the original 2.09
 approach failed, e.g., with
@@ -247,20 +256,19 @@ approach failed, e.g., with
 the \meta{some text} incorrectly started a new paragraph.  Bug reports
 about this behavior can be traced back to the time \LaTeXe{} was
 developed, e.g., one test file from 1992 has a note that the above
-case was unfortunately not resolvable despite some improvements made back
-then.  The main cause of the issue (as you probably guessed) is that
-the mechanism failed whenever the environment was executed within a
-group (\texttt{\{...\}}, \cs{begingroup}/\cs{endgroup}, or
+case was unfortunately not resolvable despite some improvements made
+back then.  The main cause of the issue (as you probably guessed) is
+that the mechanism failed whenever the environment was executed within
+a group (\texttt{\{...\}}, \cs{begingroup}/\cs{endgroup}, or
 \cs{bgroup}/\cs{egroup} pair) that was closed before the next blank
 line was reached.
 
-While most of the time  this could be visually corrected by adding some
+While most of the time this could be visually corrected by adding some
 explicit \cs{noindent}, the situation got worse when we tried to
 implement tagged PDFs resulting in incorrect structures or worse.
 
 We therefore made a new attempt to resolve this problem in every
-situation and this new solution is rolled out in the current
-release.
+situation and this new solution is rolled out in the current release.
 
 
 \section{New or improved commands}
@@ -269,31 +277,33 @@ release.
 
 The commands \cs{addvspace} and \cs{addpenalty} generated the famous
 error message \enquote{Something's wrong--perhaps a missing \cs{item}}
-when they were encountered outside vertical mode. Most of the time this
-error was bogus and if not, then it was generated several times rather
-than once.
+when they were encountered outside vertical mode. Most of the time
+this error was bogus and if not, then it was generated several times
+rather than once.
 
 Once upon a time (in \LaTeX{}~2.09) it was necessary that these
 commands were used only in vertical mode, but with \LaTeXe{} in 1994,
 we changed the internals but simply overlooked that this error message
-then had become useless. In this release, i.e.,~30 years too late, we have
-finally lifted the ban and from now on this error should only show
-up if there is indeed a missing \cs{item}.
+then had become useless. In this release, i.e.,~30 years too late, we
+have finally lifted the ban and from now on this error should only
+show up if there is indeed a missing \cs{item}.
 %
 \githubissue{1460}
 
 \subsection{Change behavior of tagging sockets with two arguments}
 
-When calling tagging sockets with two arguments using \cs{UseTaggingSocket}
-when tagging is suspended previous versions of \LaTeXe{} dropped both arguments.
-This behavior has been changed to drop the first argument and preserve the second
-one instead, thereby allowing tagging sockets to be used to wrap existing content
-which should still appear in a non-tagging context.
+When calling tagging sockets with two arguments using
+\cs{UseTaggingSocket} when tagging is suspended previous versions of
+\LaTeXe{} dropped both arguments.  This behavior has been changed to
+drop the first argument and preserve the second one instead, thereby
+allowing tagging sockets to be used to wrap existing content which
+should still appear in a non-tagging context.
 
-Since no tagging sockets currently provided by \LaTeXe{} use two arguments
-we do not expect this change to affect any existing documents, but if a custom
-tagging socket has been defined outside of the kernel it might need to be adapted
-be compatible with the new behavior.
+Since no tagging sockets currently provided by \LaTeXe{} use two
+arguments we do not expect this change to affect any existing
+documents, but if a custom tagging socket has been defined outside of
+the kernel it might need to be adapted be compatible with the new
+behavior.
 %
 \githubissue{1500}
 
@@ -302,19 +312,22 @@ be compatible with the new behavior.
 
 \subsection{Avoiding keyval option clashes between classes and packages}
 
-In \LaTeX{} News~35~\cite{40:ltnews35} we introduced keyval option processing
-to the kernel. Following the standard for \LaTeXe{} options, keyval options
-given to the \cs{documentclass} line were treated as global and so parsed by
-every package. However, with keyvals, the likelihood of a name clash between a
-class-specific option and one used by a package is much higher than it is with
-simple strings. We have therefore refined the mechanism in the current release.
+In \LaTeX{} News~35~\cite{40:ltnews35} we introduced keyval option
+processing to the kernel. Following the standard for \LaTeXe{}
+options, keyval options given to the \cs{documentclass} line were
+treated as global and so parsed by every package. However, with
+keyvals, the likelihood of a name clash between a class-specific
+option and one used by a package is much higher than it is with simple
+strings. We have therefore refined the mechanism in the current
+release.
 
-When a class uses the kernel keyval processor, any options it recognizes are
-recorded and any packages using the keyval processor will then \emph{skip}
-these \enquote{global} options. To allow for the case where a class directly
-uses an option which should be global (for example \texttt{draft}), a new key
-property \texttt{.pass-to-packages} has been added. This can then be set to
-indicate that this key is not to be skipped. For example
+When a class uses the kernel keyval processor, any options it
+recognizes are recorded and any packages using the keyval processor
+will then \emph{skip} these \enquote{global} options. To allow for the
+case where a class directly uses an option which should be global (for
+example \texttt{draft}), a new key property \texttt{.pass-to-packages}
+has been added. This can then be set to indicate that this key is not
+to be skipped. For example
 \begin{verbatim}
 \DeclareKeys{
   draft .if = {ifl@cls@draft},
@@ -322,19 +335,19 @@ indicate that this key is not to be skipped. For example
   mode  .store = \cls@mode
 }
 \end{verbatim}
-in a class would create two options, \texttt{draft} and \texttt{mode}. The
-\texttt{draft} option will be treated in the normal way by packages using
-keyvals, but they will ignore the \texttt{mode} option: it is effectively
-marked as \enquote{private} to the class.
+in a class would create two options, \texttt{draft} and
+\texttt{mode}. The \texttt{draft} option will be treated in the normal
+way by packages using keyvals, but they will ignore the \texttt{mode}
+option: it is effectively marked as \enquote{private} to the class.
 %
 \githubissue{1279}
 
 
 \subsection{Improved error raised by empty hook}
 
-When using the hook management, both hook and label names (if specified) 
-should be non-empty. Before empty hook and empty label both raised the
-same label-specific error.
+When using the hook management, both hook and label names (if
+specified) should be non-empty. Before empty hook and empty label both
+raised the same label-specific error.
 \begin{verbatim}
 ! LaTeX hooks Error: Empty code label on line ....
   Using 'top-level' instead.
@@ -348,24 +361,24 @@ This has now been improved. Now empty hook raises
 
 \subsection{Provide counter representations for link targets}
 
-To create unique target names for links the package 
-\pkg{hyperref} uses a special counter representation
-\verb+\theH+\meta{counter}. To ensure that this 
-counter representation exists, \pkg{hyperref} redefined the 
-commands \verb+\@definecounter+, \verb+\@addtoreset+ 
-and \verb+\refstepcounter+. This counter representation is also
-needed for the Tagged PDF project and and so these augmented command definitions 
-have now been incorporated
-into the kernel. 
-Thus from now on every \verb+\newcounter{+\meta{counter}\verb+}+ will not
-only define \verb+\the+\meta{counter} but also \verb+\theH+\meta{counter}.
+To create unique target names for links the package \pkg{hyperref}
+uses a special counter representation \verb+\theH+\meta{counter}. To
+ensure that this counter representation exists, \pkg{hyperref}
+redefined the commands \verb+\@definecounter+, \verb+\@addtoreset+ and
+\verb+\refstepcounter+. This counter representation is also needed for
+the Tagged PDF project and and so these augmented command definitions
+have now been incorporated into the kernel.  Thus from now on every
+\verb+\newcounter{+\meta{counter}\verb+}+ will not only define
+\verb+\the+\meta{counter} but also \verb+\theH+\meta{counter}.
 
 \subsection{Extending \cs{refstepcounter}}
 
-The package \pkg{hyperref} redefines since many years \verb+\refstepcounter+ and
-adds code that creates link targets. The kernel definition has now been extended
-with socket interfaces that will allow \pkg{hyperref} to avoid the redefinitions. The new interfaces are also used by the Tagged PDF code that needs target names to resolve
-references between structures.
+The package \pkg{hyperref} redefines since many years
+\verb+\refstepcounter+ and adds code that creates link targets. The
+kernel definition has now been extended with socket interfaces that
+will allow \pkg{hyperref} to avoid the redefinitions. The new
+interfaces are also used by the Tagged PDF code that needs target
+names to resolve references between structures.
 
 \section{Bug fixes}
 
@@ -384,46 +397,48 @@ LaTeX Warning: Suspicious rollback/min-date
 \end{verbatim}
 
 In some cases this message showed a wrong file type, i.e.,
-\verb|document class '<pkgname>'| or \verb|package '<clsname>'|.
-This has now been corrected.
+\verb|document class '<pkgname>'| or \verb|package '<clsname>'|.  This
+has now been corrected.
 %
 \githubissue{870}
 
 \subsection*{Fix existence check of document environments}
-\cs{NewDocumentEnvironment} and friends define (or redefine) a document
-environment using the space-trimmed \meta{envname}, but the existence
-check for \meta{envname} was done without space trimming. Thus when the
-user-specified \meta{envname} consists of leading and/or trailing
-space(s), it may lead to erroneously silent environment declaration.
-For example, in
+
+\cs{NewDocumentEnvironment} and friends define (or redefine) a
+document environment using the space-trimmed \meta{envname}, but the
+existence check for \meta{envname} was done without space
+trimming. Thus when the user-specified \meta{envname} consists of
+leading and/or trailing space(s), it may lead to erroneously silent
+environment declaration.  For example, in
 \begin{verbatim}
   \NewDocumentEnvironment{myenv}{}{begin}{end}
   \NewDocumentEnvironment{ myenv }{}{begin}{end}
 \end{verbatim}
 the first line defines a new environment \env{myenv} but the second
-line would check existence for \env{ myenv } (which is not yet defined),
-then redefine \env{myenv} environment without raising any errors.
-This has now been corrected.
+line would check existence for \env{ myenv } (which is not yet
+defined), then redefine \env{myenv} environment without raising any
+errors.  This has now been corrected.
 %
 \githubissue{1399}
 
 \subsection{Handling of global keys with spaces}
 
 If the global (class) options contained spaces around key names,
-\cs{ProcessKeyOptions} would fail to remove known keys from the
-list of unused global options and \cs{OptionNotUsed} would mistakenly
-add space-surrounded key names to that list.
-These has been corrected as a hotfix in patch level 1 of the November 2023
-release (but unfortunately not mentioned in~\cite{40:ltnews38}) and
-the current release, respectively.
+\cs{ProcessKeyOptions} would fail to remove known keys from the list
+of unused global options and \cs{OptionNotUsed} would mistakenly add
+space-surrounded key names to that list.  These has been corrected as
+a hotfix in patch level 1 of the November 2023 release (but
+unfortunately not mentioned in~\cite{40:ltnews38}) and the current
+release, respectively.
 %
 \githubissue{1238}
 
 \subsection{File list entries for rolled back packages/classes}
-When the rollback mechanism for packages and classes was introduced
-in 2018~\cite{40:ltnews28}, loading of the selected historic release
-was not recorded in the file list used by \cs{listfiles}.
-This has now been corrected so that the extended usage~\cite{40:ltnews39}
+
+When the rollback mechanism for packages and classes was introduced in
+2018~\cite{40:ltnews28}, loading of the selected historic release was
+not recorded in the file list used by \cs{listfiles}.  This has now
+been corrected so that the extended usage~\cite{40:ltnews39}
 \begin{verbatim}
 \listfiles[hashes,sizes]
 \end{verbatim}
@@ -443,31 +458,33 @@ preamble are possible again.
 
 
 \section{Improvement to \XeTeX\ \cs{showhyphens}}
+
 When using \cs{showhyphens} with \XeTeX, missing character warnings
-would be generated for any character not in Latin Modern. This has been
-corrected and the warnings are suppressed.
+would be generated for any character not in Latin Modern. This has
+been corrected and the warnings are suppressed.
 %
 \githubissue{1380}
 
 
 \section{Avoid code duplication in rollback}
 
-When the kernel uses \cs{AddToHook} in a region that might be 
-rolled back (which happens in a few places) and a document requests a
-rollback, then we have the situation that the hook already contains code to which we added the same
-(or slightly different) code during the
-rollback; this results in code duplication or, worse, in errors. This has
-now been corrected by dropping any such code chunk (if there is one) prior to
-adding the rollback code.
+When the kernel uses \cs{AddToHook} in a region that might be rolled
+back (which happens in a few places) and a document requests a
+rollback, then we have the situation that the hook already contains
+code to which we added the same (or slightly different) code during
+the rollback; this results in code duplication or, worse, in
+errors. This has now been corrected by dropping any such code chunk
+(if there is one) prior to adding the rollback code.
 %
 \githubissue{1407}
 
 \section{Passing template keys using \cs{KeyValue}}
 
-With the move of the template code to the kernel, some internal efficiencies
-were also made. However, there was an oversight in how passing key values from
-one setting to another was implemented, meaning that using \cs{KeyValue} could
-result in an infinite loop. This has now been fixed.
+With the move of the template code to the kernel, some internal
+efficiencies were also made. However, there was an oversight in how
+passing key values from one setting to another was implemented,
+meaning that using \cs{KeyValue} could result in an infinite
+loop. This has now been fixed.
 %
 \githubissue{1486}
 
@@ -478,11 +495,11 @@ result in an infinite loop. This has now been fixed.
 The implementation of \cs{dots} in \pkg{amsmath} has the feature that
 it selects different dots depending on the symbol that follows: e.g.,
 dots between commas would normally be on the baseline, while dots
-between binary or relational symbols would be raised. However, when symbols such
-as \cs{cong} were protected from expansion in moving arguments (so
-that they worked in places such as headings) it had the unfortunate
-side-effect that the \cs{dots} magic stopped working for them. This
-has now been corrected.
+between binary or relational symbols would be raised. However, when
+symbols such as \cs{cong} were protected from expansion in moving
+arguments (so that they worked in places such as headings) it had the
+unfortunate side-effect that the \cs{dots} magic stopped working for
+them. This has now been corrected.
 %
 \githubissue{1265}
 
@@ -494,11 +511,14 @@ has now been corrected.
 
 \subsection{Modification to generation of the \file{.tex} from \pkg{fileerr}}
 
-The \pkg{fileerr} extraction has been modified to write \texttt{rename-to-empty-base.tex}
-rather than \texttt{.tex} to comply with an expected security change in \TeX{}~Live 2025.
-The \texttt{build.lua} file for the \pkg{tools} has been  modified to rename \texttt{rename-to-empty-base.tex} to \texttt{.tex}
-after unpacking. However if using \textsf{docstrip} directly rather than using \textsf{l3build}
-or the unpacked zip file from \CTAN{}, the user must now rename the file and  install as \texttt{.tex}.
+The \pkg{fileerr} extraction has been modified to write
+\texttt{rename-to-empty-base.tex} rather than \texttt{.tex} to comply
+with an expected security change in \TeX{}~Live 2025.  The
+\texttt{build.lua} file for the \pkg{tools} has been modified to
+rename \texttt{rename-to-empty-base.tex} to \texttt{.tex} after
+unpacking. However if using \textsf{docstrip} directly rather than
+using \textsf{l3build} or the unpacked zip file from \CTAN{}, the user
+must now rename the file and install as \texttt{.tex}.
 %
 \githubissue{1412}
 
@@ -521,14 +541,15 @@ turned on.
 
 \subsection{\pkg{longtable}: Extend caption type}
 
-The \pkg{longtable} has been extended and now provides the command \cs{LTcaptype}
-(stemming from the \pkg{ltcaption} package) to change
-the counter and caption type used by the \cs{caption} command from longtable.
-So with \verb+\renewcommand\LTcaptype{figure}+, a longtable will step the
-figure counter instead of the table counter and produce an
-entry in the list of figures. An empty definition, \verb+\renewcommand\LTcaptype{}+,
-will suppress increasing of the counter. This makes it easy to define an
-unnumbered variant of longtable:
+The \pkg{longtable} has been extended and now provides the command
+\cs{LTcaptype} (stemming from the \pkg{ltcaption} package) to change
+the counter and caption type used by the \cs{caption} command from
+longtable.  So with \verb+\renewcommand\LTcaptype{figure}+, a
+longtable will step the figure counter instead of the table counter
+and produce an entry in the list of figures. An empty definition,
+\verb+\renewcommand\LTcaptype{}+, will suppress increasing of the
+counter. This makes it easy to define an unnumbered variant of
+longtable:
 \begin{verbatim}
 \newenvironment{longtable*}
   {\renewcommand\LTcaptype{}\longtable}
@@ -557,7 +578,8 @@ to run their test suite against the current release of \LaTeX{} and
 \begin{verbatim}
   l3build check --dev
 \end{verbatim}
-to run exactly the same tests using the development release of \LaTeX{}.
+to run exactly the same tests using the development release of
+\LaTeX{}.
 
 %\section{Changes to files in the \pkg{cyrillic} category}
 

--- a/base/doc/ltnews40.tex
+++ b/base/doc/ltnews40.tex
@@ -156,7 +156,7 @@
 
 \medskip
 
-\section{Introduction}
+\section{Thirty years of \LaTeXe{}}
 
 Summer 1994, i.e., thirty years ago, \LaTeXe{} saw its first public
 release. Back then it was meant to be a intermediate version (hence
@@ -177,6 +177,53 @@ that could be loaded in the document preamble. This included many of
 the ideas targeted for \LaTeX3{}, e.g., \pkg{expl3} (\LaTeX3
 progamming language), \pkg{xparse} (new document command interface),
 \pkg{xtemplate} (a configuration mechanism) and many others.
+
+
+
+\section{News from the \enquote{\LaTeX{} Tagged PDF} project}
+
+\subsection{Improved table tagging}
+
+The tagging of tabulars has been extended: it is now possible to tag
+row headers and to create cells that span more than one row.
+
+The interface to this functionality is not finalised but can be
+accessed in the current release by specifying the row and columns to
+be treated as headers.
+
+\begin{verbatim}
+\tagpdfsetup{
+ table/header-rows={1,2},
+ table/header-columns={1} }
+\end{verbatim}
+Would specify that in the following tables the first two rows and
+first column of each row should be tagged as heading entries.
+
+Similarly you may add a RowSpan attributes to tag a cell that spans
+two rows using:
+\begin{verbatim}
+\tagpdfsetup{table/multirow={2}}
+\end{verbatim}
+
+
+\subsection{Automatic MathML tagging}
+
+When lua\LaTeX{} is being used and the \pkg{luamml} package is
+available and if the document uses the \pkg{unicode-math} package,
+then the math module will automatically convert each math formula to
+MathML and use it to attach MathML associated files (or MathML
+Structure elements) to the tagged PDF. This new feature can be disabled
+with \verb+\tagpdfsetup{math/mathml/luamml=false}+ More details can be
+found in the documentation of \pkg{latex-lab-math}.
+
+\subsection{Tagging support for external packages}
+
+At \url{https://latex3.github.io/tagging-project/tagging-status/} we
+show the status of many \LaTeX{} Packages and Classes with respect to
+PDF tagging.  We also started to improve tagging support in external
+packages. If the \texttt{firstaid} key is used in addition to the
+\texttt{phase-III} key basic commands of packages including
+\pkg{amsthm} and \pkg{fancyvrb} can now be used.
 
 
 
@@ -233,27 +280,7 @@ revert to the \texttt{OT1} encoding in their document can do so with
 
 
 
-\section{News from the \enquote{\LaTeX{} Tagged PDF} project}
 
-The tagging of tabulars has been extended: it is now possible to tag
-also row headers and to create cells that span more than one row.
-
-\emph{write more details ...}
-
-
-The math module will automatically generate a MathML file and use it
-to attach MathML associated files to the structure if lua\LaTeX{} and
-the \pkg{unicode-math} package are used and the \pkg{luamml} is found.
-This new feature can be disabled with
-\verb+\tagpdfsetup{math/mathml/luamml=false}+ More details can be
-found in the documentation of \pkg{latex-lab-math}.
-
-At \url{https://latex3.github.io/tagging-project/tagging-status/} we
-show the status of many \LaTeX{} Packages and Classes with respect to
-PDF tagging.  We also started to improve tagging support in external
-packages. If the \texttt{firstaid} key is used in addition to the
-\texttt{phase-III} key basic commands of packages like \pkg{amsthm}
-and \pkg{fancyvrb} can now be used.
 
 \section{Handling paragraph continuation}
 
@@ -386,7 +413,7 @@ uses a special counter representation \verb+\theH+\meta{counter}. To
 ensure that this counter representation exists, \pkg{hyperref}
 redefined the commands \verb+\@definecounter+, \verb+\@addtoreset+ and
 \verb+\refstepcounter+. This counter representation is also needed for
-the Tagged PDF project and and so these augmented command definitions
+the Tagged PDF project and so these augmented command definitions
 have now been incorporated into the kernel.  Thus from now on every
 \verb+\newcounter{+\meta{counter}\verb+}+ will not only define
 \verb+\the+\meta{counter} but also \verb+\theH+\meta{counter}.
@@ -577,8 +604,10 @@ longtable:
 \end{verbatim}
 
 \subsection{\pkg{longtable}: Prevent \cs{pagegoal} exceeding maximum value}
-An internal guard has been added to avoid \TeX\ errors if \verb=\pagegoal= is increased
-beyond the maximum value for a \TeX\ dimension.
+
+An internal guard has been added to avoid \TeX\ errors if
+\verb=\pagegoal= is increased beyond the maximum value for a
+\TeX\ dimension.
 %
 \githubissue{1495}
 


### PR DESCRIPTION
# Internal housekeeping

## Status of pull request

- Feedback wanted 
- Ready to merge

## Checklist of required changes before merge will be approved
- [n/a] Test file(s) added
- [n/a] Version and date string updated in changed source files
- [n/a] Relevant `\changes` entries in source included
- [n/a] Relevant `changes.txt` updated
- [n/a] Rollback provided (if necessary)?
- [x] `ltnewsX.tex` (and/or `latexchanges.tex`) updated

Looks like the ltugboat change hasn't yet made it to all mirrors, so at the moment the firstaid test file errors (after David's change to it). Not much that one can do about it other that wait, I guess.

Looks like the pull request ran through, so it is really an issue that will go away by tomorrow (hopefully).
