### PR TITLE
Draft: Do not warn about ignored error messages in LuaTeX

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,10 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
+2025-12-27  Marcel Krüger  <Marcel.Krueger@latex-project.org>
+	* doc/ltluatex.tex: suppress warnings printed when messages are ignored
+	by \ignoreprimitiveerror.
+
 2025-12-24  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
     * exscale.dtx: disable tagging in measuring, (tagging/1154)
 

--- a/base/ltluatex.dtx
+++ b/base/ltluatex.dtx
@@ -30,7 +30,7 @@
 %<*plain>
 % \fi
 % \ProvidesFile{ltluatex.dtx}
-[2025/12/23 v1.2f
+[2025/12/27 v1.2g
 % LaTeX Kernel (LuaTeX support)^^A
 %\iffalse
 %<plain>   LuaTeX support for plain TeX (core)%
@@ -1562,21 +1562,23 @@ local callbacktypes = callbacktypes or {
 % \changes{v1.1g}{2018/05/02}{finish\_synctex\_callback added}
 % \changes{v1.1j}{2019/06/18}{finish\_synctex\_callback renamed finish\_synctex}
 % \changes{v1.1j}{2019/06/18}{wrapup\_run added}
+% \changes{v1.2g}{2025/12/27}{show\_ignored\_error\_message added}
 %    \begin{macrocode}
-  pre_dump             = simple,
-  start_run            = simple,
-  stop_run             = simple,
-  start_page_number    = simple,
-  stop_page_number     = simple,
-  show_error_hook      = simple,
-  show_warning_message = simple,
-  show_error_message   = simple,
-  show_lua_error_hook  = simple,
-  start_file           = simple,
-  stop_file            = simple,
-  call_edit            = simple,
-  finish_synctex       = simple,
-  wrapup_run           = simple,
+  pre_dump                   = simple,
+  start_run                  = simple,
+  stop_run                   = simple,
+  start_page_number          = simple,
+  stop_page_number           = simple,
+  show_error_hook            = simple,
+  show_warning_message       = simple,
+  show_error_message         = simple,
+  show_ignored_error_message = simple,
+  show_lua_error_hook        = simple,
+  start_file                 = simple,
+  stop_file                  = simple,
+  call_edit                  = simple,
+  finish_synctex             = simple,
+  wrapup_run                 = simple,
 %    \end{macrocode}
 % Section 8.6: PDF-related callbacks.
 % \changes{v1.1j}{2019/06/18}{page\_objnum\_provider added}
@@ -2184,6 +2186,16 @@ function shared_callbacks.mlist_to_hlist.handler(head, display_type, need_penalt
   end
   return post
 end
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{show_ignored_error_message}
+% \changes{v1.2g}{2025/12/27}{|show_ignored_error_message| added}
+%   This callback is used when errors are generated which have been ignored.
+%   Since they are ignored, the callback does not need to do anything.
+%   This suppresses the warning message Lua\TeX{} prints otherwise.
+%    \begin{macrocode}
+add_to_callback('show_ignored_error_message', function() end, 'luatexbase.ignore_ignored_error')
 %    \end{macrocode}
 % \end{macro}
 % \endgroup

--- a/base/testfiles/tlb-callbacks-001.luatex.tlg
+++ b/base/testfiles/tlb-callbacks-001.luatex.tlg
@@ -1,7 +1,6 @@
 This is a generated file for the LaTeX2e validation system.
 Don't change this file in any respect.
  LuaTeX Callback test
-- show_ignored_error_message
 + luaotfload.parse_color
 + luaotfload.parse_transparent
 + luaotfload.split_color


### PR DESCRIPTION
Note: Currently this breaks LuaTeX due to an engine bug.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- On hold, waiting for engine changes.
- Ready to merge

## Checklist of required changes before merge will be approved
- n/a Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- n/a Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
