### PR TITLE
Replace \@tempa with \reserved@a in \Ref

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,10 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
+2024-12-10  Yukai Chou  <muzimuzhi@gmail.com>
+	* ltxref.dtx (subsection{Cross Referencing})
+	Replace \@tempa with \reserved@a in \Ref (gh/1579)
+
 2024-12-03  Yukai Chou  <muzimuzhi@gmail.com>
 	* ltmarks.dtx (subsection{Allocating new mark classes}):
 	Fix inconsistent local/global assignment (gh/1574)

--- a/base/ltxref.dtx
+++ b/base/ltxref.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltxref.dtx}
-             [2024/09/20 v1.1r LaTeX Kernel (Cross Referencing)]
+             [2024/12/10 v1.1s LaTeX Kernel (Cross Referencing)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltxref.dtx}
@@ -549,10 +549,11 @@
 %  \changes{v1.1l}{2019/08/22}{Commanded moved from \texttt{varioref.sty}}
 %  \changes{v1.1p}{2022/04/12}{Macro reimplemented with a starred version}%
 %    \begin{macrocode}
-\def\@kernel@Ref#1{\protected@edef\@tempa{\@kernel@ref{#1}}%
-       \expandafter\MakeUppercase\@tempa}
-\def\@kernel@sRef#1{\protected@edef\@tempa{\@kernel@sref{#1}}%
-       \expandafter\MakeUppercase\@tempa}
+%  \changes{v1.1s}{2024/12/10}{Replace \cs{@tempa} with \cs{reserved@a} (gh/1579)}
+\def\@kernel@Ref#1{\protected@edef\reserved@a{\@kernel@ref{#1}}%
+       \expandafter\MakeUppercase\reserved@a}
+\def\@kernel@sRef#1{\protected@edef\reserved@a{\@kernel@sref{#1}}%
+       \expandafter\MakeUppercase\reserved@a}
 \NewDocumentCommand\Ref{s}
    {\IfBooleanTF{#1}{\@kernel@sRef}{\@kernel@Ref}}
 %    \end{macrocode}
@@ -583,8 +584,8 @@
 %<latexrelease>       {\csname p@#1\expandafter\endcsname\csname the#1\endcsname}%
 %<latexrelease>}
 %<latexrelease>\def\labelformat#1{\expandafter\def\csname p@#1\endcsname##1}
-%<latexrelease>\DeclareRobustCommand\Ref[1]{\protected@edef\@tempa{\ref{#1}}%
-%<latexrelease>   \expandafter\MakeUppercase\@tempa}
+%<latexrelease>\DeclareRobustCommand\Ref[1]{\protected@edef\reserved@a{\ref{#1}}%
+%<latexrelease>   \expandafter\MakeUppercase\reserved@a}
 %<latexrelease>\EndIncludeInRelease
 %<latexrelease>\IncludeInRelease{2019/10/01}%
 %<latexrelease>                 {\refstepcounter}{Add \labelformat and \Ref}%
@@ -594,8 +595,8 @@
 %<latexrelease>      {\csname p@#1\expandafter\endcsname\csname the#1\endcsname}%
 %<latexrelease>}
 %<latexrelease>\def\labelformat#1{\expandafter\def\csname p@#1\endcsname##1}
-%<latexrelease>\DeclareRobustCommand\Ref[1]{\protected@edef\@tempa{\ref{#1}}%
-%<latexrelease>   \expandafter\MakeUppercase\@tempa}
+%<latexrelease>\DeclareRobustCommand\Ref[1]{\protected@edef\reserved@a{\ref{#1}}%
+%<latexrelease>   \expandafter\MakeUppercase\reserved@a}
 %<latexrelease>\EndIncludeInRelease
 %<latexrelease>\IncludeInRelease{0000/00/00}%
 %<latexrelease>                 {\refstepcounter}{Add \labelformat and \Ref}%


### PR DESCRIPTION
2019/10/01 and 2020/10/01 rollbacks for `\Ref` are updated accordingly.

See #1579.

**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
