### PR TITLE
fix missing label in ltmarks

### DIFF
--- a/base/ltmarks.dtx
+++ b/base/ltmarks.dtx
@@ -17,7 +17,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltmarks.dtx}
-             [2025/06/19 v1.1d LaTeX Kernel (Marks)]
+             [2025/07/01 v1.1d LaTeX Kernel (Marks)]
 % \iffalse
 %
 \documentclass{l3doc}
@@ -328,6 +328,7 @@
 %
 %
 % \subsection{Understanding regions}
+% \label{sec:regions}
 %
 %   If a page has just been finished then the region \texttt{page}
 %   refers to the current page and \texttt{previous-page}, as the name


### PR DESCRIPTION
# Internal housekeeping

A missing `\label` in ltmarks caused an undefined reference. This just adds the label to the correct subsection.

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] ~Version and~ date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
