### PR TITLE
Skip hash doubling if not required in hook code

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -19,6 +19,9 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
+2025-09-23  Joseph Wright  <Joseph.Wright@latex-project.org>
+	* lthooks.dtx
+	Skip hash doubling if not required (gh/1860)
 
 2025-09-23  David Carlisle  <David.Carlisle@latex-project.org>
 

--- a/base/changes.txt
+++ b/base/changes.txt
@@ -19,7 +19,7 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
-2025-09-23  Joseph Wright  <Joseph.Wright@latex-project.org>
+2025-09-24  Joseph Wright  <Joseph.Wright@latex-project.org>
 	* lthooks.dtx
 	Skip hash doubling if not required (gh/1860)
 

--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -32,7 +32,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{lthooks.dtx}
-             [2025/09/23 v1.1m LaTeX Kernel (hooks)]
+             [2025/09/24 v1.1n LaTeX Kernel (hooks)]
 % \iffalse
 %
 \documentclass{l3doc}

--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -3643,6 +3643,10 @@
 %     \@@_prop_gput_labeled_cleanup:nnn,
 %     \@@_prop_gput_labeled_do:Nnnn
 %    }
+% \begin{macro}[EXP]{\@@_hash_check:nTF}
+% \changes{v1.1n}{2025/09/23}{New function}
+% \begin{macro}[EXP]{\@@_hash_check_aux:w}
+% \changes{v1.1n}{2025/09/23}{New function}
 %
 %    With \cs{hook_gput_code:nnn}\Arg{hook}\Arg{label}\Arg{code} a
 %    chunk of \meta{code} is added to an existing \meta{hook} labeled
@@ -3777,21 +3781,41 @@
       }
       {
 %    \end{macrocode}
+% \changes{v1.1n}{2025/09/23}{Only double hashes when needed}
 %   When adding to the code pool, we have to double hashes if
 %   \cs{AddToHook} was used (\verb|replacing_args| is false), so that
 %   later it is turned into a single parameter token, rather than a
-%   parameter to the hook macro.
+%   parameter to the hook macro. We skip this step if there are
+%   no hashes at all in the argument: the token-by-token approach
+%   otherwise becomes a major performance issue when the contents of
+%   the hook are long.
 %    \begin{macrocode}
         \exp_args:Nx \@@_prop_gput_labeled_cleanup:nnn
           {
             \@@_if_replacing_args:TF
               { \exp_not:n }
-              { \@@_double_hashes:n }
+              {
+                \@@_hash_check:nTF {#3}
+                  { \exp_not:n }
+                  { \@@_double_hashes:n }
+              }
                 {#3}
           }
           {#1} {#2}
       }
   }
+\cs_new:Npx \@@_hash_check:nTF #1
+  {
+    \exp_not:N \exp_after:wN \exp_not:N \@@_hash_check_aux:w
+      \exp_not:N \tl_to_str:n {#1} \c_hash_str \c_hash_str
+      \exp_not:N \q_stop
+  }
+\use:x
+  {
+    \cs_new:Npn \exp_not:N \@@_hash_check_aux:w
+      ##1 \c_hash_str ##2 \c_hash_str ##3 \exp_not:N \q_stop
+  }
+  { \tl_if_blank:nTF {#3} }
 %    \end{macrocode}
 %
 %   Adds code to a hook's code pool.
@@ -3880,6 +3904,8 @@
 %<latexrelease>\cs_gset_protected:Npn \hook_gput_code_with_args:nnn #1#2#3 { }
 %<latexrelease>\EndIncludeInRelease
 %    \end{macrocode}
+% \end{macro}
+% \end{macro}
 % \end{macro}
 % \end{macro}
 %

--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -3815,7 +3815,7 @@
     \cs_new:Npn \exp_not:N \@@_hash_check_aux:w
       ##1 \c_hash_str ##2 \c_hash_str ##3 \exp_not:N \q_stop
   }
-  { \tl_if_blank:nTF {#3} }
+  { \tl_if_empty:nTF {#3} }
 %    \end{macrocode}
 %
 %   Adds code to a hook's code pool.

--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -3644,9 +3644,9 @@
 %     \@@_prop_gput_labeled_do:Nnnn
 %    }
 % \begin{macro}[EXP]{\@@_hash_check:nTF}
-% \changes{v1.1n}{2025/09/23}{New function}
+% \changes{v1.1n}{2025/09/24}{New function}
 % \begin{macro}[EXP]{\@@_hash_check_aux:w}
-% \changes{v1.1n}{2025/09/23}{New function}
+% \changes{v1.1n}{2025/09/24}{New function}
 %
 %    With \cs{hook_gput_code:nnn}\Arg{hook}\Arg{label}\Arg{code} a
 %    chunk of \meta{code} is added to an existing \meta{hook} labeled
@@ -3781,7 +3781,7 @@
       }
       {
 %    \end{macrocode}
-% \changes{v1.1n}{2025/09/23}{Only double hashes when needed}
+% \changes{v1.1n}{2025/09/24}{Only double hashes when needed}
 %   When adding to the code pool, we have to double hashes if
 %   \cs{AddToHook} was used (\verb|replacing_args| is false), so that
 %   later it is turned into a single parameter token, rather than a

--- a/base/testfiles/github-1860.lvt
+++ b/base/testfiles/github-1860.lvt
@@ -1,0 +1,21 @@
+\documentclass{article}
+
+\input{test2e}
+
+\START
+\ExplSyntaxOn
+\hook_gput_code:nnn { begindocument/before } { somelabel }
+  {
+    \def \foo { FOO }
+  }
+\hook_gput_code:nnn { begindocument/before } { somelabel }
+  {
+    \def \fooa #1 {#1}
+  }
+\ExplSyntaxOff
+\OMIT
+\begin{document}
+\TIMO
+\show \foo
+\show \fooa
+\END

--- a/base/testfiles/github-1860.tlg
+++ b/base/testfiles/github-1860.tlg
@@ -1,0 +1,8 @@
+This is a generated file for the LaTeX2e validation system.
+Don't change this file in any respect.
+> \foo=macro:
+->FOO.
+l. ...\show \foo
+> \fooa=macro:
+#1->#1.
+l. ...\show \fooa


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
- Under development
- [x] Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
