### PR TITLE
Minor followup to #1583

### DIFF
--- a/base/ltfssaxes.dtx
+++ b/base/ltfssaxes.dtx
@@ -1841,6 +1841,9 @@
 \DeclareFontSeriesChangeRule {ulx}{m?}  {x}   {}
 \DeclareFontSeriesChangeRule {ulex}{m?} {ex}  {}
 \DeclareFontSeriesChangeRule {ulux}{m?} {ux}  {}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
 \DeclareFontSeriesChangeRule {eluc}{m?} {uc}  {}
 \DeclareFontSeriesChangeRule {elec}{m?} {ec}  {}
 \DeclareFontSeriesChangeRule {elc}{m?}  {c}   {}
@@ -1850,6 +1853,9 @@
 \DeclareFontSeriesChangeRule {elx}{m?}  {x}   {}
 \DeclareFontSeriesChangeRule {elex}{m?} {ex}  {}
 \DeclareFontSeriesChangeRule {elux}{m?} {ux}  {}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
 \DeclareFontSeriesChangeRule {luc}{m?}  {uc}  {}
 \DeclareFontSeriesChangeRule {lec}{m?}  {ec}  {}
 \DeclareFontSeriesChangeRule {lc}{m?}   {c}   {}
@@ -1859,6 +1865,9 @@
 \DeclareFontSeriesChangeRule {lx}{m?}   {x}   {}
 \DeclareFontSeriesChangeRule {lex}{m?}  {ex}  {}
 \DeclareFontSeriesChangeRule {lux}{m?}  {ux}  {}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
 \DeclareFontSeriesChangeRule {sluc}{m?} {uc}  {}
 \DeclareFontSeriesChangeRule {slec}{m?} {ec}  {}
 \DeclareFontSeriesChangeRule {slc}{m?}  {c}   {}
@@ -1868,6 +1877,9 @@
 \DeclareFontSeriesChangeRule {slx}{m?}  {x}   {}
 \DeclareFontSeriesChangeRule {slex}{m?} {ex}  {}
 \DeclareFontSeriesChangeRule {slux}{m?} {ux}  {}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
 \DeclareFontSeriesChangeRule {uc}{m?}   {uc}  {}
 \DeclareFontSeriesChangeRule {ec}{m?}   {ec}  {}
 \DeclareFontSeriesChangeRule {c}{m?}    {c}   {}
@@ -1877,6 +1889,9 @@
 \DeclareFontSeriesChangeRule {x}{m?}    {x}   {}
 \DeclareFontSeriesChangeRule {ex}{m?}   {ex}  {}
 \DeclareFontSeriesChangeRule {ux}{m?}   {ux}  {}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
 \DeclareFontSeriesChangeRule {sbuc}{m?} {uc}  {}
 \DeclareFontSeriesChangeRule {sbec}{m?} {ec}  {}
 \DeclareFontSeriesChangeRule {sbc}{m?}  {c}   {}
@@ -1886,6 +1901,9 @@
 \DeclareFontSeriesChangeRule {sbx}{m?}  {x}   {}
 \DeclareFontSeriesChangeRule {sbex}{m?} {ex}  {}
 \DeclareFontSeriesChangeRule {sbux}{m?} {ux}  {}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
 \DeclareFontSeriesChangeRule {buc}{m?}  {uc}  {}
 \DeclareFontSeriesChangeRule {bec}{m?}  {ec}  {}
 \DeclareFontSeriesChangeRule {bc}{m?}   {c}   {}
@@ -1895,6 +1913,9 @@
 \DeclareFontSeriesChangeRule {bx}{m?}   {x}   {}
 \DeclareFontSeriesChangeRule {bex}{m?}  {ex}  {}
 \DeclareFontSeriesChangeRule {bux}{m?}  {ux}  {}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
 \DeclareFontSeriesChangeRule {ebuc}{m?} {uc}  {}
 \DeclareFontSeriesChangeRule {ebec}{m?} {ec}  {}
 \DeclareFontSeriesChangeRule {ebc}{m?}  {c}   {}
@@ -1904,6 +1925,9 @@
 \DeclareFontSeriesChangeRule {ebx}{m?}  {x}   {}
 \DeclareFontSeriesChangeRule {ebex}{m?} {ex}  {}
 \DeclareFontSeriesChangeRule {ebux}{m?} {ux}  {}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
 \DeclareFontSeriesChangeRule {ubuc}{m?} {uc}  {}
 \DeclareFontSeriesChangeRule {ubec}{m?} {ec}  {}
 \DeclareFontSeriesChangeRule {ubc}{m?}  {c}   {}
@@ -1926,6 +1950,9 @@
 \DeclareFontSeriesChangeRule {ulx}{?m}  {ul}  {}
 \DeclareFontSeriesChangeRule {ulex}{?m} {ul}  {}
 \DeclareFontSeriesChangeRule {ulux}{?m} {ul}  {}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
 \DeclareFontSeriesChangeRule {eluc}{?m} {el}  {}
 \DeclareFontSeriesChangeRule {elec}{?m} {el}  {}
 \DeclareFontSeriesChangeRule {elc}{?m}  {el}  {}
@@ -1935,6 +1962,9 @@
 \DeclareFontSeriesChangeRule {elx}{?m}  {el}  {}
 \DeclareFontSeriesChangeRule {elex}{?m} {el}  {}
 \DeclareFontSeriesChangeRule {elux}{?m} {el}  {}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
 \DeclareFontSeriesChangeRule {luc}{?m}  {l}   {}
 \DeclareFontSeriesChangeRule {lec}{?m}  {l}   {}
 \DeclareFontSeriesChangeRule {lc}{?m}   {l}   {}
