### PR TITLE
Tagging 994

### DIFF
--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -1,3 +1,7 @@
+2025-09-25  Ulrike Fischer <Ulrike.Fischer@latex-project.org>
+	* documentmetadata-support.dtx: disable \tagpdfsetup if tagging is off, tagging/994
+	* latex-lab-graphic.dtx: correct example
+
 2025-09-15  Clea F. Rees  <cfr@noreply.codeberg.org>
 
 	* latex-lab-context.dtx (typos/English fixes)

--- a/required/latex-lab/documentmetadata-support.dtx
+++ b/required/latex-lab/documentmetadata-support.dtx
@@ -607,7 +607,7 @@
 % We disable the setup command, as various keys assume that the tagging structure is there,
 % see tagging-project issue \#994.
 %    \begin{macrocode}
-           \cs_set_eq:NN\tagpdfsetup\use_none:n
+           \cs_set_protected:Npn\tagpdfsetup##1{}
 %    \end{macrocode}
 %
 %    perhaps, need to test:

--- a/required/latex-lab/documentmetadata-support.dtx
+++ b/required/latex-lab/documentmetadata-support.dtx
@@ -18,8 +18,8 @@
 % for those people who are interested or want to report an issue.
 %
 %    \begin{macrocode}
-\def\documentmetadatasupportversion{1.0s}
-\def\documentmetadatasupportdate{2025-07-07}
+\def\documentmetadatasupportversion{1.0t}
+\def\documentmetadatasupportdate{2025-09-25}
 %    \end{macrocode}
 %
 %
@@ -603,6 +603,13 @@
 %    \begin{macrocode}
            \tag_suspend:n {global}
 %    \end{macrocode}
+% \changes{v1.0t}{2025/09/25}{Disable \cs{tagpdfsetup}}
+% We disable the setup command, as various keys assume that the tagging structure is there,
+% see tagging-project issue \#994.
+%    \begin{macrocode}
+           \cs_set_eq:NN\tagpdfsetup\use_none:n
+%    \end{macrocode}
+%
 %    perhaps, need to test:
 %    \begin{macrocode}
            %\cs_set_eq:NN\tag_suspend:n\use_none:n

--- a/required/latex-lab/latex-lab-graphic.dtx
+++ b/required/latex-lab/latex-lab-graphic.dtx
@@ -15,8 +15,8 @@
 %    https://github.com/latex3/latex2e/required/latex-lab
 %
 % for those people who are interested or want to report an issue.
-\def\ltlabgraphicdate{2025-07-28}
-\def\ltlabgraphicversion{0.80h}
+\def\ltlabgraphicdate{2025-09-25}
+\def\ltlabgraphicversion{0.80i}
 %
 %<*driver>
 \DocumentMetadata{tagging=on,pdfstandard=ua-2}
@@ -592,8 +592,7 @@
 % A tagging aware environment can then be defined like this
 % \begin{verbatim}
 % \NewDocumentEnvironment{tagged-draw}{O{}}
