### PR TITLE
Drop a surplus `\\` in `\expandableinput` docu

### DIFF
--- a/base/doc/usrguide.tex
+++ b/base/doc/usrguide.tex
@@ -43,7 +43,7 @@
     \texttt{usrguide.tex} for full details.}%
 }
 
-\date{2025-04-23}
+\date{2025-05-01}
 
 \NewDocumentCommand\cs{m}{\texttt{\textbackslash\detokenize{#1}}}
 \NewDocumentCommand\marg{m}{\arg{#1}}
@@ -1315,7 +1315,7 @@ the values \cs{topskip} (\dimeval{\topskip}) and \cs{baselineskip}
 \section{Expandable \cs{input} equivalent}
 
 \begin{decl}
-  |\expandableinput| \arg{filename} \\
+  |\expandableinput| \arg{filename}
 \end{decl}
 The \LaTeX{} definition of \cs{input} cannot be used in places where \TeX{} is
 performing expansion: the classic example is at the start of a tabular cell.


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

ff3c64752 (Add \expandableinput (#1679), 2025-04-30) didn't step the version of `ltexpl.dtx` and used non-latest version and date in the newly added `\changes` entry.

This PR corrects this.

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
