### PR TITLE
Fix amsmath timing for some packages in latex-lab-mathpkg

### DIFF
--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -1,3 +1,8 @@
+2025-06-20  Matthew Bertucci <mbertucci@willamette.edu>
+
+	* latex-lab-mathpkg.dtx:
+        Load amsmath before several packages that error if amsmath is loaded after.
+
 2025-06-19  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 
 	* latex-lab-footnotes.dtx (section{Reimplementing the \pkg{footmisc} package}):

--- a/required/latex-lab/latex-lab-mathpkg.dtx
+++ b/required/latex-lab/latex-lab-mathpkg.dtx
@@ -84,7 +84,7 @@
 % \subsection{cases}
 % Force loading of \pkg{amsmath} before \pkg{cases}.
 %    \begin{macrocode}
-\AddToHook {package/cases/before}{\RequirePackage{amsmath}}
+\AddToHook{package/cases/before}{\RequirePackage{amsmath}}
 \AddToHook{package/cases/after}{
   \RegisterMathEnvironment{subnumcases}
 }  

--- a/required/latex-lab/latex-lab-mathpkg.dtx
+++ b/required/latex-lab/latex-lab-mathpkg.dtx
@@ -68,7 +68,7 @@
 % \subsection{File declaration}
 %    \begin{macrocode}
 \ProvidesFile{latex-lab-mathpkg.ltx}
-        [2025-06-13 v0.1c mathpkg adaptions]
+        [2025-06-20 v0.1c mathpkg adaptions]
 %    \end{macrocode}
 %
 % \subsection{breqn}

--- a/required/latex-lab/latex-lab-mathpkg.dtx
+++ b/required/latex-lab/latex-lab-mathpkg.dtx
@@ -117,6 +117,7 @@
 % These packages error or lose their function if loaded before \pkg{amsmath}.
 %    \begin{macrocode}
 \AddToHook{package/accents/before}{\RequirePackage{amsmath}}
+\AddToHook{package/cleveref/before}{\RequirePackage{amsmath}}
 \AddToHook{package/esint/before}{\RequirePackage{amsmath}}
 \AddToHook{package/grmath/before}{\RequirePackage{amsmath}}
 \AddToHook{package/mathabx/before}{\RequirePackage{amsmath}}

--- a/required/latex-lab/latex-lab-mathpkg.dtx
+++ b/required/latex-lab/latex-lab-mathpkg.dtx
@@ -68,7 +68,7 @@
 % \subsection{File declaration}
 %    \begin{macrocode}
 \ProvidesFile{latex-lab-mathpkg.ltx}
-        [2025-05-10 v0.1b mathpkg adaptions]
+        [2025-06-13 v0.1c mathpkg adaptions]
 %    \end{macrocode}
 %
 % \subsection{breqn}
@@ -112,6 +112,15 @@
      }}
  }
 \ExplSyntaxOff 
+%    \end{macrocode}
+% \subsection{amsmath timing}
+% These packages error or lose their function if loaded before \pkg{amsmath}.
+%    \begin{macrocode}
+\AddToHook{package/accents/before}{\RequirePackage{amsmath}}
+\AddToHook{package/esint/before}{\RequirePackage{amsmath}}
+\AddToHook{package/grmath/before}{\RequirePackage{amsmath}}
+\AddToHook{package/mathabx/before}{\RequirePackage{amsmath}}
+\AddToHook{package/wasysym/before}{\RequirePackage{amsmath}}
 %    \end{macrocode}
 %    \begin{macrocode}
 %</kernel>


### PR DESCRIPTION
Updates latex-lab-mathpkg to load amsmath before packages that error otherwise, except in the case of `grmath` where the package loses its functionality if amsmath is loaded after. Even for packages that aren't math-specific like cleveref, I think it makes sense to do this here since latex-lab-mathpkg is only loaded when math tagging is loaded, which is when the issue occurs since it loads amsmath at begindocument.

Note this is already done for the `cases` package.

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