@@ -1944,6 +1974,9 @@
 \DeclareFontSeriesChangeRule {lx}{?m}   {l}   {}
 \DeclareFontSeriesChangeRule {lex}{?m}  {l}   {}
 \DeclareFontSeriesChangeRule {lux}{?m}  {l}   {}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
 \DeclareFontSeriesChangeRule {sluc}{?m} {sl}  {}
 \DeclareFontSeriesChangeRule {slec}{?m} {sl}  {}
 \DeclareFontSeriesChangeRule {slc}{?m}  {sl}  {}
@@ -1953,6 +1986,9 @@
 \DeclareFontSeriesChangeRule {slx}{?m}  {sl}  {}
 \DeclareFontSeriesChangeRule {slex}{?m} {sl}  {}
 \DeclareFontSeriesChangeRule {slux}{?m} {sl}  {}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
 \DeclareFontSeriesChangeRule {uc}{?m}   {m}   {}
 \DeclareFontSeriesChangeRule {ec}{?m}   {m}   {}
 \DeclareFontSeriesChangeRule {c}{?m}    {m}   {}
@@ -1962,6 +1998,9 @@
 \DeclareFontSeriesChangeRule {x}{?m}    {m}   {}
 \DeclareFontSeriesChangeRule {ex}{?m}   {m}   {}
 \DeclareFontSeriesChangeRule {ux}{?m}   {m}   {}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
 \DeclareFontSeriesChangeRule {sbuc}{?m} {sb}  {}
 \DeclareFontSeriesChangeRule {sbec}{?m} {sb}  {}
 \DeclareFontSeriesChangeRule {sbc}{?m}  {sb}  {}
@@ -1971,6 +2010,9 @@
 \DeclareFontSeriesChangeRule {sbx}{?m}  {sb}  {}
 \DeclareFontSeriesChangeRule {sbex}{?m} {sb}  {}
 \DeclareFontSeriesChangeRule {sbux}{?m} {sb}  {}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
 \DeclareFontSeriesChangeRule {buc}{?m}  {b}   {}
 \DeclareFontSeriesChangeRule {bec}{?m}  {b}   {}
 \DeclareFontSeriesChangeRule {bc}{?m}   {b}   {}
@@ -1980,6 +2022,9 @@
 \DeclareFontSeriesChangeRule {bx}{?m}   {b}   {}
 \DeclareFontSeriesChangeRule {bex}{?m}  {b}   {}
 \DeclareFontSeriesChangeRule {bux}{?m}  {b}   {}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
 \DeclareFontSeriesChangeRule {ebuc}{?m} {eb}  {}
 \DeclareFontSeriesChangeRule {ebec}{?m} {eb}  {}
 \DeclareFontSeriesChangeRule {ebc}{?m}  {eb}  {}
@@ -1989,6 +2034,9 @@
 \DeclareFontSeriesChangeRule {ebx}{?m}  {eb}  {}
 \DeclareFontSeriesChangeRule {ebex}{?m} {eb}  {}
 \DeclareFontSeriesChangeRule {ebux}{?m} {eb}  {}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
 \DeclareFontSeriesChangeRule {ubuc}{?m} {ub}  {}
 \DeclareFontSeriesChangeRule {ubec}{?m} {ub}  {}
 \DeclareFontSeriesChangeRule {ubc}{?m}  {ub}  {}

--- a/base/ltfssaxes.dtx
+++ b/base/ltfssaxes.dtx
@@ -1771,6 +1771,18 @@
 %    \end{macrocode}
 %
 %    \begin{macrocode}
+\DeclareFontSeriesChangeRule {uc}{bx}   {bx}  {b}
+\DeclareFontSeriesChangeRule {ec}{bx}   {bx}  {b}
+\DeclareFontSeriesChangeRule {c}{bx}    {bx}  {b}
+\DeclareFontSeriesChangeRule {sc}{bx}   {bx}  {b}
+\DeclareFontSeriesChangeRule {m}{bx}    {bx}  {b}
+\DeclareFontSeriesChangeRule {sx}{bx}   {bx}  {b}
+\DeclareFontSeriesChangeRule {x}{bx}    {bx}  {b}
+\DeclareFontSeriesChangeRule {ex}{bx}   {bx}  {b}
+\DeclareFontSeriesChangeRule {ux}{bx}   {bx}  {b}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
 \DeclareFontSeriesChangeRule {sbuc}{bx} {bx}  {b}
 \DeclareFontSeriesChangeRule {sbec}{bx} {bx}  {b}
 \DeclareFontSeriesChangeRule {sbc}{bx}  {bx}  {b}
@@ -1816,18 +1828,6 @@
 \DeclareFontSeriesChangeRule {ubx}{bx}  {bx}  {b}
 \DeclareFontSeriesChangeRule {ubex}{bx} {bx}  {b}
 \DeclareFontSeriesChangeRule {ubux}{bx} {bx}  {b}
-%    \end{macrocode}
-%
-%    \begin{macrocode}
-\DeclareFontSeriesChangeRule {uc}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {ec}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {c}{bx}    {bx}  {b}
-\DeclareFontSeriesChangeRule {sc}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {m}{bx}    {bx}  {b}
-\DeclareFontSeriesChangeRule {sx}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {x}{bx}    {bx}  {b}
-\DeclareFontSeriesChangeRule {ex}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {ux}{bx}   {bx}  {b}
 %    \end{macrocode}
 %
 %    Here are the special rules for \texttt{m?}:

