### PR TITLE
Evaluate section level before structure names

### DIFF
--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -1,3 +1,7 @@
+2025-12-08  Carsten Hensiek  <carsten@hensiek.com>
+	* latex-lab-sec.dtx: evaluate section level parameter before constructing
+	structure names to fix KOMA-Script compatibility
+
 2025-12-02  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
 	* latex-lab-math.dtx: add support for the MSFT-attribute
 

--- a/required/latex-lab/latex-lab-sec.dtx
+++ b/required/latex-lab/latex-lab-sec.dtx
@@ -16,8 +16,8 @@
 %
 % for those people who are interested or want to report an issue.
 %
-\def\ltlabsecdate{2025-10-20}
-\def\ltlabsecversion{0.84k}
+\def\ltlabsecdate{2025-12-08}
+\def\ltlabsecversion{0.84l}
 %    \end{macrocode}
 %<*driver>
 \DocumentMetadata{tagging=on,pdfstandard=ua-2}
@@ -241,11 +241,11 @@
   {
     \tag_struct_begin:n
       {
-         tag= \UseStructureName{sec/#1}
+         tag= \UseStructureName{sec/\int_eval:n {#1}}
         ,#2
       }
     \seq_gpush:Ne \g_@@_sec_stack_seq
-      {{\g_@@_struct_tag_tl}{\int_eval:n{#1}}{\g_@@_struct_stack_current_tl}}
+      {{\g_@@_struct_tag_tl}{\int_eval:n {#1}}{\g_@@_struct_stack_current_tl}}
   }
 \cs_generate_variant:Nn \@@_sec_begin:nn {en}
 %    \end{macrocode}
@@ -330,9 +330,9 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_sec_title_begin:nn #1 #2 %level, title
   {
-    \tag_struct_begin:n{tag=\UseStructureName{sec/#1/title},title={#2}}
+    \tag_struct_begin:n{tag=\UseStructureName{sec/\int_eval:n {#1}/title},title={#2}}
     \bool_set_true:N\l_@@_para_flattened_bool
-    \tl_set:Nn\l_@@_para_tag_tl {\UseStructureName{sec/#1/titleline}}
+    \tl_set:Nn\l_@@_para_tag_tl {\UseStructureName{sec/\int_eval:n {#1}/titleline}}
   }
 %    \end{macrocode}
 % \end{macro}
@@ -375,10 +375,10 @@
 % something like \cs{GetTitleString}. TODO.
 %    \begin{macrocode}
   {   
-    \tagstructbegin{tag=\UseStructureName{sec/#1/title},title-o={#4}}
+    \tagstructbegin{tag=\UseStructureName{sec/\int_eval:n {#1}/title},title-o={#4}}
     \cs_if_exist_use:N \@@_gincr_para_begin_int:
     \bool_if:NF #2
-     { \tagstructbegin{tag=\UseStructureName{sec/#1/number}} }
+     { \tagstructbegin{tag=\UseStructureName{sec/\int_eval:n {#1}/number}} }
     \setbox\@tempboxa\hbox{{#3}}
 %    \end{macrocode}
 % We stop paratagging now, to avoid that the \cs{noindent} creates a structure.
@@ -418,7 +418,7 @@
     { #3 }
     {
       \tag_mc_end_push:
-      \tag_struct_begin:n{tag=\UseStructureName{sec/#1/number}}
+      \tag_struct_begin:n{tag=\UseStructureName{sec/\int_eval:n {#1}/number}}
       \tag_mc_begin:n{}
       #3
       \tag_mc_end:
@@ -519,7 +519,7 @@
 %    \begin{macrocode}
 \NewTaggingSocketPlug{sec/title/init}{kernel}
  {
-   \tl_set:Ne\l_@@_para_tag_tl{\UseStructureName{sec/#1/title}}
+   \tl_set:Ne\l_@@_para_tag_tl{\UseStructureName{sec/\int_eval:n {#1}/title}}
    \bool_set_true:N \l_@@_para_flattened_bool
  }
 \AssignTaggingSocketPlug{sec/title/init}{kernel}
@@ -558,7 +558,7 @@
 \NewTaggingSocketPlug{sec/title/number}{kernel}
  {
    \tag_mc_end_push:
-   \tag_struct_begin:n{tag=\UseStructureName{sec/#1/number}}
+   \tag_struct_begin:n{tag=\UseStructureName{sec/\int_eval:n {#1}/number}}
    \tag_mc_begin:n{}
      #2
    \tag_mc_end:

--- a/required/latex-lab/testfiles-sec/koma-section-tagging.lvt
+++ b/required/latex-lab/testfiles-sec/koma-section-tagging.lvt
@@ -1,0 +1,16 @@
+\RequirePackage{latexbug}
+\DocumentMetadata{
+  pdfstandard = {a-3u, ua-1},
+  tagging     = on,
+  testphase   = phase-III
+}
+\documentclass{scrartcl}
+\tagpdfsetup{role/map-tags=pdf}
+
+\START
+\begin{document}
+\section{Test Section}
+Test text.
+\subsection{Test Subsection}
+More text.
+\end{document}


### PR DESCRIPTION
When using KOMA-Script classes (`scrartcl`) with `\DocumentMetadata` and tagging enabled, internal LaTeX3 variable names like `\l__tag_name_sec/\numexpr 1\relax` appear as structure types in the PDF instead of being mapped to standard PDF tags. This causes PDF/UA-1 validation failures (Clause 7.1, Test 5).

**Root cause:** KOMA-Script passes `\numexpr 1\relax` (unexpanded) as the section level parameter. When `latex-lab-sec.dtx` constructs structure names using `\UseStructureName{sec/#1}`, the `\numexpr` expression becomes part of the variable name without being evaluated.

**Context:** I found this issue while testing with KOMA-Script classes (latex3/tagging-project#1118), which are [not yet officially compatible](https://latex3.github.io/tagging-project/tagging-status/#classes) with tagging. However, this fix hopefully makes the section tagging infrastructure more robust by properly evaluating numeric expressions, which will benefit the codebase when KOMA-Script and other classes become compatible in the future. The underlying issue is not KOMA-specific but affects any document class that passes unexpanded `\numexpr` expressions as section level parameters.

## Solution

Evaluate the section level parameter `#1` using `\int_eval:n {#1}` before passing it to `\UseStructureName`. This ensures that expressions like `\numexpr 1\relax` are converted to `1` before string concatenation.

## Testing

**Minimal test case:**

```
\RequirePackage{latexbug}
\DocumentMetadata{
 pdfstandard = {a-3u, ua-1},
 tagging     = on,
 testphase   = phase-III
}
\documentclass{scrartcl}
\tagpdfsetup{role/map-tags=pdf}
\begin{document}
\section{Test}
Text.
\end{document}
```

**Before fix:** 18 `tag_name_sec` warnings per section  
**After fix:** 0 warnings

**Impact:** No effect on standard classes (`article`, `book`, `report`) which already pass integer values. Makes section tagging robust against unexpanded numeric expressions.

---

## Checklist of required changes before merge will be approved
- [x] Test file(s) added (`testfiles-sec/koma-section-tagging.lvt`)
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated