### PR TITLE
Merge command doc groups in lthooks.dtx

### DIFF
--- a/base/lthooks.dtx
+++ b/base/lthooks.dtx
@@ -32,7 +32,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{lthooks.dtx}
-             [2025/10/01 v1.1n LaTeX Kernel (hooks)]
+             [2025/11/24 v1.1n LaTeX Kernel (hooks)]
 % \iffalse
 %
 \documentclass{l3doc}
@@ -1156,14 +1156,9 @@
 %
 %
 %
-% \begin{function}{\hook_use:n}
+% \begin{function}{\hook_use:n, \hook_use:nnw}
 %   \begin{syntax}
-%     ~~\cs{hook_use:n} \Arg{hook}
-%   \end{syntax}
-% \end{function}
-% \vskip-1.2\baselineskip
-% \begin{function}{\hook_use:nnw}
-%   \begin{syntax}
+%     \cs{hook_use:n} \Arg{hook}
 %     \cs{hook_use:nnw} \Arg{hook} \Arg{number} \Arg{arg_1} \ldots \Arg{arg_n}
 %   \end{syntax}
 %    Executes the \Arg{hook} code followed (if set up) by the code for next
@@ -1179,14 +1174,9 @@
 %    A leading |.| is treated literally.
 % \end{function}
 %
-% \begin{function}{\hook_use_once:n}
+% \begin{function}{\hook_use_once:n, \hook_use_once:nnw}
 %   \begin{syntax}
 %     \cs{hook_use_once:n} \Arg{hook}
-%   \end{syntax}
-% \end{function}
-% \vskip-1.2\baselineskip
-% \begin{function}{\hook_use_once:nnw}
-%   \begin{syntax}
 %     \cs{hook_use_once:nnw} \Arg{hook} \Arg{number} \Arg{arg_1} \ldots \Arg{arg_n}
 %   \end{syntax}
 %     Changes the \Arg{hook} status so that from now on any addition to
@@ -1204,17 +1194,10 @@
 % \end{function}
 %
 % \begin{function}{
-%     \hook_gput_code:nnn,
+%     \hook_gput_code:nnn, \hook_gput_code_with_args:nnn
 %   }
 %   \begin{syntax}
-%     ~~~~~~~~~\cs{hook_gput_code:nnn} \Arg{hook} \Arg{label} \Arg{code}
-%   \end{syntax}
-% \end{function}
-% \vskip -1.2\baselineskip
-% \begin{function}{
-%     \hook_gput_code_with_args:nnn
-%   }
-%   \begin{syntax}
+%     \cs{hook_gput_code:nnn}           \Arg{hook} \Arg{label} \Arg{code}
 %     \cs{hook_gput_code_with_args:nnn} \Arg{hook} \Arg{label} \Arg{code}
 %   \end{syntax}
 %    Adds a chunk of \meta{code} to the \meta{hook} labeled
@@ -1239,17 +1222,10 @@
 % \end{function}
 %
 % \begin{function}{
-%     \hook_gput_next_code:nn,
+%     \hook_gput_next_code:nn, \hook_gput_next_code_with_args:nn
 %   }
 %   \begin{syntax}
-%     ~~~~~~~~~~~~~\cs{hook_gput_next_code:nn} \Arg{hook} \Arg{code}
-%   \end{syntax}
-% \end{function}
-% \vskip-1.2\baselineskip
-% \begin{function}{
-%     \hook_gput_next_code_with_args:nn,
-%   }
-%   \begin{syntax}
+%     \cs{hook_gput_next_code:nn}           \Arg{hook} \Arg{code}
 %     \cs{hook_gput_next_code_with_args:nn} \Arg{hook} \Arg{code}
 %   \end{syntax}
 %    Adds a chunk of \meta{code} for use only in the next invocation of the


### PR DESCRIPTION
Those `function` envs were split for marking added dates. Since those dates were removed now, the envs can be merged again.

45c76f0a8 (Tag new functions in lthooks.dtx (#1241), 2024-01-16)
09625e687 (remove the "added=" notes that were added in 2023 - no longer useful, 2025-10-02)

Also in command syntaxes, alignment spaces are
- only kept for command groups having exactly the same arguments, and
- moved from the left to the right side of commands, to better align with the style used for \hook_use:n and \hook_show:n syntaxes.

| Before | After |
|--------|--------|
| <img width="667" height="83" alt="image" src="https://github.com/user-attachments/assets/e3e8e627-28a8-4ae7-9c97-ba593c3fc56d" /> | <img width="649" height="67" alt="image" src="https://github.com/user-attachments/assets/02708a11-33ad-404c-8092-7f6da53b762d" /> |
| <img width="754" height="82" alt="image" src="https://github.com/user-attachments/assets/dcd7ce7a-ac71-42db-bde6-0c4af8f65654" /> | <img width="736" height="64" alt="image" src="https://github.com/user-attachments/assets/9eaff834-8848-4b78-9d58-5fba039950d4" /> |
| <img width="816" height="561" alt="image" src="https://github.com/user-attachments/assets/0e117c58-f93f-4daa-9281-d1608f780b1d" /> | <img width="801" height="65" alt="image" src="https://github.com/user-attachments/assets/18a9efd8-c8e3-485a-a28f-050596c07c78" /> |
| <img width="795" height="75" alt="image" src="https://github.com/user-attachments/assets/ec5202be-62c8-467d-aae4-450b5ac4ad35" /> | <img width="786" height="71" alt="image" src="https://github.com/user-attachments/assets/0566e16c-819e-45ea-b8f1-4310a9c3688d" /> |


# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