--- a/base/ltfssaxes.dtx
+++ b/base/ltfssaxes.dtx
@@ -261,10 +261,10 @@
 % \end{itemize}
 %
 % \changes{1.0k}{2024/12/13}{Minor modifications to a few
-%   \cs{DeclareFontSeriesChangeRule} entries (gh/1396)}
+%   \cs{DeclareFontSeriesChangeRule} entries (gh/1583)}
 % \changes{1.0k}{2024/12/13}{Add numerous \cs{DeclareFontSeriesChangeRule}
 %   entries to support the full range of weights (from \texttt{ul} to
-%   \texttt{ub}) and widths (from \texttt{uc} to \texttt{ux}) (gh/1396)}
+%   \texttt{ub}) and widths (from \texttt{uc} to \texttt{ux}) (gh/1583)}
 %    \begin{macrocode}
 \DeclareFontSeriesChangeRule {uluc}{ul} {uluc} {}
 \DeclareFontSeriesChangeRule {uluc}{el} {eluc} {}

--- a/base/ltfssaxes.dtx
+++ b/base/ltfssaxes.dtx
@@ -35,7 +35,7 @@
 %
 %
 \ProvidesFile{ltfssaxes.dtx}
-             [2024/12/16 v1.0k LaTeX Kernel (NFSS Axes handing)]
+             [2025/05/12 v1.0l LaTeX Kernel (NFSS Axes handing)]
 % \iffalse
 \documentclass{ltxdoc}
 \begin{document}

