### PR TITLE
suspend tagging in \@settodim in calc

### DIFF
--- a/required/latex-lab/testfiles-math/mtag-tlc3.tlg
+++ b/required/latex-lab/testfiles-math/mtag-tlc3.tlg
@@ -527,12 +527,12 @@ Overfull \hbox (9.0542pt too wide) detected at line 434
 .....\mathoff
 ....\glue(\tabskip) 0.0
 .\pdfliteral page{EMC}
-.\marks4{e-,295,322,}
-.\marks4{e+,295,322,}
-.\write1{\new@label@record{mcid-296}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{296}{tagmcid}{\__property_code_tagmcid: }}}
+.\marks4{e-,293,321,}
+.\marks4{e+,293,321,}
+.\write1{\new@label@record{mcid-294}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{294}{tagmcid}{\__property_code_tagmcid: }}}
 .\pdfliteral shipout page{/Formula <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
-.\marks4{b-,296,323,Formula,,,}
-.\marks4{b+,296,323,Formula,,,}
+.\marks4{b-,294,322,Formula,,,}
+.\marks4{b+,294,322,Formula,,,}
 .\mathoff
 .\glue 0.0 plus 1.0fil
 )

--- a/required/latex-lab/testfiles/gh-tagging628-settodim-calc.lvt
+++ b/required/latex-lab/testfiles/gh-tagging628-settodim-calc.lvt
@@ -1,0 +1,9 @@
+\DocumentMetadata{testphase={phase-III,table}}
+\input{regression-test}
+\documentclass{article} 
+\usepackage{calc}
+\begin{document}
+\START
+\settowidth\parindent{\begin{tabular}{l}xxx\end{tabular}}
+x
+\end{document}

--- a/required/latex-lab/testfiles/gh-tagging628-settodim-calc.tlg
+++ b/required/latex-lab/testfiles/gh-tagging628-settodim-calc.tlg
@@ -1,0 +1,19 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <7> on input line ....
+LaTeX Font Info:    External font `cmex10' loaded for size
+(Font)              <5> on input line ....
+[1
+] (gh-tagging628-settodim-calc.aux)
+Package tagpdf Info: Finalizing the tagging structure:
+(tagpdf)             Writing out ~6 structure objects
+(tagpdf)             with ~3 'MC' leaf nodes.
+(tagpdf)             Be patient if there are lots of objects!
+Package tagpdf Info: writing ParentTree
+Package tagpdf Info: writing IDTree
+Package tagpdf Info: writing RoleMap
+Package tagpdf Info: writing ClassMap
+Package tagpdf Info: writing NameSpaces
+Package tagpdf Info: writing StructElems
+Package tagpdf Info: writing Root

--- a/required/tools/calc.dtx
+++ b/required/tools/calc.dtx
@@ -1325,7 +1325,6 @@
 %    {Changed kernel macro}
 % \changes{v4.3a}{2024/11/03}
 %    {Suspend Tagging}
-%    {Changed kernel macro}    
 % \begin{macro}{\settototalheight}
 % \changes{v4.2}{2005/08/06}
 %    {Added macro}

--- a/required/tools/calc.dtx
+++ b/required/tools/calc.dtx
@@ -40,7 +40,7 @@
 %<driver> \ProvidesFile{calc.drv}
 % \fi
 %         \ProvidesFile{calc.dtx}
-          [2023/07/08 v4.3 Infix arithmetic (KKT,FJ)]
+          [2024/11/03 v4.3a Infix arithmetic (KKT,FJ)]
 %
 % \iffalse
 %<*driver>
@@ -1323,6 +1323,9 @@
 % \begin{macro}{\@settodim}
 % \changes{v4.2}{2005/08/06}
 %    {Changed kernel macro}
+% \changes{v4.3a}{2024/11/03}
+%    {Suspend Tagging}
+%    {Changed kernel macro}    
 % \begin{macro}{\settototalheight}
 % \changes{v4.2}{2005/08/06}
 %    {Added macro}
@@ -1333,7 +1336,8 @@
 % A search on the internet confirmed that some people do that kind of thing.
 %    \begin{macrocode}
 \def\@settodim#1#2#3{%
-  \setbox\@tempboxa\hbox{{#3}}%
+  \setbox\@tempboxa\hbox
+    {{\SuspendTagging{\@settodim}#3\ResumeTagging{\@settodim}}}%
   \dimen@ii=\z@
   \@tf@r\reserved@a #1\do{%
   \advance\dimen@ii\reserved@a\@tempboxa}%
@@ -1354,4 +1358,3 @@
 %
 % \Finale
 \endinput
-

--- a/required/tools/changes.txt
+++ b/required/tools/changes.txt
@@ -5,6 +5,9 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 =======================================================================
 
+2024-11-03  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
+	* calc.dtx: suspend tagging in \@settodim (tagging/628)
+
 ================================================================================
 All changes above are only part of the development branch for the next release.
 ================================================================================


### PR DESCRIPTION
This suspends tagging also in the @settodim definition of calc sty for https://github.com/latex3/tagging-project/issues/628

# Internal housekeeping

## Status of pull request
- Ready to merge

## Checklist of required changes before merge will be approved
- [x] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [n/a ] Rollback provided (if necessary)?
- [n/a ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
