### PR TITLE
Restore support for quiet unpacking in base bundle

### DIFF
--- a/base/build.lua
+++ b/base/build.lua
@@ -211,7 +211,9 @@ function bundleunpack ()
           -- of localdir w.r.t. unpackdir
           os_setenv .. " TEXINPUTS=" .. unpackdir .. os_concat ..
           unpackexe .. " " .. unpackopts .. " -output-directory=" .. unpackdir
-            .. " " .. unpackdir .. "/" .. j,"w"
+            .. " " .. unpackdir .. "/" .. j
+            .. (options["quiet"] and (" > " .. os_null) or ""),
+          "w"
         ):write(string.rep("y\n", 300)):close()
       if not success then
         return 1


### PR DESCRIPTION
In the customized `bundleunpack()` in `./base/build.lua`, the support for quite unpacking in vanilla `l3build` was lost. This PR restores it.

Related source line in `l3build`
https://github.com/latex3/l3build/blob/0cab79cb0994ec84c280610cc88018ec9703f16b/l3build-unpack.lua#L86

# Internal housekeeping

## Status of pull request

- Feedback wanted 
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [ ] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [ ] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
