### PR TITLE
Add missing variant `\property_ref_undefined_warn:e`

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,10 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
+2025-09-05  Yukai Chou  <muzimuzhi@gmail.com>
+	* ltproperties.dtx: Add missing variant \property_ref_undefined_warn:e
+		(gh/1854)
+
 2025-08-23  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
 	* lttagging.dtx: Add generic tagging sockets and sockets for paraOn/Off.
     * lttagging.dtx: move para-sockets from tagpdf to lttagging, use tagging sockets for the semantic paragraph.

--- a/base/ltproperties.dtx
+++ b/base/ltproperties.dtx
@@ -30,7 +30,7 @@
 %<*driver> 
 % \fi
 \ProvidesFile{ltproperties.dtx}
-             [2025/08/01 v1.0j LaTeX Kernel (Properties)]
+             [2025/09/05 v1.0k LaTeX Kernel (Properties)]
 % \iffalse
 %
 \documentclass[full]{l3doc}
@@ -828,7 +828,9 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\property_ref_undefined_warn:n}
+% \begin{macro}{\property_ref_undefined_warn:n,
+%               \property_ref_undefined_warn:e}
+%   \changes{v1.0k}{2025-09-05}{Add missing |e| variant (gh/1854)}
 %    \begin{macrocode}
 \cs_new_protected:Npn \property_ref_undefined_warn:n #1 %#1 label
   {
@@ -838,6 +840,7 @@
        \@latex@warning{Reference~`#1'~on~page~\thepage\space undefined}%
     }         
   }
+\cs_generate_variant:Nn \property_ref_undefined_warn:n {e}
 %    \end{macrocode}
 % \end{macro}
 %


### PR DESCRIPTION
See #1854.

- 214ce87af (expand label/property name consistently in LaTeX2e commands, 2023-09-13) added `\property_ref_undefined_warn:x` to the documentation
- e32d404e7 (Ltproperties activechars (#<span>1140</span>), 2023-10-29) renamed `x` variants to `e` variants.

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
