### PR TITLE
Fixes missing argument of a \newsocket

### DIFF
--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -1,3 +1,6 @@
+2024-11-21 Ulrike Fischer <Ulrike.Fischer@latex-project.org>
+	* latex-lab-float.dtx: Correct socket declaration.
+
 2024-11-18 Joseph Wright <Joseph.Wright@latex-project.org>
 	* latex-lab-math.dtx: Use "@@" for a couple of internals
 

--- a/required/latex-lab/latex-lab-float.dtx
+++ b/required/latex-lab/latex-lab-float.dtx
@@ -549,7 +549,7 @@
  }
 %    \end{macrocode}
 % These socket are currently defined in tagpdf.
-% \changes{v0.6j}{2024-11-21}
+% \changes{v0.81g}{2024-11-21}{add missing argument to socket}
 %    \begin{macrocode}
 \str_if_exist:cF { l__socket_tagsupport/para/begin_plug_str } 
  {

--- a/required/latex-lab/latex-lab-float.dtx
+++ b/required/latex-lab/latex-lab-float.dtx
@@ -16,8 +16,8 @@
 %
 % for those people who are interested or want to report an issue.
 %
-\def\ltlabfloatdate{2024-09-20}
-\def\ltlabfloatversion{0.81f}
+\def\ltlabfloatdate{2024-11-21}
+\def\ltlabfloatversion{0.81g}
 %<*driver>
 \documentclass{l3doc}
 \EnableCrossrefs
@@ -549,11 +549,12 @@
  }
 %    \end{macrocode}
 % These socket are currently defined in tagpdf.
+% \changes{v0.6j}{2024-11-21}
 %    \begin{macrocode}
 \str_if_exist:cF { l__socket_tagsupport/para/begin_plug_str } 
  {
-   \NewSocket{tagsupport/para/begin} 
-   \NewSocket{tagsupport/para/end} 
+   \NewSocket{tagsupport/para/begin}{0} 
+   \NewSocket{tagsupport/para/end}{0} 
  }
 %    \end{macrocode}
 %


### PR DESCRIPTION
normally not relevant but as shown on tex.sx people can actually find that

# Internal housekeeping
## Status of pull request
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
