### PR TITLE
Fix misplaced `\begin{macrocode}`

### DIFF
--- a/base/classes.dtx
+++ b/base/classes.dtx
@@ -53,7 +53,7 @@
 %<*driver>
 \ProvidesFile{classes.drv}
 %</driver>
-              [2024/06/29 v1.4n
+              [2025/01/22 v1.4n
 %<article|report|book> Standard LaTeX document class]
 %<10pt|11pt|12pt>      Standard LaTeX file (size option)]
 %    \end{macrocode}

--- a/base/classes.dtx
+++ b/base/classes.dtx
@@ -3024,9 +3024,9 @@
 %    Note that this environment is not defined for books.
 % \changes{v1.3e}{1995/06/19}{Added setting of \cs{@endparpenalty}
 %         to avoid page break after abstract heading.}
-%    \begin{macrocode}
 % \changes{v1.3m}{1995/10/23}{Added setting of \cs{beginparpenalty} to
 %    discourage page break before abstract heading.}
+%    \begin{macrocode}
 %<*article|report>
 \if@titlepage
   \newenvironment{abstract}{%

--- a/base/classes.dtx
+++ b/base/classes.dtx
@@ -3024,7 +3024,7 @@
 %    Note that this environment is not defined for books.
 % \changes{v1.3e}{1995/06/19}{Added setting of \cs{@endparpenalty}
 %         to avoid page break after abstract heading.}
-% \changes{v1.3m}{1995/10/23}{Added setting of \cs{beginparpenalty} to
+% \changes{v1.3m}{1995/10/23}{Added setting of \cs{@beginparpenalty} to
 %    discourage page break before abstract heading.}
 %    \begin{macrocode}
 %<*article|report>


### PR DESCRIPTION
This PR fixes a misplaced `\begin{macrocode}` and a typo.

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] ~~Version and~~ date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
