### PR TITLE
Correct \changes entries

### DIFF
--- a/base/ltpage.dtx
+++ b/base/ltpage.dtx
@@ -204,7 +204,7 @@
 %                             error (pr/3203).}
 % \changes{v1.0m}{2020/07/27}{Don't make the command \cs{long} (gh/354)}
 % \changes{v1.0n}{2022/04/04}{Interface with new mark mechanism}
-% \changes{v1.1a}{2025/06/01}{}
+% \changes{v1.0o}{2024/11/16}{Drop legacy mark support}
 %    \begin{macrocode}
 \ExplSyntaxOn
 \DeclareRobustCommand*\markboth[2]{%
@@ -216,7 +216,7 @@
 %
 % \changes{v1.0m}{2020/07/27}{Don't make the command \cs{long} (gh/354)}
 % \changes{v1.0n}{2022/04/04}{Interface with new mark mechanism}
-% \changes{v1.1a}{2025/06/01}{}
+% \changes{v1.0o}{2024/11/16}{Drop legacy mark support}
 %    \begin{macrocode}
 \DeclareRobustCommand*\markright[1]{%
     \mark_insert:nn{2e-right}{#1}


### PR DESCRIPTION
Introduced by 7726e8545 (ltmarks & multicol (#1548), 2024-11-18).

In PR commit https://github.com/latex3/latex2e/commit/e82f1f0b0b46b4c39ff4af82ab430380fca973c2 (which was part of the merged PR #1548), two copies of flawed `\changes{v1.1a}{2025/06/01}{}` were added to `base/ltpage.dtx`. They both used date and version in the future (the `ltpage.dtx` was at '2024/11/16 v1.0o', and empty descriptions.

Relevant diff lines
```diff
diff --git a/base/ltpage.dtx b/base/ltpage.dtx
index f4efe0fd5..2ac5ad3db 100644
--- a/base/ltpage.dtx
+++ b/base/ltpage.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltpage.dtx}
-             [2022/04/03 v1.0n LaTeX Kernel (page style setup)]
+             [2024/11/16 v1.0o LaTeX Kernel (page style setup)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltpage.dtx}
@@ -180,8 +180,8 @@
 %    \begin{macrocode}
 %</2ekernel>
 %<*2ekernel|latexrelease>
-%<latexrelease>\IncludeInRelease{2022/06/01}%
-%<latexrelease>                 {\markboth}{New mark support}%
+%<latexrelease>\IncludeInRelease{2025/06/01}%
+%<latexrelease>                 {\markboth}{Drop legacy mark support}%
 %    \end{macrocode}
 %
 %
@@ -204,61 +204,24 @@
 %                             error (pr/3203).}
 % \changes{v1.0m}{2020/07/27}{Don't make the command \cs{long} (gh/354)}
 % \changes{v1.0n}{2022/04/04}{Interface with new mark mechanism}
+% \changes{v1.1a}{2025/06/01}{}
 %    \begin{macrocode}
 \ExplSyntaxOn
 \DeclareRobustCommand*\markboth[2]{%
```

This PR corrects these two `\changes` entries. Found when digging for #1653.

**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

# Internal housekeeping

## Status of pull request

- Feedback wanted 
- Ready to merge

## Checklist of required changes before merge will be approved
- [n/a] Test file(s) added
- [n/a] Version and date string updated in changed source files
- [n/a] Relevant `\changes` entries in source included
- [n/a] Relevant `changes.txt` updated
- [n/a] Rollback provided (if necessary)?
- [n/a] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