-%  {\leavevmode
-%   \ExplSyntaxOn
+%  {\leavevmode  
 %   \tag_socket_use:nn{graphic/init}{#1} 
 %   \tag_socket_use:nn{graphic/begin}{tagged-draw~environment}
 %   \tag_suspend:n{\draw} %

--- a/required/latex-lab/testfiles/gh-tagging994.luatex.tlg
+++ b/required/latex-lab/testfiles/gh-tagging994.luatex.tlg
@@ -1,0 +1,91 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+Completed box being shipped out [1]
+\vbox(633.0+0.0)x407.0, direction TLT
+.\hbox(0.0+0.0)x0.0, direction TLT
+..\kern-72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil, direction TLT
+...\kern-72.26999
+...\hbox(0.0+0.0)x0.0, direction TLT
+....\latelua0{ltx.__pdf.backend_ThisPage_gpush(tex.count["g_shipout_readonly_int"])}
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue 16.0
+.\vbox(617.0+0.0)x345.0, shifted 62.0, direction TLT
+..\vbox(12.0+0.0)x345.0, glue set 12.0fil, direction TLT
+...\glue 0.0 plus 1.0fil
+...\pdflinkstate 1
+...\hbox(0.0+0.0)x345.0, direction TLT
+....\hbox(0.0+0.0)x345.0, direction TLT
+...\pdflinkstate 0
+..\glue 25.0
+..\glue(\lineskip) 0.0
+..\vbox(550.0+0.0)x345.0, glue set 530.9433fil, direction TLT
+...\write-{}
+...\glue(\topskip) 0.0
+...\hbox(14.5+9.5)x345.0, glue set 300.99997fil, direction TLT
+....\localpar
+.....\localinterlinepenalty=0
+.....\localbrokenpenalty=0
+.....\localleftbox=null
+.....\localrightbox=null
+....\hbox(0.0+0.0)x15.0, direction TLT
+....\hbox(14.5+9.5)x29.00003, direction TLT
+.....\mathon
+.....\vbox(14.5+9.5)x29.00003, direction TLT
+......\hbox(8.39996+3.60004)x29.00003, direction TLT
+.......\glue(\tabskip) 0.0
+.......\hbox(8.39996+3.60004)x17.00003, direction TLT
+........\rule(8.39996+3.60004)x0.0
+........\glue 6.0
+........\glue 0.0 plus 1.0fil
+........\glue 0.00002
+........\OT1/cmr/m/n/10 1
+........\glue 0.0 plus 1.0fil
+........\glue 6.0
+.......\glue(\tabskip) 0.0
+.......\hbox(8.39996+3.60004)x12.0, direction TLT
+........\glue 6.0
+........\glue 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fil
+........\glue 6.0
+.......\glue(\tabskip) 0.0
+......\glue(\lineskip) 0.0
+......\hbox(8.39996+3.60004)x29.00003, direction TLT
+.......\glue(\tabskip) 0.0
+.......\hbox(8.39996+3.60004)x17.00003, direction TLT
+........\rule(8.39996+3.60004)x0.0
+........\glue 6.0
+........\glue 0.0 plus 1.0fil
+........\glue 0.00002
+........\OT1/cmr/m/n/10 3
+........\glue 0.0 plus 1.0fil
+........\glue 6.0
+.......\glue(\tabskip) 0.0
+.......\hbox(8.39996+3.60004)x12.0, direction TLT
+........\glue 6.0
+........\glue 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fil
+........\glue 6.0
+.......\glue(\tabskip) 0.0
+.....\mathoff
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue -5.0
+...\glue 0.0 plus 1.0fil
+...\glue 0.0
+...\glue 0.0 plus 0.0001fil
+..\pdflinkstate 1
+..\glue(\baselineskip) 23.55556
+..\hbox(6.44444+0.0)x345.0, direction TLT
+...\hbox(6.44444+0.0)x345.0, glue set 170.0fil, direction TLT
+....\glue 0.0 plus 1.0fil
+....\OT1/cmr/m/n/10 1
+....\glue 0.0 plus 1.0fil
+..\pdflinkstate 0
+.\kern0.0
+.\kern-633.0
+.\hbox(0.0+0.0)x0.0, direction TLT
+.\kern633.0
+(gh-tagging994.aux)

--- a/required/latex-lab/testfiles/gh-tagging994.lvt
+++ b/required/latex-lab/testfiles/gh-tagging994.lvt
@@ -1,0 +1,10 @@
+\DocumentMetadata{lang=en,tagging=off}
+\input{regression-test}
+\documentclass{article}
+\begin{document}
+\START\showoutput
+\begin{tabular}{cc}
+1&\tagpdfsetup{table/multirow={2}}\\
+3&
+\end{tabular}
+\end{document}

--- a/required/latex-lab/testfiles/gh-tagging994.tlg
+++ b/required/latex-lab/testfiles/gh-tagging994.tlg
@@ -1,0 +1,85 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+Completed box being shipped out [1]
+\vbox(633.0+0.0)x407.0
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue 16.0
+.\vbox(617.0+0.0)x345.0, shifted 62.0
+..\vbox(12.0+0.0)x345.0, glue set 12.0fil
+...\glue 0.0 plus 1.0fil
+...\pdfrunninglinkoff
+...\hbox(0.0+0.0)x345.0
+....\hbox(0.0+0.0)x345.0
+...\pdfrunninglinkon
+..\glue 25.0
+..\glue(\lineskip) 0.0
+..\vbox(550.0+0.0)x345.0, glue set 530.94328fil
+...\write-{}
+...\glue(\topskip) 0.0
+...\hbox(14.5+9.5)x345.0, glue set 301.0012fil
+....\hbox(0.0+0.0)x15.0
+....\hbox(14.5+9.5)x28.9988
+.....\mathon
+.....\vbox(14.5+9.5)x28.9988
+......\hbox(8.39996+3.60004)x28.9988
+.......\glue(\tabskip) 0.0
+.......\hbox(8.39996+3.60004)x16.9988
+........\rule(8.39996+3.60004)x0.0
+........\glue 6.0
+........\glue 0.0 plus 1.0fil
+........\glue 0.00002
+........\T1/cmr/m/n/10 1
+........\glue 0.0 plus 1.0fil
+........\glue 6.0
+.......\glue(\tabskip) 0.0
+.......\hbox(8.39996+3.60004)x12.0
+........\glue 6.0
+........\glue 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fil
+........\glue 6.0
+.......\glue(\tabskip) 0.0
+......\glue(\lineskip) 0.0
+......\hbox(8.39996+3.60004)x28.9988
+.......\glue(\tabskip) 0.0
+.......\hbox(8.39996+3.60004)x16.9988
+........\rule(8.39996+3.60004)x0.0
+........\glue 6.0
+........\glue 0.0 plus 1.0fil
+........\glue 0.00002
+........\T1/cmr/m/n/10 3
+........\glue 0.0 plus 1.0fil
+........\glue 6.0
+.......\glue(\tabskip) 0.0
+.......\hbox(8.39996+3.60004)x12.0
+........\glue 6.0
+........\glue 0.0 plus 1.0fil
+........\glue 0.0 plus 1.0fil
+........\glue 6.0
+.......\glue(\tabskip) 0.0
+.....\mathoff
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue -5.0
+...\glue 0.0 plus 1.0fil
+...\glue 0.0
+...\glue 0.0 plus 0.0001fil
+..\pdfrunninglinkoff
+..\glue(\baselineskip) 23.5849
+..\hbox(6.4151+0.0)x345.0
+...\hbox(6.4151+0.0)x345.0, glue set 170.00061fil
+....\glue 0.0 plus 1.0fil
+....\T1/cmr/m/n/10 1
+....\glue 0.0 plus 1.0fil
+..\pdfrunninglinkon
+.\kern 0.0
+.\kern -633.0
+.\hbox(0.0+0.0)x0.0
+.\kern 633.0
+(gh-tagging994.aux)


### PR DESCRIPTION
Disable \tagpdfsetup is tagging=off is used https://github.com/latex3/tagging-project/issues/994

## Status of pull request
- Ready to merge

## Checklist of required changes before merge will be approved
- [x] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [n/a ] Rollback provided (if necessary)?
- [n/a ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
