### PR TITLE
Docu fixes for `\usepackage` hook sequence

### DIFF
--- a/base/ltfilehook.dtx
+++ b/base/ltfilehook.dtx
@@ -34,7 +34,7 @@
 %\iffalse
 %<*driver,structuredlog>
 %\fi
-\def\ltfilehookdate{2025/01/24}
+\def\ltfilehookdate{2025/01/25}
 \def\ltfilehookversion{v1.0o}
 %\iffalse
 %</driver,structuredlog>
@@ -252,7 +252,7 @@
 %  \begin{tabbing}
 %    mm\=mm\=mm\=mm\=\kill
 %    \>\cs{UseHook}\texttt{\{\hook{package/before}\}} \\
-%    \>\cs{UseHook}\texttt{\{\hook{package/\meta{package name}/before}\}} \\[5pt]
+%    \>\cs{UseOneTimeHook}\texttt{\{\hook{package/\meta{package name}/before}\}} \\[5pt]
 %    \>\>\cs{UseHook}\texttt{\{\hook{file/before}\}} \\
 %    \>\>\cs{UseHook}\texttt{\{\hook{file/\meta{package name}.sty/before}\}} \\
 %    \>\>\> \meta{package contents} \\
@@ -260,7 +260,7 @@
 %    \>\>\cs{UseHook}\texttt{\{\hook{file/after}\}} \\[5pt]
 %    \>\>\emph{code from \cs{AtEndOfPackage} if
 %                used inside the package} \\[5pt]
-%    \>\cs{UseHook}\texttt{\{\hook{package/\meta{package name}/after}\}} \\
+%    \>\cs{UseOneTimeHook}\texttt{\{\hook{package/\meta{package name}/after}\}} \\
 %    \>\cs{UseHook}\texttt{\{\hook{package/after}\}}
 %  \end{tabbing}
 %    and similar for class file loading, except that \hook{package/}


### PR DESCRIPTION
Follow-up to a97249805c851dcf15b10bb8475ff6cddaa27d2a and 591d18c575286920150c9caa8d7099f46b3b5e43. See also #1634.

**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] <s>Version and</s> date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
