### PR TITLE
Delay registration of eqnarray until begindocument

### DIFF
--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -1,3 +1,8 @@
+2025-06-29  Matthew Bertucci <mbertucci@willamette.edu>
+
+	* latex-lab-math.dtx:
+        Delay registration of eqnarray until begindocument to avoid error with fleqn (tagging/844)
+
 2025-06-29  Marcel Krüger  <Marcel.Krueger@latex-project.org>
 
 	* latex-lab-math.dtx:

--- a/required/latex-lab/latex-lab-math.dtx
+++ b/required/latex-lab/latex-lab-math.dtx
@@ -21,7 +21,7 @@
 %
 
 \def\ltlabmathdate{2025-06-29}
-\def\ltlabmathversion{0.6q}
+\def\ltlabmathversion{0.6r}
 %
 %<*driver>
 \DocumentMetadata{tagging=on,pdfstandard=ua-2}
@@ -2855,9 +2855,14 @@
 % \subsection{Modifying kernel environments}
 %
 %   We need to cover this even though it is, of course, not encouraged.
+%   Registration is delayed until begindocument to avoid error with redefinition
+%   in, e.g., fleqn.clo.
 %    \begin{macrocode}
-\math_register_env:n { eqnarray }
-\math_register_env:n { eqnarray* }
+\tl_gput_right:Nn \@kernel@before@begindocument
+  {
+    \math_register_env:n { eqnarray }
+    \math_register_env:n { eqnarray* }
+  }
 %    \end{macrocode}
 %
 % Tabulars currently contain a \$ that shouldn't trigger math


### PR DESCRIPTION
# Internal housekeeping

Closes https://github.com/latex3/tagging-project/issues/844. Not sure if this is the best fix. I just copied what latex-lab-math does for `equation`.

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
