### PR TITLE
Fix tagging in `array` “math” cells 

### DIFF
--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -1,3 +1,7 @@
+2025-08-27  Max Chernoff <tex@maxchernoff.ca>
+
+	* latex-lab-math.dtx: Use a loop to scan for \).
+
 2025-08-21  Ulrike Fischer <Ulrike.Fischer@latex-project.org>
 	* latex-lab-block.dtx: use sockets for semantic paragraph
 	* latex-lab-marginpar.dtx: use Sect as container if there is no text-unit structure. 

--- a/required/latex-lab/latex-lab-math.dtx
+++ b/required/latex-lab/latex-lab-math.dtx
@@ -20,8 +20,8 @@
 %
 %
 
-\def\ltlabmathdate{2025-07-30}
-\def\ltlabmathversion{0.6s}
+\def\ltlabmathdate{2025-08-27}
+\def\ltlabmathversion{0.6t}
 %
 %<*driver>
 \DocumentMetadata{tagging=on,pdfstandard=ua-2}
@@ -2024,7 +2024,7 @@
 % \end{macro}
 %
 % \begin{macro}{\@@_grab_dollar:w}
-% \begin{macro}{\@@_grab_dollar:n}
+% \begin{macro}{\@@_grab:n}
 % \changes{v0.6c}{2024-08-22}{Correct handling of empty math segments}
 %   Top-level function to handle grabbing of inline math mode delimited by
 %   |$| tokens. We provide two different ways to do that: a token-by-token
@@ -2032,13 +2032,14 @@
 %   work anywhere that the end |$| token may be hidden, most obviously in
 %   tabulars. The function here is therefore set up as a variable starting
 %   point.
