### PR TITLE
double @@ for l3doc

### DIFF
--- a/required/tools/array.dtx
+++ b/required/tools/array.dtx
@@ -2525,6 +2525,7 @@ Bug reports can be opened (category \texttt{#1}) at\\%
 %    start the wanted =\halign=.
 %    \changes{v2.3b}{1994/12/08}{add \cs{tabularnewline}}
 %    \changes{v2.6m}{2025/09/24}{Check \cs{currentgrouptype} in \cs{par} (gh1864)}
+%    \changes{v2.6n}{2025/09/25}{double @ for l3doc conventions (gh1864)}
 %    \begin{macrocode}
   \let\\\@arraycr \let\tabularnewline\\%
   \def\par{\ifnum\currentgrouptype=6~ \else\@@@@par\fi}%

--- a/required/tools/array.dtx
+++ b/required/tools/array.dtx
@@ -39,7 +39,7 @@
 %    \begin{macrocode}
 %<+package>\NeedsTeXFormat{LaTeX2e}[2024/06/01]
 %<+package>\ProvidesPackage{array}
-%<+package>         [2025/09/24 v2.6m Tabular extension package (FMi)]
+%<+package>         [2025/09/25 v2.6n Tabular extension package (FMi)]
 %
 % \fi
 %
@@ -2527,7 +2527,7 @@ Bug reports can be opened (category \texttt{#1}) at\\%
 %    \changes{v2.6m}{2025/09/24}{Check \cs{currentgrouptype} in \cs{par} (gh1864)}
 %    \begin{macrocode}
   \let\\\@arraycr \let\tabularnewline\\%
-  \def\par{\ifnum\currentgrouptype=6~ \else\@@par\fi}%
+  \def\par{\ifnum\currentgrouptype=6~ \else\@@@@par\fi}%
 %    \end{macrocode}
 %    Another socket for tagging. TODO: what about \cs{arrayleft} above?
 %    \begin{macrocode}

--- a/required/tools/changes.txt
+++ b/required/tools/changes.txt
@@ -5,6 +5,10 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 =======================================================================
 
+2025-09-25  David Carlisle  <David.Carlisle@latex-project.org>
+
+	* array.dtx: double @@ for l3doc conventions
+
 2025-09-24  David Carlisle  <David.Carlisle@latex-project.org>
 
 	* array.dtx: Check \currentgrouptype  in \par (gh1864)

--- a/required/tools/testfiles/github-1864b.lvt
+++ b/required/tools/testfiles/github-1864b.lvt
@@ -1,0 +1,33 @@
+
+\documentclass{article}
+\usepackage{array}
+\input{test2e}
+% should produce 7 typeout
+\AddToHook{para/end}{\typeout{!END OF PARA}}
+
+\hfuzz=\maxdimen
+
+\begin{document}
+
+$x$
+
+\START
+
+AAA
+
+BBB
+
+\vbox{CCC}
+
+xxx\vadjust{DDD}EEE
+
+\begin{tabular}{l}
+111\\
+
+\noalign{FFF}%
+222
+\end{tabular}GGG
+
+
+\end{document}
+

--- a/required/tools/testfiles/github-1864b.tlg
+++ b/required/tools/testfiles/github-1864b.tlg
@@ -1,0 +1,11 @@
+This is a generated file for the LaTeX2e validation system.
+Don't change this file in any respect.
+!END OF PARA
+!END OF PARA
+!END OF PARA
+!END OF PARA
+!END OF PARA
+!END OF PARA
+!END OF PARA
+[1
+] (github-1864b.aux)


### PR DESCRIPTION

`\@@par` needs to be written as `\@@@@par` in yesterday's update, as it's within a `%<@@=tbl` region.