### PR TITLE
Consistency in appearance of switches in source2e

### DIFF
--- a/base/ltfiles.dtx
+++ b/base/ltfiles.dtx
@@ -32,7 +32,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltfiles.dtx}
-             [2025/04/25 v1.2w LaTeX Kernel (File Handling)]
+             [2025/05/22 v1.2w LaTeX Kernel (File Handling)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltfiles.dtx}
@@ -332,7 +332,7 @@
   \fi
 %    \end{macrocode}
 %
-% Way back in 1991 (08/26) FMi \& RmS set the |\@noskipsec| switch
+% Way back in 1991 (08/26) FMi \& RmS set the |@noskipsec| switch
 % to true in the preamble and to false here.
 % This was done to trap lists and related text in the preamble but it
 % does not catch everything; hence Change 1.1g was introduced.

--- a/base/ltlists.dtx
+++ b/base/ltlists.dtx
@@ -31,7 +31,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltlists.dtx}
-             [2025/01/26 v1.0v LaTeX Kernel (List Environments)]
+             [2025/05/22 v1.0v LaTeX Kernel (List Environments)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltlists.dtx}
@@ -156,7 +156,7 @@
 %   of the |\item| command. Initialized to |\@mklab| by the |\list|
 %   command.  This command must produce  some stretch---i.e., an
 %   |\hfil|.
-% \item[\cs{@inlabel}] A switch that is false except between the time
+% \item[\texttt{@inlabel}] A switch that is false except between the time
 %   an |\item| is encountered and the time that \TeX{}
 %   actually enters horizontal mode.  Should be tested by commands
 %   that can be messed up by the list environment's use of |\everypar|.
@@ -176,7 +176,7 @@
 % \item[\texttt{@nmbrlist}] Set true by |\usecounter| command, causes
 %   list to be numbered.
 % \item[\cs{@listctr}] |\def|'ed by |\usecounter| to name of counter.
-% \item[\cs{@noskipsec}] A switch set true by a sectioning command when
+% \item[\texttt{@noskipsec}] A switch set true by a sectioning command when
 %    it is creating an in-text heading with |\everypar|.
 % \end{description}
 %
@@ -711,7 +711,7 @@
 % a paragraph-making environment, \cs{everypar} is changed to remove the
 % space, and \cs{par} is redefined to restore \cs{everypar}.  Instead of
 % redefining \cs{par} and \cs{everypar}, \cs{@endparenv} was changed to
-% set the @endpe switch, letting \cs{end} redefine \cs{par} and
+% set the |@endpe| switch, letting \cs{end} redefine \cs{par} and
 % \cs{everypar}.
 %
 % This allows paragraph-making environments to work right when called
@@ -1003,7 +1003,7 @@
 %    an item?  As with all such settings of |\clubpenalty| it is local
 %    so will have no effect if the item starts in a group.
 %
-%    Only resetting |\@nobreak| when it is true is now
+%    Only resetting |@nobreak| when it is true is now
 %    essential since now it is sometimes set locally.
 % \changes{v1.0m}{1996/10/23}{Added setting of \cs{clubpenalty} and
 %    set \cs{@nobreakfalse} only when necessary}

--- a/base/ltmarks.dtx
+++ b/base/ltmarks.dtx
@@ -17,7 +17,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltmarks.dtx}
-             [2025/01/10 v1.1c LaTeX Kernel (Marks)]
+             [2025/05/22 v1.1c LaTeX Kernel (Marks)]
 % \iffalse
 %
 \documentclass{l3doc}
@@ -158,7 +158,7 @@
 %   a mark inside a box or inside a footnote never shows up anywhere.
 %
 %   If used in vertical mode it obeys \LaTeX's internal
-%   \cs{@nobreak} switch, i.e., it does not introduce a
+%   \texttt{@nobreak} switch, i.e., it does not introduce a
 %   breakpoint if used after a heading. If used in horizontal mode it
 %   doesn't handle spacing (like, for example, \cs{index} or
 %   \cs{label} does, so it should be attached to material that is

--- a/base/ltpage.dtx
+++ b/base/ltpage.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltpage.dtx}
-             [2024/11/16 v1.0o LaTeX Kernel (page style setup)]
+             [2025/05/22 v1.0o LaTeX Kernel (page style setup)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltpage.dtx}
@@ -193,7 +193,7 @@
 %
 % User commands for setting \LaTeX\ marks.
 %
-% Test for |\@nobreak| added 15 Apr 86 in |\markboth| and |\markright|
+% Test for |@nobreak| added 15 Apr 86 in |\markboth| and |\markright|
 % letting |\label| and |\index| to |\relax| added 22 Feb 86 so these
 %   commands can appear in sectioning command arguments
 % RmS 91/06/21 Same for |\glossary|

--- a/base/ltsect.dtx
+++ b/base/ltsect.dtx
@@ -31,7 +31,7 @@
 %%% From File: ltsect.dtx
 %<*driver>
 % \fi
-\ProvidesFile{ltsect.dtx}[2025/01/23 v1.1h LaTeX Kernel (Sectioning)]
+\ProvidesFile{ltsect.dtx}[2025/05/22 v1.1h LaTeX Kernel (Sectioning)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltsect.dtx}
@@ -234,7 +234,7 @@
 % \begin{macro}{\if@noskipsec}
 % \begin{macro}{\@noskipsectrue}
 % \changes{1.0w}{1996/09/29}{Added documentation}
-% Way back in 1991 (08/26) FMi \& RmS set the |\@noskipsec| switch
+% Way back in 1991 (08/26) FMi \& RmS set the |@noskipsec| switch
 % to true for the preamble and to false in |\document|.
 % This was done to trap lists and related text in the preamble but it
 % does not catch everything.


### PR DESCRIPTION
# Internal housekeeping

Sometimes 2e switches in source2e are written as, for example `\@nobreak`, but usually they are written as `@nobreak`. I think the latter is less likely to cause confusion as there is no `\@nobreak` command. Also, sometimes both forms were used in the same section (see ltlists subsection 1.1). This PR just converts the few I could find from the former to the latter formatting.

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