+% \changes{0.6t}{2025-08-27}{Use a loop to scan for \cs{)}}
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_grab_dollar:w { \@@_grab_dollar_delim:w }
 %    \end{macrocode}
 %   After grabbing inline math material, there is again common processing
 %   independent of mechanism of collection.
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_grab_dollar:n #1
+\cs_new_protected:Npn \@@_grab:n #1
   {
 %    \end{macrocode}
 %  We need to do processing first as this picks up \enquote{fake} math mode:
@@ -2081,7 +2082,7 @@
 %   any processing if the token is \tn{m@th} found in the content.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_grab_dollar_delim:w #1 $ % $
-  { \@@_grab_dollar:n {#1} }
+  { \@@_grab:n {#1} }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -2110,10 +2111,10 @@
 %    
 %
 %
-% \begin{macro}{\@@_grab_inline:w}
+% \begin{macro}{\@@_grab_inline_delim:w}
 %   Collect inline math content and deal with the need to move to math mode.
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_grab_inline:w % \(
+\cs_new_protected:Npn \@@_grab_inline_delim:w % \(
   #1 \)
   {
     \tl_if_blank:nF {#1}
@@ -2122,6 +2123,13 @@
       }
     \bool_set_false:N \l_@@_collected_bool
   }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\@@_grab_inline:w}
+%   See |\@@_grab_dollar:w|.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_grab_inline:w { \@@_grab_inline_delim:w }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -2160,13 +2168,14 @@
 %    \end{macrocode}
 % \end{variable}
 %
-% \begin{macro}{\@@_grab_dollar_loop:}
+% \begin{macro}{\@@_grab_loop_aux:}
 % \begin{macro}{\@@_grab_loop:}
 %   The lead-off here establishes a group: we need that as we will have to
 %   be careful in the way \tn{cr} is handled and ensure this is only
 %   manipulated whilst grabbing. The main loop is then started.
+% \changes{0.6t}{2025-08-27}{Use a loop to scan for \cs{)}}
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_grab_dollar_loop:
+\cs_new_protected:Npn \@@_grab_loop_aux:
   {
     \group_begin:
       \tl_clear:N \l_@@_grabbed_tl
@@ -2213,6 +2222,7 @@
 %   }
 %   Filter out the special cases: for performance reasons, use a hash table
 %   approach rather than a loop (\emph{cf.}~\pkg{collcell}).
+% \changes{0.6t}{2025-08-27}{Use a loop to scan for \cs{)}}
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_grab_loop_token:N #1
   {
@@ -2221,6 +2231,8 @@
       { \@@_grab_loop_store:n {#1} }
   }
 \cs_new_protected:cpn { @@_grab_loop_ \token_to_str:N $ : }
+  { \@@_grab_loop_end: }
+\cs_new_protected:cpn { @@_grab_loop_ \token_to_str:N \) : }
   { \@@_grab_loop_end: }
 \cs_new_protected:cpn { @@_grab_loop_ \token_to_str:N \\ : }
   {
@@ -2290,7 +2302,7 @@
 \cs_new_protected:Npn \@@_grab_loop_end:
   {
     \exp_args:NNV \group_end:
-    \@@_grab_dollar:n \l_@@_grabbed_tl
+    \@@_grab:n \l_@@_grabbed_tl
   }
 %    \end{macrocode}
 % \end{macro}
@@ -2875,7 +2887,10 @@
 \tl_if_exist:NT\@kernel@tabular@init
  {
    \tl_put_right:Nn\@kernel@tabular@init
-    {\cs_set_protected:Npn \@@_grab_dollar:w { \@@_grab_dollar_loop: }}
+    {
+      \cs_set_protected:Npn \@@_grab_dollar:w { \@@_grab_loop_aux: }
+      \cs_set_protected:Npn \@@_grab_inline:w { $ }
+    }
  }
 %    \end{macrocode}
 %

--- a/required/latex-lab/testfiles-math-luatex/mathml-luamml-array.lvt
+++ b/required/latex-lab/testfiles-math-luatex/mathml-luamml-array.lvt
@@ -1,0 +1,21 @@
+\DocumentMetadata{lang=en, tagging=on}
+\input{regression-test}
+\tagpdfsetup{math/mathml/luamml/load=true}
+
+\documentclass{article}
+
+\START
+\SHOWFILE{mathml-luamml-array-luamml-mathml.html}
+\OMIT
+\begin{document}
+    \TIMO
+    
+    $aaa$
+    \(bbb\)
+    \begin{tabular}{>{$}r<{$}}
+        ccc
+    \end{tabular}
+    \begin{tabular}{>{\(}r<{\)}}
+        ddd
+    \end{tabular}
+\end{document}

--- a/required/latex-lab/testfiles-math-luatex/mathml-luamml-array.tlg
+++ b/required/latex-lab/testfiles-math-luatex/mathml-luamml-array.tlg
@@ -1,0 +1,84 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+-------- mathml-luamml-array-luamml-mathml.html (start) ---------
+(mathml-luamml-array-luamml-mathml.html) <!DOCTYPE html>[nl]
+<html xmlns="http://www.w3.org/1999/xhtml">[nl]
+[nl]
+<div>[nl]
+<h2>\mml 1</h2>[nl]
+<p>$aaa$</p>[nl]
+<p>6CA725F1CE355FC4D1ABF1D6120357A1</p>[nl]
+[nl]
+<math xmlns="http://www.w3.org/1998/Math/MathML">[nl]
+ <mi>𝑎</mi>[nl]
+ <mi>𝑎</mi>[nl]
+ <mi>𝑎</mi>[nl]
+</math>[nl]
+</div>[nl]
+[nl]
+<div>[nl]
+<h2>\mml 2</h2>[nl]
+<p>$bbb$</p>[nl]
+<p>DD72AF2292CCDB64265D6909B5EB0878</p>[nl]
+[nl]
+<math xmlns="http://www.w3.org/1998/Math/MathML">[nl]
+ <mi>𝑏</mi>[nl]
+ <mi>𝑏</mi>[nl]
+ <mi>𝑏</mi>[nl]
+</math>[nl]
+</div>[nl]
+[nl]
+<div>[nl]
+<h2>\mml 3</h2>[nl]
+<p>$ccc$</p>[nl]
+<p>E25DDB1B7908E8DD2D244D7D2A2D1C0A</p>[nl]
+[nl]
+<math xmlns="http://www.w3.org/1998/Math/MathML">[nl]
+ <mi>𝑐</mi>[nl]
+ <mi>𝑐</mi>[nl]
+ <mi>𝑐</mi>[nl]
+</math>[nl]
+</div>[nl]
+[nl]
+<div>[nl]
+<h2>\mml 4</h2>[nl]
+<p>$ddd$</p>[nl]
+<p>EC4C708D55ED11F964B372C8A9B1F12D</p>[nl]
+[nl]
+<math xmlns="http://www.w3.org/1998/Math/MathML">[nl]
+ <mi>𝑑</mi>[nl]
+ <mi>𝑑</mi>[nl]
+ <mi>𝑑</mi>[nl]
+</math>[nl]
+</div>[nl]
+[nl]
+</html>[nl]
+-------- mathml-luamml-array-luamml-mathml.html (end) -----------
+Inserting mathml with Hash 6CA725F1CE355FC4D1ABF1D6120357A1
+====>grabbed math=macro:->aaa
+Inserting mathml with Hash DD72AF2292CCDB64265D6909B5EB0878
+====>grabbed math=macro:->bbb
+Inserting mathml with Hash E25DDB1B7908E8DD2D244D7D2A2D1C0A
+====>grabbed math=macro:->ccc
+Inserting mathml with Hash EC4C708D55ED11F964B372C8A9B1F12D
+====>grabbed math=macro:->ddd
+[1
+]<<latex-list-css.html>><<latex-align-css.html>> (mathml-luamml-array.aux)
+MathML statistic
+================
+==> 4 MathML fragments read
+==> 4 different MathML fragments
+==> 4 math fragments found
+==> 4 fitting MathML AF found
+==> 4 MathML AF attached
+Package tagpdf Info: Finalizing the tagging structure:
+(tagpdf)             Writing out ~18 structure objects
+(tagpdf)             with ~15 'MC' leaf nodes.
+(tagpdf)             Be patient if there are lots of objects!
+Package tagpdf Info: writing ParentTree
+Package tagpdf Info: writing IDTree
+Package tagpdf Info: writing RoleMap
+Package tagpdf Info: writing ClassMap
+Package tagpdf Info: writing NameSpaces
+Package tagpdf Info: writing StructElems
+Package tagpdf Info: writing Root

--- a/required/tools/array.dtx
+++ b/required/tools/array.dtx
@@ -39,7 +39,7 @@
 %    \begin{macrocode}
 %<+package>\NeedsTeXFormat{LaTeX2e}[2024/06/01]
 %<+package>\ProvidesPackage{array}
-%<+package>         [2025/07/18 v2.6k Tabular extension package (FMi)]
+%<+package>         [2025/08/27 v2.6l Tabular extension package (FMi)]
 %
 % \fi
 %
@@ -2950,9 +2950,11 @@ Bug reports can be opened (category \texttt{#1}) at\\%
 %    =\d@llar...=.
 % \changes{v2.0d}{1990/08/20}{`d@llar local to preamble.}
 % \changes{v2.6h}{2025/02/18}{Surround dollar with \cs{MathCollectTrue}/\cs{MathCollectFalse}}%    
+% \changes{v2.6l}{2025/08/27}{Decrement the math level when array columns are used}
 %    \begin{macrocode}
   \hbox \bgroup 
     \MathCollectFalse$\MathCollectTrue
+    \advance\@math@level\m@ne
     \col@sep\tabcolsep \let\d@llarbegin\begingroup
                                     \let\d@llarend\endgroup
 %    \end{macrocode}

--- a/required/tools/changes.txt
+++ b/required/tools/changes.txt
@@ -5,6 +5,11 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 =======================================================================
 
+2025-08-27  Max Chernoff  <tex@maxchernoff.ca>
+
+	* array.dtx (section{The Environment Definitions}): Correctly handle math
+	grabbing with math-type columns.
+
 2025-07-18  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 
 	* array.dtx (section{Building and calling \texttt{\textbackslash halign}}):


### PR DESCRIPTION
Fixes latex3/tagging-project#983.

`l3build check` passes, but I wouldn't be surprised if some third-party package depends on `array` incrementing the math level.

I _think_ that this should be fine without an explicit rollback since the `2023-11-01` rollback should handle most cases for `array` and `latex-lab` doesn't use rollback (I think), but let me know if you want me to add the rollback code.

# Internal housekeeping

## Status of pull request

- Feedback wanted

## Checklist of required changes before merge will be approved
- [x] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
