### PR TITLE
correct doc about list handler (ltluatex)

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,12 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
+2025-01-10  Udi Fogiel  <udi@udifogiel.com>
+
+	* ltluatex.dtx (subsubsection{Handlers}):
+	Correct documentation about the return value
+	of the list handler
+
 2025-01-10  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 
 	* ltmarks.dtx (subsection{Updating mark structures}):

--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,7 +6,7 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
-2025-01-10  Udi Fogiel  <udi@udifogiel.com>
+2025-01-11  Udi Fogiel  <udi@udifogiel.com>
 
 	* ltluatex.dtx (subsubsection{Handlers}):
 	Correct documentation about the return value

--- a/base/ltluatex.dtx
+++ b/base/ltluatex.dtx
@@ -30,7 +30,7 @@
 %<*plain>
 % \fi
 % \ProvidesFile{ltluatex.dtx}
-[2024/08/16 v1.2e
+[2025/01/11 v1.2e
 % LaTeX Kernel (LuaTeX support)^^A
 %\iffalse
 %<plain>   LuaTeX support for plain TeX (core)%
@@ -1676,14 +1676,15 @@ end
 %     passed the return value of the previous (and the other arguments
 %     untouched, if any). The return value is that of the last function;
 %   \item[list] is a specialized variant of \emph{data} for functions
-%     filtering node lists. Such functions may return either the head of a
-%     modified node list, or the boolean values |true| or |false|. The
-%     functions are chained the same way as for \emph{data} except that for
-%     the following. If
-%     one function returns |false|, then |false| is immediately returned and
-%     the following functions are \emph{not} called. If one function returns
+%     filtering node lists. Such functions are called with a node list head
+%     as the first argument and may return either the head of a modified node list,
+%     or the boolean values |true| or |false|.
+%     The functions are chained the same way as for \emph{data} except for
+%     the following cases.
+%     If a function returns |false|, then |false| is immediately returned and
+%     the following functions are \emph{not} called. If a function returns
 %     |true|, then the same head is passed to the next function. If all
-%     functions return |true|, then |true| is returned, otherwise the return
+%     functions return |true|, then the original head is returned, otherwise the return
 %     value of the last function not returning |true| is used.
 %   \item[reverselist] is a specialized variant of \emph{list} which executes
 %     functions in inverse order.


### PR DESCRIPTION
The documentation states that of all the functions in the callback returns true then the callback returns true as well, but the following example (and the code) shows that the return value in this case is the head passed to the callback.

```tex
\directlua{
luatexbase.create_callback('foo', 'list', false)
luatexbase.add_to_callback('foo', function(head) print('bar') return true end, 'baz') 
print(luatexbase.call_callback('foo', token.scan_list()))
}\hbox{foo}

\stop
```
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
