### PR TITLE
Indent verbatim content and fix a typo

### DIFF
--- a/base/doc/clsguide.tex
+++ b/base/doc/clsguide.tex
@@ -42,7 +42,7 @@
     \texttt{clsguide.tex} for full details.}%
 }
 
-\date{2025-02-20}
+\date{2025-04-01}
 
 \NewDocumentCommand\cs{m}{\texttt{\textbackslash\detokenize{#1}}}
 \NewDocumentCommand\marg{m}{\arg{#1}}
@@ -865,14 +865,14 @@ The part of the \meta{key} before the \m{property} is the \m{name}, with the
 
 For example, with
 \begin{verbatim}
-\DeclareKeys[mypkg]
- {
-   draft.if          = @mypkg@draft      ,
-   draft.usage       = preamble          ,
-   name.store        = \@mypkg@name      ,
-   name.usage        = load              ,
-   second-name.store = \@mypkg@other@name
- }
+   \DeclareKeys[mypkg]
+     {
+       draft.if          = @mypkg@draft      ,
+       draft.usage       = preamble          ,
+       name.store        = \@mypkg@name      ,
+       name.usage        = load              ,
+       second-name.store = \@mypkg@other@name
+     }
 \end{verbatim}
 three options would be created. The option \texttt{draft} can be given anywhere
 in the preamble, and will set a switch called |\if@mypkg@draft|. The option
@@ -894,9 +894,9 @@ e.g.~by forwarding to another package. The entire option is available as
 may not contain an |=|~sign. For example, this may be used to pass an
 unknown option on to a non-keyval class such as \pkg{article}:
 \begin{verbatim}
-\DeclareUnknownKeyHandler{%
-  \PassOptionsToClass{\CurrentOption}{article}
-}
+   \DeclareUnknownKeyHandler{%
+     \PassOptionsToClass{\CurrentOption}{article}
+   }
 \end{verbatim}
 
 \begin{decl}
@@ -956,13 +956,13 @@ explicitly supplied or passed on by |\PassOptionsToPackage|.
 The main purpose of |\LoadClassWithOptions| is to allow one class to simply
 build on another, for example:
 \begin{verbatim}
-  \LoadClassWithOptions{article}
+   \LoadClassWithOptions{article}
 \end{verbatim}
 This should be compared with the slightly different construction
 \begin{verbatim}
-  \DeclareOption*{\PassOptionsToClass{\CurrentOption}{article}}
-  \ProcessOptions\relax
-  \LoadClass{article}
+   \DeclareOption*{\PassOptionsToClass{\CurrentOption}{article}}
+   \ProcessOptions\relax
+   \LoadClass{article}
 \end{verbatim}
 As used above, the effects are more or less the same, but the first is a lot
 less to type; also the |\LoadClassWithOptions| method runs slightly quicker.
@@ -970,16 +970,16 @@ less to type; also the |\LoadClassWithOptions| method runs slightly quicker.
 If, however, the class declares options of its own then the two constructions
 are different. Compare, for example:
 \begin{verbatim}
-  \DeclareOption{landscape}{\@landscapetrue}
-  \ProcessOptions\relax
-  \LoadClassWithOptions{article}
+   \DeclareOption{landscape}{\@landscapetrue}
+   \ProcessOptions\relax
+   \LoadClassWithOptions{article}
 \end{verbatim}
 with:
 \begin{verbatim}
-  \DeclareOption{landscape}{\@landscapetrue}
-  \DeclareOption*{\PassOptionsToClass{\CurrentOption}{article}}
-  \ProcessOptions\relax
-  \LoadClass{article}
+   \DeclareOption{landscape}{\@landscapetrue}
+   \DeclareOption*{\PassOptionsToClass{\CurrentOption}{article}}
+   \ProcessOptions\relax
+   \LoadClass{article}
 \end{verbatim}
 In the first example, the \textsf{article} class will be loaded with option
 |landscape| precisely when the current class is called with this option. By
@@ -1174,13 +1174,13 @@ team strongly suggest using the L3 programming layer commands in the
 Suppose that you want to define an environment for displaying text that is
 numbered as an equation. A straightforward way to do this is as follows:
 \begin{verbatim}
-  \newenvironment{texteqn}{%
-    \begin{equation}%
-      \begin{minipage}{0.9\linewidth}%
-  }{%
-      \end{minipage}%
-    \end{equation}%
-  }
+   \newenvironment{texteqn}{%
+     \begin{equation}%
+       \begin{minipage}{0.9\linewidth}%
+   }{%
+       \end{minipage}%
+     \end{equation}%
+   }
 \end{verbatim}
 However, if you have tried this then you will probably have noticed that it
 does not work perfectly when used in the middle of a paragraph because an
@@ -1190,14 +1190,14 @@ environment.
 You can avoid this problem using |\ignorespacesafterend|; it should be
 inserted as shown here:
 \begin{verbatim}
-  \newenvironment{texteqn}{%
-    \begin{equation}%
-      \begin{minipage}{0.9\linewidth}%
-  }{%
-      \end{minipage}%
-    \end{equation}%
-    \ignorespacesafterend
-  }
+   \newenvironment{texteqn}{%
+     \begin{equation}%
+       \begin{minipage}{0.9\linewidth}%
+   }{%
+       \end{minipage}%
+     \end{equation}%
+     \ignorespacesafterend
+   }
 \end{verbatim}
 
 This command may also have other uses.
@@ -1260,7 +1260,7 @@ supported
 For example, the case changing command \cs{MakeUppercase} is (conceptually)
 defined as
 \begin{verbatim}
-\ExpandArgs{e}\MakeUppercaseAux{\BCPdata{casing}}{#1}
+   \ExpandArgs{e}\MakeUppercaseAux{\BCPdata{casing}}{#1}
 \end{verbatim}
 where |#1| is the user input and the first argument to
 \cs{MakeUppercaseAux} takes two arguments, the locale and input text.
@@ -1293,7 +1293,7 @@ but note that the label names of \cs{label} and \cs{RecordProperties}
 share a single namespace. This means that you get a \texttt{Label `A'
   multiply defined} warning with the following code:
 \begin{verbatim}
-\label{A}\RecordProperties{A}{abspage}
+   \label{A}\RecordProperties{A}{abspage}
 \end{verbatim}
 
 
@@ -1309,10 +1309,10 @@ this to work the default value for the property would need to be a number too,
 because recorded values aren't known in the first \LaTeX{} run.}
 
 \begin{verbatim}
-\section{A section}
-\RecordProperties{mylabel}{pagenum,counter}
-\RefProperty{mylabel}{counter} % outputs section
-\setcounter{mycounter}{\RefProperty{mylabel}{pagenum}} 
+   \section{A section}
+   \RecordProperties{mylabel}{pagenum,counter}
+   \RefProperty{mylabel}{counter} % outputs section
+   \setcounter{mycounter}{\RefProperty{mylabel}{pagenum}}
 \end{verbatim}
 
 
@@ -1370,9 +1370,9 @@ immediately when \cs{RecordProperties} is used but during the next
    \cs{pdfsavepos}/\cs{savepos}.  E.g.~(if \pkg{bidi} is used it can
    be necessary to save the position before and after the label):
    \begin{verbatim}
-     \pdfsavepos 
-     \RecordProperties{myposition}{xpos,ypos}%
-     \pdfsavepos
+      \pdfsavepos
+      \RecordProperties{myposition}{xpos,ypos}%
+      \pdfsavepos
    \end{verbatim}  
 \end{description} 
  
@@ -1393,7 +1393,7 @@ property is referenced but not yet known, e.g., in the first run.
 \meta{code} is the code executed when storing the value. For example, the 
 \texttt{pagenum} property is declared as 
 \begin{verbatim}
-\NewProperty{pagenum}{shipout}{0}{\the\value{page}}
+   \NewProperty{pagenum}{shipout}{0}{\the\value{page}}
 \end{verbatim}
 
 The commands related to properties are offered as a set of CamelCase
@@ -1419,7 +1419,7 @@ Implementing this mechanism requires a number of steps and a family of commands
 which allow variation in outcomes. A typical use of templates will make use of
 most or all of |\NewTemplateType|, |\DeclareTemplateInterface|,
 |\DeclareTemplateCode|, |\DeclareInstance| and |\UseInstance|, plus potentially
-some more specialised commands. These are descrined in \texttt{lttemplates-doc}
+some more specialised commands. These are described in \texttt{lttemplates-doc}
 in full detail.
 
 \subsection{Preparing link targets}


### PR DESCRIPTION
* base/doc/clsguide.tex (subsection{Creating and using keyval options}) (subsection{Passing options around})
(subsection{Better user-defined math display environments}) (subsection{Querying localisation})
(subsection{Extended and expandable references of properties}): Consequently indent verbatim content with 3 spaces. (subsubsection{Templates (prototype document commands)}): Fix Typo.

# Internal housekeeping

## Status of pull request

- Feedback wanted 

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated

## Another note
I think there are some stale whitespaces in the file, but I wasn't brave enough to do `M-x whitespace-cleanup RET` to deal with them in one go.  I fixed just 2 where I changed the file.
