### PR TITLE
bit more documentation on .code property  for #1928

### DIFF
--- a/base/doc/clsguide.tex
+++ b/base/doc/clsguide.tex
@@ -42,7 +42,7 @@
     \texttt{clsguide.tex} for full details.}%
 }
 
-\date{2025-10-02}
+\date{2025-12-06}
 
 \NewDocumentCommand\cs{m}{\texttt{\textbackslash\detokenize{#1}}}
 \NewDocumentCommand\marg{m}{\arg{#1}}
@@ -854,7 +854,8 @@ This command creates a series of options from a comma-separated
 
 The basic properties provided here are
 \begin{itemize}
-  \item \texttt{.code} --- executes arbitrary code
+  \item \texttt{.code} --- executes arbitrary code; within the code one can refer to the
+     value of the key using \texttt{\#1} 
   \item \texttt{.if} --- sets a \TeX{} |\if...| switch
   \item \texttt{.ifnot} --- sets an inverted \TeX{} |\if...| switch
   \item \texttt{.pass-to-packages} --- for class options, this specifies
@@ -872,18 +873,22 @@ For example, with
 \begin{verbatim}
    \DeclareKeys[mypkg]
      {
-       draft.if          = @mypkg@draft      ,
-       draft.usage       = preamble          ,
-       name.store        = \@mypkg@name      ,
-       name.usage        = load              ,
-       second-name.store = \@mypkg@other@name
+       draft.if          = @mypkg@draft       ,
+       draft.usage       = preamble           ,
+       name.store        = \@mypkg@name       ,
+       name.usage        = load               ,
+       second-name.store = \@mypkg@other@name ,
+       head-color.code   = \renewcommand{\head@color}{\color{#1}} ,
+       head-color.usage  = preamble
      }
 \end{verbatim}
-three options would be created. The option \texttt{draft} can be given anywhere
+four options would be created. The option \texttt{draft} can be given anywhere
 in the preamble, and will set a switch called |\if@mypkg@draft|. The option
 \texttt{name} can only be given during package loading, and will save whatever
-value it is given in |\@mypkg@name|. Finally, the option \texttt{second-name}
+value it is given in |\@mypkg@name|. The option \texttt{second-name}
 can be given anywhere, and will save its value in |\@mypkg@other@name|.
+Finally, \texttt{head-color} redefines \cs{head@color} to use the color
+given as the key value.
 
 Keys created \emph{before} the use of |\ProcessKeyOptions| act as package
 options.


### PR DESCRIPTION

# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [n/a] Test file(s) added
- [x] Version and date string updated in changed source files
- [n/a] Relevant `\changes` entries in source included
- [n/a] Relevant `changes.txt` updated
- [n/a] Rollback provided (if necessary)?
- [n/a] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
