### PR TITLE
do not expand mark content in debug messages

### DIFF
--- a/base/ltmarks.dtx
+++ b/base/ltmarks.dtx
@@ -17,7 +17,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltmarks.dtx}
-             [2024/12/25 v1.1b LaTeX Kernel (Marks)]
+             [2025/01/10 v1.1c LaTeX Kernel (Marks)]
 % \iffalse
 %
 \documentclass{l3doc}
@@ -1476,7 +1476,14 @@
                 {
 %<*trace>
                   \@@_debug:n { \iow_term:x { Marks:~ extract~ last~
-                       mark~ for~ class~ '##1'~ =~  \g_@@_tmp_tl } }
+%    \end{macrocode}
+%    The mark content in \cs{g_@@_tmp_tl} may contain aribtrary code
+%    that may react badly if it is expanded in a write. So we better
+%    avoid that expansion, otherwise debugging might generate spurious
+%    errors when turned on.
+% \changes{v1.1c}{2025/01/10}{Do not expand mark content while debugging}
+%    \begin{macrocode}
+                       mark~ for~ class~ '##1'~ =~ \exp_not:o \g_@@_tmp_tl } }
 %</trace>
                   \tl_gput_right:Ne \g_@@_last_marks_tl
                      { \mark_insert:nn {##1} { \@@_drop_id:o { \g_@@_tmp_tl } } }
@@ -1488,10 +1495,15 @@
 %    faster in case there is none.
 %    \begin{macrocode}
 %<*trace>
-                  \@@_debug:n { \iow_term:x { Marks:~ extract~ first~
-                      mark~ for~ class~ '##1'~ =~
-                      \tex_splitfirstmarks:D
+                  \@@_debug:n { \iow_term:x {
+                      Marks:~ extract~ first~ mark~ for~ class~ '##1'~ =~
+%    \end{macrocode}
+%    Again no expansion for the mark content.
+%    \begin{macrocode}
+                      \exp_not:o {
+                        \tex_splitfirstmarks:D
                         \use:c { c_@@_class_##1_mark }
+                      }
                   } }
 %</trace>
                   \tl_gput_right:Ne \g_@@_first_marks_tl


### PR DESCRIPTION
# Internal housekeeping

## Status of pull request

 Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [n/a] Rollback provided (if necessary)?
- [n/a] `ltnewsX.tex` (and/or `latexchanges.tex`) updated

really just internal to debug mode
