### PR TITLE
Skip mapping over undeclared prop in `\ShowHook` etc.

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,10 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
+2024-10-29  Yukai Chou <muzimuzhi@gmail.com>
+	* lthooks.dtx (subsection{Setting rules for hooks code}):
+	Skip mapping over undeclared \g__hook_<hook>_code_prop (gh/1513).
+
 2024-10-27  Marcel Krüger  <Marcel.Krueger@latex-project.org>
 	* lttagging.dtx
 	Change tagging sockets with two arguments to drop the first argument

--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -32,7 +32,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{lthooks.dtx}
-             [2024/10/21 v1.1j LaTeX Kernel (hooks)]
+             [2024/10/29 v1.1k LaTeX Kernel (hooks)]
 % \iffalse
 %
 \documentclass{l3doc}
@@ -6174,6 +6174,8 @@
       }
 %    \end{macrocode}
 %
+% \changes{v1.1k}{2024/10/29}
+%         {Skip mapping over undeclared \cs{g_@@_\meta{hook}_code_prop} (gh/1513)}
 %    \begin{macrocode}
     \@@_if_usable:nF {#1}
       { \@@_log_line:x { The~hook~is~not~declared. } }
@@ -6183,7 +6185,9 @@
       { #2 { The~hook~is~empty } }
       {
         \@@_log_line:x { Code~chunks: }
-        \prop_if_empty:cTF { g_@@_#1_code_prop }
+        \bool_lazy_or:nnTF
+          { ! \prop_if_exist_p:c { g_@@_#1_code_prop } }
+          { \prop_if_empty_p:c { g_@@_#1_code_prop } }
           { \@@_log_line_indent:x { --- } }
           {
             \prop_map_inline:cn { g_@@_#1_code_prop }
@@ -6445,19 +6449,24 @@
 %   |#2|${}={}$\meta{label_1}\verb=|=\meta{label_2},
 %   and |#3|${}={}$\meta{hook} (the latter may be the argument |#1| to
 %   \cs{@@_list_rules:nn}, or \texttt{??} if it is a default rule).
+% \changes{v1.1k}{2024/10/29}
+%         {Skip mapping over undeclared \cs{g_@@_\meta{hook}_code_prop} (gh/1513)}
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_list_rules:nn #1 #2
   {
-    \cs_set_protected:Npn \@@_tmp:w ##1 ##2 ##3 {#2}
-    \prop_map_inline:cn { g_@@_#1_code_prop }
+    \prop_if_exist:cT { g_@@_#1_code_prop }
       {
+        \cs_set_protected:Npn \@@_tmp:w ##1 ##2 ##3 {#2}
         \prop_map_inline:cn { g_@@_#1_code_prop }
           {
-            \@@_if_label_case:nnnnn {##1} {####1}
-              { \prop_map_break: }
-              { \@@_list_one_rule:nnn {##1} {####1} }
-              { \@@_list_one_rule:nnn {####1} {##1} }
-                  {#1}
+            \prop_map_inline:cn { g_@@_#1_code_prop }
+              {
+                \@@_if_label_case:nnnnn {##1} {####1}
+                  { \prop_map_break: }
+                  { \@@_list_one_rule:nnn {##1} {####1} }
+                  { \@@_list_one_rule:nnn {####1} {##1} }
+                      {#1}
+              }
           }
       }
   }

--- a/base/testfiles-lthooks/github-1513.lvt
+++ b/base/testfiles-lthooks/github-1513.lvt
@@ -1,0 +1,17 @@
+
+\ExplSyntaxOn
+\debug_on:n { check-declarations , deprecation }
+\ExplSyntaxOff
+
+\documentclass{article}
+
+\input{regression-test}
+
+
+\usepackage{amsmath}
+
+\START
+
+\ShowHook{package/amsmath/after}
+
+\END

--- a/base/testfiles-lthooks/github-1513.lvt
+++ b/base/testfiles-lthooks/github-1513.lvt
@@ -8,10 +8,10 @@
 \input{regression-test}
 
 
-\usepackage{amsmath}
+\usepackage{tracefnt}
 
 \START
 
-\ShowHook{package/amsmath/after}
+\ShowHook{package/tracefnt/after}
 
 \END

--- a/base/testfiles-lthooks/github-1513.tlg
+++ b/base/testfiles-lthooks/github-1513.tlg
@@ -1,0 +1,16 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+-> The generic hook 'package/amsmath/after':
+> The hook is not declared.
+> Code chunks:
+>     ---
+> Document-level (top-level) code:
+>     ---
+> Extra code for next invocation:
+>     -> 
+> Rules:
+>     ---
+> Execution order:
+>     Not set because the hook is undeclared.
+<recently read> }
+l. ...\ShowHook{package/amsmath/after}

--- a/base/testfiles-lthooks/github-1513.tlg
+++ b/base/testfiles-lthooks/github-1513.tlg
@@ -1,6 +1,6 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
--> The generic hook 'package/amsmath/after':
+-> The generic hook 'package/tracefnt/after':
 > The hook is not declared.
 > Code chunks:
 >     ---
@@ -13,4 +13,4 @@ Don't change this file in any respect.
 > Execution order:
 >     Not set because the hook is undeclared.
 <recently read> }
-l. ...\ShowHook{package/amsmath/after}
+l. ...\ShowHook{package/tracefnt/after}


### PR DESCRIPTION
I'm not so familiar with hooks implementation, so maybe there're more uncaught similar cases.

Rollback needed? Only `\ShowHook`, `\LogHook` and friends are affected.

`ltnews40.tex` entry not added. Maybe after #1512 gets merged?

# Internal housekeeping

## Status of pull request

- Feedback wanted 
- Under development
- Ready to merge

## Checklist of required changes before merge will be approved
- [x] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
