### PR TITLE
Adjust indentation of verbatim examples

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -8,7 +8,8 @@ not part of the distribution.
 
 2025-06-24  Joseph Wright  <Joseph.Wright@latex-project.org>
 	* usrguide.tex
-	Add c-type arg. to overview (gh/1761)
+	Add c-type arg. to overview (gh/1761).
+        Indent code examples to align with other guides (gh/1800).
 
 2025-06-23  Maurice Hansen
 

--- a/base/doc/usrguide.tex
+++ b/base/doc/usrguide.tex
@@ -43,7 +43,7 @@
     \texttt{usrguide.tex} for full details.}%
 }
 
-\date{2025-06-24}
+\date{2025-06-26}
 
 \NewDocumentCommand\cs{m}{\texttt{\textbackslash\detokenize{#1}}}
 \NewDocumentCommand\marg{m}{\arg{#1}}


### PR DESCRIPTION
* base/doc/usrguide.tex: Indent content of verbatim environments with 3 spaces, like in other guides.
Unify spacing in \NewDocumentCommand examples.

FWIW: I used this small Lisp function to adjust the indentation with Emacs:
```
(defun usrguide-indent-verbatim ()
  (interactive)
  (save-excursion
    (goto-char (point-min))
    (let (i s)
      (while (re-search-forward "^\\\\begin{verbatim}[ \t]*\n" nil t)
        (setq s (point))
        ;; There is some indentation, remember what:
        (when (looking-at-p " ")
          (setq i (skip-chars-forward " ")))
        (re-search-forward "^\\\\end{verbatim}" nil t)
        ;; Unindent first:
        (when i (indent-rigidly s (line-end-position 0) (- i)))
        (indent-rigidly s (line-end-position 0) 3)
        ;; Reset for the next iteration of `while':
        (setq i nil)))))
```

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ ] Version and date string updated in changed source files
  **I didn't change the date string since there is no content change.**
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
