### PR TITLE
Extend \ProcessKeyOptions to support multiple families

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -10,6 +10,10 @@ not part of the distribution.
 	* ltcmd.dtx, lthooks.dtx
 	Support \showstream (gh/1062)
 
+2025-06-25  Joseph Wright  <Joseph.Wright@latex-project.org>
+	* ltkeys.tex, clsguide.tex
+	Support for multiple key families in \ProcessKeyOptions (gh/1756)
+
 2025-06-24  Joseph Wright  <Joseph.Wright@latex-project.org>
 	* usrguide.tex
 	Add c-type arg. to overview (gh/1761)

--- a/base/changes.txt
+++ b/base/changes.txt
@@ -11,7 +11,7 @@ not part of the distribution.
 	Support \showstream (gh/1062)
 
 2025-06-25  Joseph Wright  <Joseph.Wright@latex-project.org>
-	* ltkeys.tex, clsguide.tex
+	* ltkeys.dtx, clsguide.tex
 	Support for multiple key families in \ProcessKeyOptions (gh/1756)
 
 2025-06-24  Joseph Wright  <Joseph.Wright@latex-project.org>

--- a/base/doc/clsguide.tex
+++ b/base/doc/clsguide.tex
@@ -42,7 +42,7 @@
     \texttt{clsguide.tex} for full details.}%
 }
 