--- a/base/ltfssaxes.dtx
+++ b/base/ltfssaxes.dtx
@@ -1723,329 +1723,329 @@
 %    The following entries handle a request for \texttt{bx} and fall
 %    back to \texttt{b} if that can't be fulfilled.
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {uluc}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {ulec}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {ulc}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {ulsc}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {ul}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {ulsx}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {ulx}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {ulex}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {ulux}{bx} {bx}  {b}
+\DeclareFontSeriesChangeRule {uluc}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {ulec}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {ulc}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {ulsc}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {ul}{bx}   {bx}   {b}
+\DeclareFontSeriesChangeRule {ulsx}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {ulx}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {ulex}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {ulux}{bx} {bx}   {b}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {eluc}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {elec}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {elc}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {elsc}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {el}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {elsx}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {elx}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {elex}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {elux}{bx} {bx}  {b}
+\DeclareFontSeriesChangeRule {eluc}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {elec}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {elc}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {elsc}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {el}{bx}   {bx}   {b}
+\DeclareFontSeriesChangeRule {elsx}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {elx}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {elex}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {elux}{bx} {bx}   {b}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {luc}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {lec}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {lc}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {lsc}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {l}{bx}    {bx}  {b}
-\DeclareFontSeriesChangeRule {lsx}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {lx}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {lex}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {lux}{bx}  {bx}  {b}
+\DeclareFontSeriesChangeRule {luc}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {lec}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {lc}{bx}   {bx}   {b}
+\DeclareFontSeriesChangeRule {lsc}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {l}{bx}    {bx}   {b}
+\DeclareFontSeriesChangeRule {lsx}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {lx}{bx}   {bx}   {b}
+\DeclareFontSeriesChangeRule {lex}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {lux}{bx}  {bx}   {b}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {sluc}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {slec}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {slc}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {slsc}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {sl}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {slsx}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {slx}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {slex}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {slux}{bx} {bx}  {b}
+\DeclareFontSeriesChangeRule {sluc}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {slec}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {slc}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {slsc}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {sl}{bx}   {bx}   {b}
+\DeclareFontSeriesChangeRule {slsx}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {slx}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {slex}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {slux}{bx} {bx}   {b}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {uc}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {ec}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {c}{bx}    {bx}  {b}
-\DeclareFontSeriesChangeRule {sc}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {m}{bx}    {bx}  {b}
-\DeclareFontSeriesChangeRule {sx}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {x}{bx}    {bx}  {b}
-\DeclareFontSeriesChangeRule {ex}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {ux}{bx}   {bx}  {b}
+\DeclareFontSeriesChangeRule {uc}{bx}   {bx}   {b}
+\DeclareFontSeriesChangeRule {ec}{bx}   {bx}   {b}
+\DeclareFontSeriesChangeRule {c}{bx}    {bx}   {b}
+\DeclareFontSeriesChangeRule {sc}{bx}   {bx}   {b}
+\DeclareFontSeriesChangeRule {m}{bx}    {bx}   {b}
+\DeclareFontSeriesChangeRule {sx}{bx}   {bx}   {b}
+\DeclareFontSeriesChangeRule {x}{bx}    {bx}   {b}
+\DeclareFontSeriesChangeRule {ex}{bx}   {bx}   {b}
+\DeclareFontSeriesChangeRule {ux}{bx}   {bx}   {b}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {sbuc}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {sbec}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {sbc}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {sbsc}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {sb}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {sbsx}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {sbx}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {sbex}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {sbux}{bx} {bx}  {b}
+\DeclareFontSeriesChangeRule {sbuc}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {sbec}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {sbc}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {sbsc}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {sb}{bx}   {bx}   {b}
+\DeclareFontSeriesChangeRule {sbsx}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {sbx}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {sbex}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {sbux}{bx} {bx}   {b}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {buc}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {bec}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {bc}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {bsc}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {b}{bx}    {bx}  {b}
-\DeclareFontSeriesChangeRule {bsx}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {bx}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {bex}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {bux}{bx}  {bx}  {b}
+\DeclareFontSeriesChangeRule {buc}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {bec}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {bc}{bx}   {bx}   {b}
+\DeclareFontSeriesChangeRule {bsc}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {b}{bx}    {bx}   {b}
+\DeclareFontSeriesChangeRule {bsx}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {bx}{bx}   {bx}   {b}
+\DeclareFontSeriesChangeRule {bex}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {bux}{bx}  {bx}   {b}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {ebuc}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {ebec}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {ebc}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {ebsc}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {eb}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {ebsx}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {ebx}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {ebex}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {ebux}{bx} {bx}  {b}
+\DeclareFontSeriesChangeRule {ebuc}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {ebec}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {ebc}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {ebsc}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {eb}{bx}   {bx}   {b}
+\DeclareFontSeriesChangeRule {ebsx}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {ebx}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {ebex}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {ebux}{bx} {bx}   {b}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {ubuc}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {ubec}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {ubc}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {ubsc}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {ub}{bx}   {bx}  {b}
-\DeclareFontSeriesChangeRule {ubsx}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {ubx}{bx}  {bx}  {b}
-\DeclareFontSeriesChangeRule {ubex}{bx} {bx}  {b}
-\DeclareFontSeriesChangeRule {ubux}{bx} {bx}  {b}
+\DeclareFontSeriesChangeRule {ubuc}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {ubec}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {ubc}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {ubsc}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {ub}{bx}   {bx}   {b}
+\DeclareFontSeriesChangeRule {ubsx}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {ubx}{bx}  {bx}   {b}
+\DeclareFontSeriesChangeRule {ubex}{bx} {bx}   {b}
+\DeclareFontSeriesChangeRule {ubux}{bx} {bx}   {b}
 %    \end{macrocode}
 %
 %    Here are the special rules for \texttt{m?}:
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {uluc}{m?} {uc}  {}
-\DeclareFontSeriesChangeRule {ulec}{m?} {ec}  {}
-\DeclareFontSeriesChangeRule {ulc}{m?}  {c}   {}
-\DeclareFontSeriesChangeRule {ulsc}{m?} {sc}  {}
-\DeclareFontSeriesChangeRule {ul}{m?}   {m}   {}
-\DeclareFontSeriesChangeRule {ulsx}{m?} {sx}  {}
-\DeclareFontSeriesChangeRule {ulx}{m?}  {x}   {}
-\DeclareFontSeriesChangeRule {ulex}{m?} {ex}  {}
-\DeclareFontSeriesChangeRule {ulux}{m?} {ux}  {}
+\DeclareFontSeriesChangeRule {uluc}{m?} {uc}   {}
+\DeclareFontSeriesChangeRule {ulec}{m?} {ec}   {}
+\DeclareFontSeriesChangeRule {ulc}{m?}  {c}    {}
+\DeclareFontSeriesChangeRule {ulsc}{m?} {sc}   {}
+\DeclareFontSeriesChangeRule {ul}{m?}   {m}    {}
+\DeclareFontSeriesChangeRule {ulsx}{m?} {sx}   {}
+\DeclareFontSeriesChangeRule {ulx}{m?}  {x}    {}
+\DeclareFontSeriesChangeRule {ulex}{m?} {ex}   {}
+\DeclareFontSeriesChangeRule {ulux}{m?} {ux}   {}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {eluc}{m?} {uc}  {}
-\DeclareFontSeriesChangeRule {elec}{m?} {ec}  {}
-\DeclareFontSeriesChangeRule {elc}{m?}  {c}   {}
-\DeclareFontSeriesChangeRule {elsc}{m?} {sc}  {}
-\DeclareFontSeriesChangeRule {el}{m?}   {m}   {}
-\DeclareFontSeriesChangeRule {elsx}{m?} {sx}  {}
-\DeclareFontSeriesChangeRule {elx}{m?}  {x}   {}
-\DeclareFontSeriesChangeRule {elex}{m?} {ex}  {}
-\DeclareFontSeriesChangeRule {elux}{m?} {ux}  {}
+\DeclareFontSeriesChangeRule {eluc}{m?} {uc}   {}
+\DeclareFontSeriesChangeRule {elec}{m?} {ec}   {}
+\DeclareFontSeriesChangeRule {elc}{m?}  {c}    {}
+\DeclareFontSeriesChangeRule {elsc}{m?} {sc}   {}
+\DeclareFontSeriesChangeRule {el}{m?}   {m}    {}
+\DeclareFontSeriesChangeRule {elsx}{m?} {sx}   {}
+\DeclareFontSeriesChangeRule {elx}{m?}  {x}    {}
+\DeclareFontSeriesChangeRule {elex}{m?} {ex}   {}
+\DeclareFontSeriesChangeRule {elux}{m?} {ux}   {}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {luc}{m?}  {uc}  {}
-\DeclareFontSeriesChangeRule {lec}{m?}  {ec}  {}
-\DeclareFontSeriesChangeRule {lc}{m?}   {c}   {}
-\DeclareFontSeriesChangeRule {lsc}{m?}  {sc}  {}
-\DeclareFontSeriesChangeRule {l}{m?}    {m}   {}
-\DeclareFontSeriesChangeRule {lsx}{m?}  {sx}  {}
-\DeclareFontSeriesChangeRule {lx}{m?}   {x}   {}
-\DeclareFontSeriesChangeRule {lex}{m?}  {ex}  {}
-\DeclareFontSeriesChangeRule {lux}{m?}  {ux}  {}
+\DeclareFontSeriesChangeRule {luc}{m?}  {uc}   {}
+\DeclareFontSeriesChangeRule {lec}{m?}  {ec}   {}
+\DeclareFontSeriesChangeRule {lc}{m?}   {c}    {}
+\DeclareFontSeriesChangeRule {lsc}{m?}  {sc}   {}
+\DeclareFontSeriesChangeRule {l}{m?}    {m}    {}
+\DeclareFontSeriesChangeRule {lsx}{m?}  {sx}   {}
+\DeclareFontSeriesChangeRule {lx}{m?}   {x}    {}
+\DeclareFontSeriesChangeRule {lex}{m?}  {ex}   {}
+\DeclareFontSeriesChangeRule {lux}{m?}  {ux}   {}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {sluc}{m?} {uc}  {}
-\DeclareFontSeriesChangeRule {slec}{m?} {ec}  {}
-\DeclareFontSeriesChangeRule {slc}{m?}  {c}   {}
-\DeclareFontSeriesChangeRule {slsc}{m?} {sc}  {}
-\DeclareFontSeriesChangeRule {sl}{m?}   {m}   {}
-\DeclareFontSeriesChangeRule {slsx}{m?} {sx}  {}
-\DeclareFontSeriesChangeRule {slx}{m?}  {x}   {}
-\DeclareFontSeriesChangeRule {slex}{m?} {ex}  {}
-\DeclareFontSeriesChangeRule {slux}{m?} {ux}  {}
+\DeclareFontSeriesChangeRule {sluc}{m?} {uc}   {}
+\DeclareFontSeriesChangeRule {slec}{m?} {ec}   {}
+\DeclareFontSeriesChangeRule {slc}{m?}  {c}    {}
+\DeclareFontSeriesChangeRule {slsc}{m?} {sc}   {}
+\DeclareFontSeriesChangeRule {sl}{m?}   {m}    {}
+\DeclareFontSeriesChangeRule {slsx}{m?} {sx}   {}
+\DeclareFontSeriesChangeRule {slx}{m?}  {x}    {}
+\DeclareFontSeriesChangeRule {slex}{m?} {ex}   {}
+\DeclareFontSeriesChangeRule {slux}{m?} {ux}   {}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {uc}{m?}   {uc}  {}
-\DeclareFontSeriesChangeRule {ec}{m?}   {ec}  {}
-\DeclareFontSeriesChangeRule {c}{m?}    {c}   {}
-\DeclareFontSeriesChangeRule {sc}{m?}   {sc}  {}
-\DeclareFontSeriesChangeRule {m}{m?}    {m}   {}
-\DeclareFontSeriesChangeRule {sx}{m?}   {sx}  {}
-\DeclareFontSeriesChangeRule {x}{m?}    {x}   {}
-\DeclareFontSeriesChangeRule {ex}{m?}   {ex}  {}
-\DeclareFontSeriesChangeRule {ux}{m?}   {ux}  {}
+\DeclareFontSeriesChangeRule {uc}{m?}   {uc}   {}
+\DeclareFontSeriesChangeRule {ec}{m?}   {ec}   {}
+\DeclareFontSeriesChangeRule {c}{m?}    {c}    {}
+\DeclareFontSeriesChangeRule {sc}{m?}   {sc}   {}
+\DeclareFontSeriesChangeRule {m}{m?}    {m}    {}
+\DeclareFontSeriesChangeRule {sx}{m?}   {sx}   {}
+\DeclareFontSeriesChangeRule {x}{m?}    {x}    {}
+\DeclareFontSeriesChangeRule {ex}{m?}   {ex}   {}
+\DeclareFontSeriesChangeRule {ux}{m?}   {ux}   {}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {sbuc}{m?} {uc}  {}
-\DeclareFontSeriesChangeRule {sbec}{m?} {ec}  {}
-\DeclareFontSeriesChangeRule {sbc}{m?}  {c}   {}
-\DeclareFontSeriesChangeRule {sbsc}{m?} {sc}  {}
-\DeclareFontSeriesChangeRule {sb}{m?}   {m}   {}
-\DeclareFontSeriesChangeRule {sbsx}{m?} {sx}  {}
-\DeclareFontSeriesChangeRule {sbx}{m?}  {x}   {}
-\DeclareFontSeriesChangeRule {sbex}{m?} {ex}  {}
-\DeclareFontSeriesChangeRule {sbux}{m?} {ux}  {}
+\DeclareFontSeriesChangeRule {sbuc}{m?} {uc}   {}
+\DeclareFontSeriesChangeRule {sbec}{m?} {ec}   {}
+\DeclareFontSeriesChangeRule {sbc}{m?}  {c}    {}
+\DeclareFontSeriesChangeRule {sbsc}{m?} {sc}   {}
+\DeclareFontSeriesChangeRule {sb}{m?}   {m}    {}
+\DeclareFontSeriesChangeRule {sbsx}{m?} {sx}   {}
+\DeclareFontSeriesChangeRule {sbx}{m?}  {x}    {}
+\DeclareFontSeriesChangeRule {sbex}{m?} {ex}   {}
+\DeclareFontSeriesChangeRule {sbux}{m?} {ux}   {}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {buc}{m?}  {uc}  {}
-\DeclareFontSeriesChangeRule {bec}{m?}  {ec}  {}
-\DeclareFontSeriesChangeRule {bc}{m?}   {c}   {}
-\DeclareFontSeriesChangeRule {bsc}{m?}  {sc}  {}
-\DeclareFontSeriesChangeRule {b}{m?}    {m}   {}
-\DeclareFontSeriesChangeRule {bsx}{m?}  {sx}  {}
-\DeclareFontSeriesChangeRule {bx}{m?}   {x}   {}
-\DeclareFontSeriesChangeRule {bex}{m?}  {ex}  {}
-\DeclareFontSeriesChangeRule {bux}{m?}  {ux}  {}
+\DeclareFontSeriesChangeRule {buc}{m?}  {uc}   {}
+\DeclareFontSeriesChangeRule {bec}{m?}  {ec}   {}
+\DeclareFontSeriesChangeRule {bc}{m?}   {c}    {}
+\DeclareFontSeriesChangeRule {bsc}{m?}  {sc}   {}
+\DeclareFontSeriesChangeRule {b}{m?}    {m}    {}
+\DeclareFontSeriesChangeRule {bsx}{m?}  {sx}   {}
+\DeclareFontSeriesChangeRule {bx}{m?}   {x}    {}
+\DeclareFontSeriesChangeRule {bex}{m?}  {ex}   {}
+\DeclareFontSeriesChangeRule {bux}{m?}  {ux}   {}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {ebuc}{m?} {uc}  {}
-\DeclareFontSeriesChangeRule {ebec}{m?} {ec}  {}
-\DeclareFontSeriesChangeRule {ebc}{m?}  {c}   {}
-\DeclareFontSeriesChangeRule {ebsc}{m?} {sc}  {}
-\DeclareFontSeriesChangeRule {eb}{m?}   {m}   {}
-\DeclareFontSeriesChangeRule {ebsx}{m?} {sx}  {}
-\DeclareFontSeriesChangeRule {ebx}{m?}  {x}   {}
-\DeclareFontSeriesChangeRule {ebex}{m?} {ex}  {}
-\DeclareFontSeriesChangeRule {ebux}{m?} {ux}  {}
+\DeclareFontSeriesChangeRule {ebuc}{m?} {uc}   {}
+\DeclareFontSeriesChangeRule {ebec}{m?} {ec}   {}
+\DeclareFontSeriesChangeRule {ebc}{m?}  {c}    {}
+\DeclareFontSeriesChangeRule {ebsc}{m?} {sc}   {}
+\DeclareFontSeriesChangeRule {eb}{m?}   {m}    {}
+\DeclareFontSeriesChangeRule {ebsx}{m?} {sx}   {}
+\DeclareFontSeriesChangeRule {ebx}{m?}  {x}    {}
+\DeclareFontSeriesChangeRule {ebex}{m?} {ex}   {}
+\DeclareFontSeriesChangeRule {ebux}{m?} {ux}   {}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {ubuc}{m?} {uc}  {}
-\DeclareFontSeriesChangeRule {ubec}{m?} {ec}  {}
-\DeclareFontSeriesChangeRule {ubc}{m?}  {c}   {}
-\DeclareFontSeriesChangeRule {ubsc}{m?} {sc}  {}
-\DeclareFontSeriesChangeRule {ub}{m?}   {m}   {}
-\DeclareFontSeriesChangeRule {ubsx}{m?} {sx}  {}
-\DeclareFontSeriesChangeRule {ubx}{m?}  {x}   {}
-\DeclareFontSeriesChangeRule {ubex}{m?} {ex}  {}
-\DeclareFontSeriesChangeRule {ubux}{m?} {ux}  {}
+\DeclareFontSeriesChangeRule {ubuc}{m?} {uc}   {}
+\DeclareFontSeriesChangeRule {ubec}{m?} {ec}   {}
+\DeclareFontSeriesChangeRule {ubc}{m?}  {c}    {}
+\DeclareFontSeriesChangeRule {ubsc}{m?} {sc}   {}
+\DeclareFontSeriesChangeRule {ub}{m?}   {m}    {}
+\DeclareFontSeriesChangeRule {ubsx}{m?} {sx}   {}
+\DeclareFontSeriesChangeRule {ubx}{m?}  {x}    {}
+\DeclareFontSeriesChangeRule {ubex}{m?} {ex}   {}
+\DeclareFontSeriesChangeRule {ubux}{m?} {ux}   {}
 %    \end{macrocode}
 %
 %    And there the special rules for \texttt{?m}:
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {uluc}{?m} {ul}  {}
-\DeclareFontSeriesChangeRule {ulec}{?m} {ul}  {}
-\DeclareFontSeriesChangeRule {ulc}{?m}  {ul}  {}
-\DeclareFontSeriesChangeRule {ulsc}{?m} {ul}  {}
-\DeclareFontSeriesChangeRule {ul}{?m}   {ul}  {}
-\DeclareFontSeriesChangeRule {ulsx}{?m} {ul}  {}
-\DeclareFontSeriesChangeRule {ulx}{?m}  {ul}  {}
-\DeclareFontSeriesChangeRule {ulex}{?m} {ul}  {}
-\DeclareFontSeriesChangeRule {ulux}{?m} {ul}  {}
+\DeclareFontSeriesChangeRule {uluc}{?m} {ul}   {}
+\DeclareFontSeriesChangeRule {ulec}{?m} {ul}   {}
+\DeclareFontSeriesChangeRule {ulc}{?m}  {ul}   {}
+\DeclareFontSeriesChangeRule {ulsc}{?m} {ul}   {}
+\DeclareFontSeriesChangeRule {ul}{?m}   {ul}   {}
+\DeclareFontSeriesChangeRule {ulsx}{?m} {ul}   {}
+\DeclareFontSeriesChangeRule {ulx}{?m}  {ul}   {}
+\DeclareFontSeriesChangeRule {ulex}{?m} {ul}   {}
+\DeclareFontSeriesChangeRule {ulux}{?m} {ul}   {}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {eluc}{?m} {el}  {}
-\DeclareFontSeriesChangeRule {elec}{?m} {el}  {}
-\DeclareFontSeriesChangeRule {elc}{?m}  {el}  {}
-\DeclareFontSeriesChangeRule {elsc}{?m} {el}  {}
-\DeclareFontSeriesChangeRule {el}{?m}   {el}  {}
-\DeclareFontSeriesChangeRule {elsx}{?m} {el}  {}
-\DeclareFontSeriesChangeRule {elx}{?m}  {el}  {}
-\DeclareFontSeriesChangeRule {elex}{?m} {el}  {}
-\DeclareFontSeriesChangeRule {elux}{?m} {el}  {}
+\DeclareFontSeriesChangeRule {eluc}{?m} {el}   {}
+\DeclareFontSeriesChangeRule {elec}{?m} {el}   {}
+\DeclareFontSeriesChangeRule {elc}{?m}  {el}   {}
+\DeclareFontSeriesChangeRule {elsc}{?m} {el}   {}
+\DeclareFontSeriesChangeRule {el}{?m}   {el}   {}
+\DeclareFontSeriesChangeRule {elsx}{?m} {el}   {}
+\DeclareFontSeriesChangeRule {elx}{?m}  {el}   {}
+\DeclareFontSeriesChangeRule {elex}{?m} {el}   {}
+\DeclareFontSeriesChangeRule {elux}{?m} {el}   {}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {luc}{?m}  {l}   {}
-\DeclareFontSeriesChangeRule {lec}{?m}  {l}   {}
-\DeclareFontSeriesChangeRule {lc}{?m}   {l}   {}
-\DeclareFontSeriesChangeRule {lsc}{?m}  {l}   {}
-\DeclareFontSeriesChangeRule {l}{?m}    {l}   {}
-\DeclareFontSeriesChangeRule {lsx}{?m}  {l}   {}
-\DeclareFontSeriesChangeRule {lx}{?m}   {l}   {}
-\DeclareFontSeriesChangeRule {lex}{?m}  {l}   {}
-\DeclareFontSeriesChangeRule {lux}{?m}  {l}   {}
+\DeclareFontSeriesChangeRule {luc}{?m}  {l}    {}
+\DeclareFontSeriesChangeRule {lec}{?m}  {l}    {}
+\DeclareFontSeriesChangeRule {lc}{?m}   {l}    {}
+\DeclareFontSeriesChangeRule {lsc}{?m}  {l}    {}
+\DeclareFontSeriesChangeRule {l}{?m}    {l}    {}
+\DeclareFontSeriesChangeRule {lsx}{?m}  {l}    {}
+\DeclareFontSeriesChangeRule {lx}{?m}   {l}    {}
+\DeclareFontSeriesChangeRule {lex}{?m}  {l}    {}
+\DeclareFontSeriesChangeRule {lux}{?m}  {l}    {}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {sluc}{?m} {sl}  {}
-\DeclareFontSeriesChangeRule {slec}{?m} {sl}  {}
-\DeclareFontSeriesChangeRule {slc}{?m}  {sl}  {}
-\DeclareFontSeriesChangeRule {slsc}{?m} {sl}  {}
-\DeclareFontSeriesChangeRule {sl}{?m}   {sl}  {}
-\DeclareFontSeriesChangeRule {slsx}{?m} {sl}  {}
-\DeclareFontSeriesChangeRule {slx}{?m}  {sl}  {}
-\DeclareFontSeriesChangeRule {slex}{?m} {sl}  {}
-\DeclareFontSeriesChangeRule {slux}{?m} {sl}  {}
+\DeclareFontSeriesChangeRule {sluc}{?m} {sl}   {}
+\DeclareFontSeriesChangeRule {slec}{?m} {sl}   {}
+\DeclareFontSeriesChangeRule {slc}{?m}  {sl}   {}
+\DeclareFontSeriesChangeRule {slsc}{?m} {sl}   {}
+\DeclareFontSeriesChangeRule {sl}{?m}   {sl}   {}
+\DeclareFontSeriesChangeRule {slsx}{?m} {sl}   {}
+\DeclareFontSeriesChangeRule {slx}{?m}  {sl}   {}
+\DeclareFontSeriesChangeRule {slex}{?m} {sl}   {}
+\DeclareFontSeriesChangeRule {slux}{?m} {sl}   {}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {uc}{?m}   {m}   {}
-\DeclareFontSeriesChangeRule {ec}{?m}   {m}   {}
-\DeclareFontSeriesChangeRule {c}{?m}    {m}   {}
-\DeclareFontSeriesChangeRule {sc}{?m}   {m}   {}
-\DeclareFontSeriesChangeRule {m}{?m}    {m}   {}
-\DeclareFontSeriesChangeRule {sx}{?m}   {m}   {}
-\DeclareFontSeriesChangeRule {x}{?m}    {m}   {}
-\DeclareFontSeriesChangeRule {ex}{?m}   {m}   {}
-\DeclareFontSeriesChangeRule {ux}{?m}   {m}   {}
+\DeclareFontSeriesChangeRule {uc}{?m}   {m}    {}
+\DeclareFontSeriesChangeRule {ec}{?m}   {m}    {}
+\DeclareFontSeriesChangeRule {c}{?m}    {m}    {}
+\DeclareFontSeriesChangeRule {sc}{?m}   {m}    {}
+\DeclareFontSeriesChangeRule {m}{?m}    {m}    {}
+\DeclareFontSeriesChangeRule {sx}{?m}   {m}    {}
+\DeclareFontSeriesChangeRule {x}{?m}    {m}    {}
+\DeclareFontSeriesChangeRule {ex}{?m}   {m}    {}
+\DeclareFontSeriesChangeRule {ux}{?m}   {m}    {}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {sbuc}{?m} {sb}  {}
-\DeclareFontSeriesChangeRule {sbec}{?m} {sb}  {}
-\DeclareFontSeriesChangeRule {sbc}{?m}  {sb}  {}
-\DeclareFontSeriesChangeRule {sbsc}{?m} {sb}  {}
-\DeclareFontSeriesChangeRule {sb}{?m}   {sb}  {}
-\DeclareFontSeriesChangeRule {sbsx}{?m} {sb}  {}
-\DeclareFontSeriesChangeRule {sbx}{?m}  {sb}  {}
-\DeclareFontSeriesChangeRule {sbex}{?m} {sb}  {}
-\DeclareFontSeriesChangeRule {sbux}{?m} {sb}  {}
+\DeclareFontSeriesChangeRule {sbuc}{?m} {sb}   {}
+\DeclareFontSeriesChangeRule {sbec}{?m} {sb}   {}
+\DeclareFontSeriesChangeRule {sbc}{?m}  {sb}   {}
+\DeclareFontSeriesChangeRule {sbsc}{?m} {sb}   {}
+\DeclareFontSeriesChangeRule {sb}{?m}   {sb}   {}
+\DeclareFontSeriesChangeRule {sbsx}{?m} {sb}   {}
+\DeclareFontSeriesChangeRule {sbx}{?m}  {sb}   {}
+\DeclareFontSeriesChangeRule {sbex}{?m} {sb}   {}
+\DeclareFontSeriesChangeRule {sbux}{?m} {sb}   {}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {buc}{?m}  {b}   {}
-\DeclareFontSeriesChangeRule {bec}{?m}  {b}   {}
-\DeclareFontSeriesChangeRule {bc}{?m}   {b}   {}
-\DeclareFontSeriesChangeRule {bsc}{?m}  {b}   {}
-\DeclareFontSeriesChangeRule {b}{?m}    {b}   {}
-\DeclareFontSeriesChangeRule {bsx}{?m}  {b}   {}
-\DeclareFontSeriesChangeRule {bx}{?m}   {b}   {}
-\DeclareFontSeriesChangeRule {bex}{?m}  {b}   {}
-\DeclareFontSeriesChangeRule {bux}{?m}  {b}   {}
+\DeclareFontSeriesChangeRule {buc}{?m}  {b}    {}
+\DeclareFontSeriesChangeRule {bec}{?m}  {b}    {}
+\DeclareFontSeriesChangeRule {bc}{?m}   {b}    {}
+\DeclareFontSeriesChangeRule {bsc}{?m}  {b}    {}
+\DeclareFontSeriesChangeRule {b}{?m}    {b}    {}
+\DeclareFontSeriesChangeRule {bsx}{?m}  {b}    {}
+\DeclareFontSeriesChangeRule {bx}{?m}   {b}    {}
+\DeclareFontSeriesChangeRule {bex}{?m}  {b}    {}
+\DeclareFontSeriesChangeRule {bux}{?m}  {b}    {}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {ebuc}{?m} {eb}  {}
-\DeclareFontSeriesChangeRule {ebec}{?m} {eb}  {}
-\DeclareFontSeriesChangeRule {ebc}{?m}  {eb}  {}
-\DeclareFontSeriesChangeRule {ebsc}{?m} {eb}  {}
-\DeclareFontSeriesChangeRule {eb}{?m}   {eb}  {}
-\DeclareFontSeriesChangeRule {ebsx}{?m} {eb}  {}
-\DeclareFontSeriesChangeRule {ebx}{?m}  {eb}  {}
-\DeclareFontSeriesChangeRule {ebex}{?m} {eb}  {}
-\DeclareFontSeriesChangeRule {ebux}{?m} {eb}  {}
+\DeclareFontSeriesChangeRule {ebuc}{?m} {eb}   {}
+\DeclareFontSeriesChangeRule {ebec}{?m} {eb}   {}
+\DeclareFontSeriesChangeRule {ebc}{?m}  {eb}   {}
+\DeclareFontSeriesChangeRule {ebsc}{?m} {eb}   {}
+\DeclareFontSeriesChangeRule {eb}{?m}   {eb}   {}
+\DeclareFontSeriesChangeRule {ebsx}{?m} {eb}   {}
+\DeclareFontSeriesChangeRule {ebx}{?m}  {eb}   {}
+\DeclareFontSeriesChangeRule {ebex}{?m} {eb}   {}
+\DeclareFontSeriesChangeRule {ebux}{?m} {eb}   {}
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareFontSeriesChangeRule {ubuc}{?m} {ub}  {}
-\DeclareFontSeriesChangeRule {ubec}{?m} {ub}  {}
-\DeclareFontSeriesChangeRule {ubc}{?m}  {ub}  {}
-\DeclareFontSeriesChangeRule {ubsc}{?m} {ub}  {}
-\DeclareFontSeriesChangeRule {ub}{?m}   {ub}  {}
-\DeclareFontSeriesChangeRule {ubsx}{?m} {ub}  {}
-\DeclareFontSeriesChangeRule {ubx}{?m}  {ub}  {}
-\DeclareFontSeriesChangeRule {ubex}{?m} {ub}  {}
-\DeclareFontSeriesChangeRule {ubux}{?m} {ub}  {}
+\DeclareFontSeriesChangeRule {ubuc}{?m} {ub}   {}
+\DeclareFontSeriesChangeRule {ubec}{?m} {ub}   {}
+\DeclareFontSeriesChangeRule {ubc}{?m}  {ub}   {}
+\DeclareFontSeriesChangeRule {ubsc}{?m} {ub}   {}
+\DeclareFontSeriesChangeRule {ub}{?m}   {ub}   {}
+\DeclareFontSeriesChangeRule {ubsx}{?m} {ub}   {}
+\DeclareFontSeriesChangeRule {ubx}{?m}  {ub}   {}
+\DeclareFontSeriesChangeRule {ubex}{?m} {ub}   {}
+\DeclareFontSeriesChangeRule {ubux}{?m} {ub}   {}
 %    \end{macrocode}
 %
 %    \begin{macrocode}

--- a/base/ltfssaxes.dtx
+++ b/base/ltfssaxes.dtx
@@ -1389,9 +1389,9 @@
 %    In the following rule, we use \texttt{eb} instead of \texttt{b}
 %    in the fourth argument, since \texttt{eb} is a better
 %    approximation to \texttt{ub} than \texttt{b} and \texttt{ebuc}
-%    is already in the first argument and we can therefore assume that
-%    this font face actually exists. A similar consideration also
-%    applies to some other rules in the following.
+%    is already in the first argument and therefore this font face probably
+%    actually exists. A similar consideration also applies to some other rules
+%    in the following.
 %    \begin{macrocode}
 \DeclareFontSeriesChangeRule {ebuc}{ub} {ubuc} {ebuc}
 \DeclareFontSeriesChangeRule {ebuc}{uc} {ebuc} {}


### PR DESCRIPTION
This PR is a minor followup to #1583:
- Correct a wrong GitHub number in two `\changes` entries
- Split the entries for `m?` and `?m` into individual `macrocode` blocks, analogous to the other entries
- Move one block for `m` weight rules between the blocks for `sl` weight rules and `sb` weight rules
- A rewording
- Unification of spaces



# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
