### PR TITLE
use xhtml and mathml namespaces when writing mathml file

### DIFF
--- a/required/latex-lab/latex-lab-math.dtx
+++ b/required/latex-lab/latex-lab-math.dtx
@@ -875,7 +875,7 @@
   {
     <!DOCTYPE~html>
     \iow_newline:
-    <html>
+    <html~ xmlns="http://www.w3.org/1999/xhtml">
     \iow_newline:
   }
 \tl_new:N \l_@@_mathml_write_before_tl
@@ -1252,7 +1252,7 @@
     \iow_now:Ne \g_@@_writedummy_iow
      {
       \l_@@_mathml_write_before_tl
-      <math></math>
+      <math~ xmlns="http://www.w3.org/1998/Math/MathML"></math>
       \c_@@_mathml_write_after_tl
       }
  }

--- a/required/latex-lab/testfiles-math-luatex/mathml-luamml-1.tlg
+++ b/required/latex-lab/testfiles-math-luatex/mathml-luamml-1.tlg
@@ -2,7 +2,7 @@ This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 -------- mathml-luamml-1-luamml-mathml.html (start) ---------
 (mathml-luamml-1-luamml-mathml.html) <!DOCTYPE html>^^M
-<html>^^M
+<html xmlns="http://www.w3.org/1999/xhtml">^^M
 ^^M
 <div>^^M
 <h2>\mml 1</h2>^^M

--- a/required/latex-lab/testfiles-math/mathml-AF-hash.tlg
+++ b/required/latex-lab/testfiles-math/mathml-AF-hash.tlg
@@ -2,20 +2,20 @@ This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 -------- mathml-AF-hash-mathml-dummy.html (start) ---------
 (mathml-AF-hash-mathml-dummy.html) <!DOCTYPE html>^^M
-<html>^^M
+<html xmlns="http://www.w3.org/1999/xhtml">^^M
 ^^M
 <div>^^M
 <h2>\mml 1</h2>^^M
 <p>\begin {equation}\sqrt {x^2}=\lvert x\rvert \end {equation}</p>^^M
 <p>97E0ED65D7DB327BEE6496118E96C5B1</p>^^M
-<math></math>^^M
+<math xmlns="http://www.w3.org/1998/Math/MathML"></math>^^M
 </div>^^M
 ^^M
 <div>^^M
 <h2>\mml 2</h2>^^M
 <p>\begin {equation*}\sqrt {x^2}=\lvert x\rvert \end {equation*}</p>^^M
 <p>626AD6FB6CF94CF1BE7FF5A7B8335B53</p>^^M
-<math></math>^^M
+<math xmlns="http://www.w3.org/1998/Math/MathML"></math>^^M
 </div>^^M
 ^^M
 </html>^^M

--- a/required/latex-lab/testfiles-math/mathml-write.tlg
+++ b/required/latex-lab/testfiles-math/mathml-write.tlg
@@ -2,34 +2,34 @@ This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 -------- mathml-write-mathml-dummy.html (start) ---------
 (mathml-write-mathml-dummy.html) <!DOCTYPE html>^^M
-<html>^^M
+<html xmlns="http://www.w3.org/1999/xhtml">^^M
 ^^M
 <div>^^M
 <h2>\mml 1</h2>^^M
 <p>$x$</p>^^M
 <p>332CC365A4987AACCE0EAD01B8BDCC0B</p>^^M
-<math></math>^^M
+<math xmlns="http://www.w3.org/1998/Math/MathML"></math>^^M
 </div>^^M
 ^^M
 <div>^^M
 <h2>\mml 2</h2>^^M
 <p>$y$</p>^^M
 <p>DECEEAF6940A8C7A5A02373728002B0F</p>^^M
-<math></math>^^M
+<math xmlns="http://www.w3.org/1998/Math/MathML"></math>^^M
 </div>^^M
 ^^M
 <div>^^M
 <h2>\mml 3</h2>^^M
 <p>$x>y$</p>^^M
 <p>DA3B83BB996516B60C4CD3E6BF444044</p>^^M
-<math></math>^^M
+<math xmlns="http://www.w3.org/1998/Math/MathML"></math>^^M
 </div>^^M
 ^^M
 <div>^^M
 <h2>\mml 4</h2>^^M
 <p>\begin {equation*}\sqrt {x^2}=\lvert x\rvert \end {equation*}</p>^^M
 <p>626AD6FB6CF94CF1BE7FF5A7B8335B53</p>^^M
-<math></math>^^M
+<math xmlns="http://www.w3.org/1998/Math/MathML"></math>^^M
 </div>^^M
 ^^M
 </html>^^M


### PR DESCRIPTION
If the matching PR in the tagging project https://github.com/latex3/tagging-project/pull/775 is merged, we will want  to use namespaced elements in the MathML files. This PR adds the matching namespaces when writing out dummy files.

