### PR TITLE
Add support for "\={i}" to OT1 and T1

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,10 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
+2024-11-06  Joseph Wright  <Joseph.Wright@latex-project.org>
+	* ltoutenc.dtx
+	Add support for \={i} to OT1 and T1
+
 2024-11-05 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
 	* ltproperties.dtx: add missing variants (gh/1532).
 

--- a/base/ltoutenc.dtx
+++ b/base/ltoutenc.dtx
@@ -37,14 +37,14 @@
 %<TS1>\ProvidesFile{ts1enc.def}[2001/06/05 v3.0e (jk/car/fm)
 %<TU>\ProvidesFile{tuenc.def}
 %<package>\ProvidesPackage{fontenc}
-%<OT1|T1|OMS|OML|OT4|TU|package> [2021/04/29 v2.0v
+%<OT1|T1|OMS|OML|OT4|TU|package> [2024/11/06 v2.1b
 %<OT1|T1|OMS|OML|OT4|TS1|TU>      Standard LaTeX file]
 %<package>                        Standard LaTeX package]
 %
 %<*driver>
 % \fi
 \ProvidesFile{ltoutenc.dtx}
-             [2024/02/08 v2.1a LaTeX Kernel (font encodings)]
+             [2024/11/06 v2.1b LaTeX Kernel (font encodings)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltoutenc.dtx}
@@ -1827,6 +1827,7 @@
 %                             T1, pr/3295}
 % \changes{v1.94}{2001/06/05}{Text composite Commands need kludges for
 %                               `,' -- see tlb1903.lvt}
+% \changes{v2.1b}{2024/11/06}{Support for macron-i for OT1}
 %    \begin{macrocode}
 \DeclareTextComposite{\.}{OT1}{i}{`\i}
 \DeclareTextComposite{\.}{OT1}{\i}{`\i}
@@ -1834,6 +1835,7 @@
 \DeclareTextCompositeCommand{\'}{OT1}{i}{\@tabacckludge'\i}
 \DeclareTextCompositeCommand{\^}{OT1}{i}{\^\i}
 \DeclareTextCompositeCommand{\"}{OT1}{i}{\"\i}
+\DeclareTextCompositeCommand{\=}{OT1}{i}{\=\i}
 %    \end{macrocode}
 %
 % T1 encoding is given more extensive set of overloads for \verb|\c|
@@ -2275,6 +2277,12 @@
 \DeclareTextCompositeCommand{\c}{T1}{R}{\textcommabelow{R}}
 \DeclareTextCompositeCommand{\c}{T1}{r}{\textcommabelow{r}}
 \fi
+%    \end{macrocode}
+%
+% \changes{v2.1b}{2024/11/06}{Support for macron-i for T1}
+% One oddity.
+%    \begin{macrocode}
+\DeclareTextCompositeCommand{\=}{T1}{\i}{\=\i}
 %    \end{macrocode}
 %
 %    \begin{macrocode}


### PR DESCRIPTION
# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
- Under development
- [x] Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated

I'm not seeing a need for rollback here or a news entry as this is an edge case - but if I'm wrong, do say!