### PR TITLE
Fix inconsistent local/global assignment (gh/1574)

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,10 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
+2024-12-03  Yukai Chou  <muzimuzhi@gmail.com>
+	* ltmarks.dtx (subsection{Allocating new mark classes}):
+	Fix inconsistent local/global assignment (gh/1574)
+
 2024-11-27  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 
 	* ltfssdcl.dtx (section{Interface Commands}):

--- a/base/ltmarks.dtx
+++ b/base/ltmarks.dtx
@@ -17,7 +17,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltmarks.dtx}
-             [2024/11/14 v1.1a LaTeX Kernel (Marks)]
+             [2024/12/03 v1.1b LaTeX Kernel (Marks)]
 % \iffalse
 %
 \documentclass{l3doc}
@@ -979,7 +979,8 @@
 %
 %
 %  \begin{macro}{\@@_init_region:nn,\c_@@_empty_tl}
-%    
+% \changes{v1.1b}{2024/12/03}{Fix inconsistent local/global assignment (gh/1574)}
+%
 %    For each class (\texttt{\#2}) and region (\texttt{\#1}), we need
 %    three token lists: one for top, first, and last. The default value to be
 %    returned is \enquote{empty}.
@@ -988,12 +989,12 @@
   \tl_new:c { g_@@_#1_top_   #2 _tl }
   \tl_new:c { g_@@_#1_first_ #2 _tl }
   \tl_new:c { g_@@_#1_last_  #2 _tl }
-  \tl_set_eq:cN  { g_@@_#1_top_   #2 _tl } \c_@@_empty_tl
-  \tl_set_eq:cN  { g_@@_#1_first_ #2 _tl } \c_@@_empty_tl
-  \tl_set_eq:cN  { g_@@_#1_last_  #2 _tl } \c_@@_empty_tl
+  \tl_gset_eq:cN  { g_@@_#1_top_   #2 _tl } \c_@@_empty_tl
+  \tl_gset_eq:cN  { g_@@_#1_first_ #2 _tl } \c_@@_empty_tl
+  \tl_gset_eq:cN  { g_@@_#1_last_  #2 _tl } \c_@@_empty_tl
 }
 %    \end{macrocode}
-%    
+%
 %    All marks will have an identification in the form of a
 %    number\footnote{There are a few cases where special
 %    identification strings are used, e.g., \texttt{2.09-compat}.} that is

--- a/base/testfiles-ltmarks/xmarks-001.lvt
+++ b/base/testfiles-ltmarks/xmarks-001.lvt
@@ -7,6 +7,9 @@
 \pagestyle{headings}
 
 \input{regression-test}
+\ExplSyntaxOn
+\debug_on:n { check-declarations, deprecation }
+\ExplSyntaxOff
 
 \DebugMarksOn
 


### PR DESCRIPTION
Thanks to the refactoring taken place in 7726e8545 (ltmarks & multicol (#1548), 2024-11-18), only a few lines need to be altered.

I adapted an existing test instead of adding a new one.

Need a ltnews entry?

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
