### PR TITLE
Missing mark decls

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,12 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
+2025-06-19  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
+
+	* ltmarks.dtx (subsection{Allocating new mark classes}):
+	Also initialize saved-column region used in multicol so that one doesn't get
+	missing declaration errors when L3 layer debugging is enabled (SX chat)
+
 2025-06-16  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 
 	* ltclass.dtx (section{User interface}):

--- a/base/ltmarks.dtx
+++ b/base/ltmarks.dtx
@@ -974,11 +974,12 @@
   \@@_init_region:nn {mcol-19}{#1}
   \@@_init_region:nn {mcol-20}{#1}
 %    \end{macrocode}
-%    We also have to initialize the \texttt{saved-column} region which
+%    We also have to initialize the \texttt{saved-column} region that
 %    is used in \pkg{multicol}. Perhaps we should have a
-%    \cs{NewMarkRegion} so that could be  generalized for other
-%    packages. We'll have t osee if there is a need for it. Right now
-%    all this is hard-wired.
+%    \cs{NewMarkRegion} so all that could be  generalized for other
+%    packages. We'll have to see if there is a need for it. Right now
+%    all this is hard-wired until it is clear that there is a real
+%    reason for new regions.
 % \changes{v1.1d}{2025/06/19}{Also initialize saved-column region (SX chat)}
 %    \begin{macrocode}
   \@@_init_region:nn {saved-column}{#1}

--- a/base/ltmarks.dtx
+++ b/base/ltmarks.dtx
@@ -17,7 +17,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltmarks.dtx}
-             [2025/05/22 v1.1c LaTeX Kernel (Marks)]
+             [2025/06/19 v1.1d LaTeX Kernel (Marks)]
 % \iffalse
 %
 \documentclass{l3doc}
@@ -973,6 +973,15 @@
   \@@_init_region:nn {mcol-18}{#1}
   \@@_init_region:nn {mcol-19}{#1}
   \@@_init_region:nn {mcol-20}{#1}
+%    \end{macrocode}
+%    We also have to initialize the \texttt{saved-column} region which
+%    is used in \pkg{multicol}. Perhaps we should have a
+%    \cs{NewMarkRegion} so that could be  generalized for other
+%    packages. We'll have t osee if there is a need for it. Right now
+%    all this is hard-wired.
+% \changes{v1.1d}{2025/06/19}{Also initialize saved-column region (SX chat)}
+%    \begin{macrocode}
+  \@@_init_region:nn {saved-column}{#1}
 }
 %    \end{macrocode}
 % \end{macro}

--- a/required/tools/testfiles/sx-chat-multicol.lvt
+++ b/required/tools/testfiles/sx-chat-multicol.lvt
@@ -1,0 +1,23 @@
+\ExplSyntaxOn
+\debug_on:n { check-declarations , deprecation }
+\ExplSyntaxOff
+\documentclass{article}
+
+\input{regression-test}
+
+\usepackage{multicol}
+\usepackage{lipsum}
+\begin{document}
+
+\START  % should not error with undeclared variables
+
+\noindent % or the indent would apply
+\begin{minipage}[t]{\linewidth} % some separation
+  \begin{multicols}{2}
+    \lipsum[1][1-2]
+  \end{multicols}
+\end{minipage}
+
+\newpage
+\OMIT
+\end{document}

--- a/required/tools/testfiles/sx-chat-multicol.tlg
+++ b/required/tools/testfiles/sx-chat-multicol.tlg
@@ -1,0 +1,4 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+[1
+]

--- a/support/lipsum.sty
+++ b/support/lipsum.sty
@@ -30,7 +30,7 @@
   {lipsum}
   {\lipsumdate}
   {\lipsumversion}
-  {150 paragraphs of Lorem Ipsum dummy text}
+  {150 paragraphs of Lorem Ipsum dummy text -- special version for testsuite}
 \@ifpackagelater { expl3 } { 2018/10/31 }
   { }
   {
@@ -306,6 +306,10 @@
     \tl_set:No
       \l__lipsum_par_list_end_tl{}
   }
+
+%FMi thow two have been missing (maybe there are more):
+\tl_new:N \l__lipsum_par_list_item_start_tl
+\tl_new:N \l__lipsum_par_list_item_end_tl
 
 \NewDocumentCommand\NewLipsumPar{m}{
   \seq_gput_right:Nn{\g__lipsum_paragraph_seq}{#1}


### PR DESCRIPTION
# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [x] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [n/a] Rollback provided (if necessary)?
- [n/a] `ltnewsX.tex` (and/or `latexchanges.tex`) updated

Properly declare tl variables for one more region used in multicol, also fix missing declaration in private lipsum of the test suite.