-\date{2025-06-20}
+\date{2025-06-25}
 
 \NewDocumentCommand\cs{m}{\texttt{\textbackslash\detokenize{#1}}}
 \NewDocumentCommand\marg{m}{\arg{#1}}
@@ -838,6 +838,10 @@ options has two parts: creating the key options and setting (using) them.
 Options created in this way \emph{may} be used after package loading as general
 key--value settings: this will depend on the nature of the underlying code.
 
+In the following, the \emph{family} for keys is a namespace used in creating
+the keys. At point of use, multiple families may be examined: see
+\cs{ProcessKeyOptions}.
+
 \begin{decl}
   |\DeclareKeys| \oarg{family} \arg{declarations}
 \end{decl}
@@ -901,13 +905,15 @@ unknown option on to a non-keyval class such as \pkg{article}:
 \end{verbatim}
 
 \begin{decl}
-  |\ProcessKeyOptions| \oarg{family}
+  |\ProcessKeyOptions| \oarg{families}
 \end{decl}
 The |\ProcessKeyOptions| function is used to check the current option list
-against the keys defined for \m{family}. Global (class) options and local
-(package) options are checked when this function is called in a package.
-The command will process \emph{all} options given the current
-package or class: there is no need to also apply \cs{ProcessOptions}.
+against the keys defined for \m{families} (a comma-separated list). Global
+(class) options and local (package) options are checked when this function is
+called in a package. The command will process \emph{all} options given the
+current package or class: there is no need to also apply \cs{ProcessOptions}.
+\cs{ProcessKeyOptions} should appear \emph{only once} in a class or package
+file.
 
 \begin{decl}
   |\SetKeys| \oarg{family} \arg{keyvals}

--- a/base/doc/ltnews42.tex
+++ b/base/doc/ltnews42.tex
@@ -186,6 +186,16 @@ also tidied up a little on this occasion.
 %
 \githubissue{1727}
 
+\subsection{Allow multiple family names in \cs{ProcessKeyOptions}}
+
+The ability to process key--value options was introduced into the kernel in the
+June 2022 release~\cite{42:ltnews35}, with the command \cs{ProcessKeyOptions}
+carrying out the option assignment. In the original version, this takes an
+optional argument which can select one key family (namespace) for options. We
+have now extended this to take a comma list of possible families.
+%
+\githubissue{1756}
+
 \section{Bug fixes}
 
 %\subsection{A fix}
@@ -233,6 +243,10 @@ Leslie Lamport.
 \bibitem{42:ltnews} \LaTeX{} Project Team.
   \emph{\LaTeXe{} news 1--42}. November 2025.
   \url{https://latex-project.org/news/latex2e-news/ltnews.pdf}
+
+\bibitem{42:ltnews35} \LaTeX{} Project Team.
+  \emph{\LaTeXe{} news 35}. June 2022.
+  \url{https://latex-project.org/news/latex2e-news/ltnews35.pdf}
 
 \bibitem{42:ltnews41} \LaTeX{} Project Team.
   \emph{\LaTeXe{} news 41}. June 2025.

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -62,8 +62,10 @@
 %     \cs{DeclareKeys} \oarg{family} \marg{declarations}
 %   \end{syntax}
 %   Creates a series of options from a comma-separated \meta{declarations} list.
-%   The \meta{family} is a namespace for the keys.
-%   Each entry in this list is a key--value pair, with the \meta{key} having one
+%   The \meta{family} is a namespace for the keys; if not given, the basename of
+%   the current class or package is used.
+%   Each entry in the \meta{declarations} (a commas-separated list)
+%   is a key--value pair, with the \meta{key} having one
 %   or more \meta{properties}. A small number of \enquote{basic}
 %   \meta{properties} are described below. The full range of properties,
 %   provided by \pkg{l3keys}, can also be used for more powerful processing.

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltkeys.dtx}
-             [2025/06/25 v1.0q LaTeX Kernel (Keyval options)]
+             [2025/06/27 v1.0q LaTeX Kernel (Keyval options)]
 % \iffalse
 \documentclass{l3doc}
 \GetFileInfo{ltkeys.dtx}
@@ -128,7 +128,12 @@
 %   The \cs{ProcessKeyOptions} function is used to check the current
 %   option list against the keys defined for \meta{families} (a comma-separated
 %   list). Global (class) options and local (package) options are checked when
-%   this function is called in a package.
+%   this function is called in a package. Where there is more than one
+%   \meta{family} in the list of \meta{families}, processing takes place in
+%   the order of the \meta{families}. Every key known in a \meta{family} is
+%   passed for processing, thus a key defined in more than one \meta{family}
+%   will be processed several times, and if the code paths are shared, the
+%   outcome will be determined by the last entry in the list of \meta{families}.
 % \end{function}
 %
 % \begin{function}{\SetKeys}

--- a/base/ltkeys.dtx
+++ b/base/ltkeys.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltkeys.dtx}
-             [2025/02/18 v1.0p LaTeX Kernel (Keyval options)]
+             [2025/06/25 v1.0q LaTeX Kernel (Keyval options)]
 % \iffalse
 \documentclass{l3doc}
 \GetFileInfo{ltkeys.dtx}
@@ -62,6 +62,7 @@
 %     \cs{DeclareKeys} \oarg{family} \marg{declarations}
 %   \end{syntax}
 %   Creates a series of options from a comma-separated \meta{declarations} list.
+%   The \meta{family} is a namespace for the keys.
 %   Each entry in this list is a key--value pair, with the \meta{key} having one
 %   or more \meta{properties}. A small number of \enquote{basic}
 %   \meta{properties} are described below. The full range of properties,
@@ -120,12 +121,12 @@
 %
 % \begin{function}{\ProcessKeyOptions}
 %   \begin{syntax}
-%     \cs{ProcessKeyOptions} \oarg{family}
+%     \cs{ProcessKeyOptions} \oarg{families}
 %   \end{syntax}
 %   The \cs{ProcessKeyOptions} function is used to check the current
-%   option list against the keys defined for \meta{family}. Global (class)
-%   options and local (package) options are checked when this function
-%   is called in a package.
+%   option list against the keys defined for \meta{families} (a comma-separated
+%   list). Global (class) options and local (package) options are checked when
+%   this function is called in a package.
 % \end{function}
 %
 % \begin{function}{\SetKeys}
@@ -261,6 +262,16 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}{\l_@@_local_clist}
+% \changes{v1.0q}{2025/06/25}{New variable}
+%   Holds the local options when appropriate: otherwise empty. Needed as
+%   the \LaTeXe{} setup here can be equal to \cs{scan_stop:}, which is not
+%   generally supported.
+%    \begin{macrocode}
+\clist_new:N \l_@@_local_clist
+%    \end{macrocode}
+% \end{macro}
+%
 % \begin{variable}{\l_@@_options_loading_bool}
 %   Used to indicate we are in the loading phase: controls the outcome
 %   of warnings.
@@ -278,7 +289,7 @@
 %         {Define key option handler in \pkg{ltkeys}}
 % \changes{v1.0i}{2022/07/05}{Support \cs{CurrentOption}}
 % \changes{v1.0p}{2025/01/15}{Only process global options on first pass}
-% \begin{macro}{\@@_options_end:}
+% \changes{v1.0q}{2025/06/25}{Revise for multiple family support}
 %   The main function calls functions to collect up the global and local
 %   options into \cs{l_@@_options_clist} before calling the
 %   underlying functions to actually do the processing. So that a suitable
@@ -296,35 +307,33 @@
   { \@@_options_expand_module:Nn \@@_options_aux:n {#1} }
 \cs_new_protected:Npn \@@_options_aux:n #1
   {
-    \cs_set_protected:Npn \@@_option_end: { }
-    \clist_clear:N \l_@@_options_clist
+    \@@_options_local:
+    \clist_map_inline:nn {#1}
+      {
+        \clist_clear:N \l_@@_options_clist
+        \cs_if_exist:cF { opt@handler@ \@currname . \@currext }
+          { \@@_options_global:n {##1} }
+        \@@_options_local:n {##1}
+        \bool_set_true:N \l_@@_options_loading_bool
+        \clist_map_variable:NNn \l_@@_options_clist \CurrentOption
+          { \keys_set:nV {##1} \CurrentOption }
+        \bool_set_false:N \l_@@_options_loading_bool
+        \@@_options_loaded:n {##1}
+      }
+    \clist_if_empty:NF \l_@@_unused_clist
+      {
+        \clist_map_inline:Nn \l_@@_unused_clist
+          {
+            \msg_error:nnxx { keys } { option-unknown }
+              {##1} { \@currname }
+          }
+      }
     \cs_if_exist:cF { opt@handler@ \@currname . \@currext }
       {
-        \@@_options_global:n {#1}
         \cs_gset_protected:cpn { opt@handler@ \@currname . \@currext }
-          { \ProcessKeyOptions [ #1 ] }
+          { \ProcessKeyOptions [ {#1} ] }
       }
-    \@@_options_local:
-    \keys_if_exist:nnF {#1} { unknown }
-      {
-        \keys_define:nn {#1}
-          {
-            unknown .code:n =
-              {
-                \msg_error:nnxx { keys } { option-unknown }
-                  { \l_keys_key_str } { \@currname }
-              }
-          }
-        \cs_set_protected:Npn \@@_option_end:
-          { \keys_define:nn {#1} { unknown .undefine: } }
-      }
-    \bool_set_true:N \l_@@_options_loading_bool
-    \clist_map_variable:NNn \l_@@_options_clist \CurrentOption
-      { \keys_set:nV {#1} \CurrentOption }
-    \bool_set_false:N \l_@@_options_loading_bool
     \AtEndOfPackage { \cs_set_eq:NN \@unprocessedoptions \scan_stop: }
-    \@@_option_end:
-    \@@_options_loaded:n {#1}
   }
 %    \end{macrocode}
 % \changes{v1.0j}{2022/07/23}
@@ -337,7 +346,6 @@
     but~the~package~"\msg_module_name:n {#2}"~has~not~created~an~option~with~this~name.
   }
 %    \end{macrocode}
-% \end{macro}
 % \end{macro}
 % \end{macro}
 %
@@ -476,22 +484,66 @@
 %
 % \begin{macro}{\@@_options_local:}
 % \changes{v1.0h}{2022/06/20}{Use raw options data}
+% \changes{v1.0q}{2025/06/25}{Revise for multiple family support}
 %   If local options are found, they are added to the processing list.
 %   \LaTeXe{} stores options for each file in a macro which may or may not
-%   exist, hence the need to use \cs{cs_if_exist:c}.
+%   exist, hence the need to use \cs{cs_if_exist:c}. For tracking the unused
+%   options, we need to hold only the option name, hence needing a mapping.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_options_local:
   {
+    \clist_clear:N \l_@@_local_clist
     \cs_if_eq:NNF \@currext \@clsextension
       {
         \cs_if_exist:cT { @raw@opt@ \@currname . \@currext }
           {
-            \clist_put_right:Nv \l_@@_options_clist
+            \clist_set_eq:Nc \l_@@_local_clist
               { @raw@opt@ \@currname . \@currext }
           }
       }
+    \clist_map_inline:Nn \l_@@_local_clist
+      {
+        \clist_put_right:Ne \l_@@_unused_clist
+          { \tl_trim_spaces:e { \@@_remove_equals:n {##1} } }
+      }
   }
 %    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\@@_options_local:n}
+% \changes{v1.0q}{2025/06/25}{New function}
+% \begin{macro}{\@@_options_local:nnn}
+% \changes{v1.0q}{2025/06/25}{New function}
+%   A simpler version of the code used for package options: we stack up those
+%   that are known, unless the family supports unknown keys in which case we hover
+%   up everything.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_options_local:n #1
+  {
+    \keys_if_exist:nnTF {#1} { unknown }
+      {
+        \clist_put_right:NV \l_@@_options_clist \l_@@_local_clist
+        \clist_clear:N \l_@@_unused_clist
+      }
+      {
+        \clist_map_inline:Nn \l_@@_local_clist
+          {
+            \exp_args:Ne \@@_options_local:nnn
+              { \tl_trim_spaces:e { \@@_remove_equals:n {##1} } }
+              {##1} {#1}
+          }
+      }
+  }
+\cs_new_protected:Npn \@@_options_local:nnn #1#2#3
+  {
+    \keys_if_exist:nnT {#3} {#1}
+      {
+        \clist_put_right:Nn \l_@@_options_clist {#2}
+        \clist_remove_all:Nn \l_@@_unused_clist {#1}
+      }
+   }
+%    \end{macrocode}
+% \end{macro}
 % \end{macro}
 %
 % \begin{macro}[EXP]{\@@_remove_equals:n}

--- a/base/testfiles/github-1756.lvt
+++ b/base/testfiles/github-1756.lvt
@@ -2,13 +2,13 @@
 \ProvidesExplPackage{testpackage}{2025-06-25}{}{}
 \keys_define:nn { testpackage-a }
   {
-    testoption-a .code:n = { \def \testmacroa { seen } } ,
-    testoption-b .code:n = { \def \testmacrob { seen } }
+    testoption-a .code:n = { \typeout { OPT-A } } ,
+    testoption-b .code:n = { \typeout { OPT-B } }
   }
 \keys_define:nn { testpackage-b }
   {
-    testoption-a .code:n = { \def \testmacroa { seen } } ,
-    testoption-c .code:n = { \def \testmacroc { seen } }
+    testoption-a .code:n = { \typeout { OPT-A } } ,
+    testoption-c .code:n = { \typeout { OPT-C } }
   }
 \ProcessKeyOptions [ testpackage-a ,  testpackage-b ]
 \endinput

--- a/base/testfiles/github-1756.lvt
+++ b/base/testfiles/github-1756.lvt
@@ -1,0 +1,25 @@
+\begin{filecontents*}[overwrite]{testpackage.sty}
+\ProvidesExplPackage{testpackage}{2025-06-25}{}{}
+\keys_define:nn { testpackage-a }
+  {
+    testoption-a .code:n = { \def \testmacroa { seen } } ,
+    testoption-b .code:n = { \def \testmacrob { seen } }
+  }
+\keys_define:nn { testpackage-b }
+  {
+    testoption-a .code:n = { \def \testmacroa { seen } } ,
+    testoption-c .code:n = { \def \testmacroc { seen } }
+  }
+\ProcessKeyOptions [ testpackage-a ,  testpackage-b ]
+\endinput
+\end{filecontents*}
+
+\input{test2e}
+
+\documentclass{article}
+
+\START
+
+\usepackage[testoption-a, testoption-b, testoption-c, testoption-d]{testpackage}
+
+\END

--- a/base/testfiles/github-1756.tlg
+++ b/base/testfiles/github-1756.tlg
@@ -1,0 +1,10 @@
+This is a generated file for the LaTeX2e validation system.
+Don't change this file in any respect.
+(testpackage.sty
+Package: testpackage ....-..-.. 
+! LaTeX Error: Unknown option 'testoption-d' for package testpackage.
+For immediate help type H <return>.
+ ...                                              
+l. ......Options [ testpackage-a ,  testpackage-b ]
+LaTeX has been asked to set an option called 'testoption-d' but the package "testpackage" has not created an option with this name.
+)

--- a/base/testfiles/github-1756.tlg
+++ b/base/testfiles/github-1756.tlg
@@ -2,6 +2,10 @@ This is a generated file for the LaTeX2e validation system.
 Don't change this file in any respect.
 (testpackage.sty
 Package: testpackage ....-..-.. 
+OPT-A
+OPT-B
+OPT-A
+OPT-C
 ! LaTeX Error: Unknown option 'testoption-d' for package testpackage.
 For immediate help type H <return>.
  ...                                              


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
- Under development
- [x] Ready to merge

## Checklist of required changes before merge will be approved
- [x] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
