### PR TITLE
fix missing `\cs` and missing backslash

### DIFF
--- a/base/ltfilehook.dtx
+++ b/base/ltfilehook.dtx
@@ -34,7 +34,7 @@
 %\iffalse
 %<*driver,structuredlog>
 %\fi
-\def\ltfilehookdate{2024/03/13}
+\def\ltfilehookdate{2024/12/23}
 \def\ltfilehookversion{v1.0o}
 %\iffalse
 %</driver,structuredlog>
@@ -1292,7 +1292,7 @@
 %</2ekernel>
 %<*2ekernel|latexrelease>
 %<latexrelease>\IncludeInRelease{2020/10/01}%
-%<latexrelease>          {@@_set_curr_file:nNN}{Set curr file}%
+%<latexrelease>          {\@@_set_curr_file:nNN}{Set curr file}%
 \ExplSyntaxOn
 %<@@=filehook>
 \cs_new_protected:Npn \@@_set_curr_file:nNN #1

--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -32,7 +32,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{lthooks.dtx}
-             [2024/11/26 v1.1l LaTeX Kernel (hooks)]
+             [2024/12/23 v1.1l LaTeX Kernel (hooks)]
 % \iffalse
 %
 \documentclass{l3doc}
@@ -7803,7 +7803,7 @@
 %
 %  \begin{macro}{\ClearHookRule}
 %    A special setup rule that removes an existing relation.
-%    Basically {@@_rule_gclear:nnn} plus fixing the property list for debugging.
+%    Basically \cs{@@_rule_gclear:nnn} plus fixing the property list for debugging.
 %    \fmiinline{Needs perhaps an L3 interface, or maybe it should get dropped?}
 %    \begin{macrocode}
 \NewDocumentCommand \ClearHookRule { m m m }


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

# Internal housekeeping

Fixes a missing `\cs` in lthooks.dtx and a missing backslash in ltfilehook.dtx, both mentioned in #1596. This does not fix any other issues from #1596.

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
