### PR TITLE
Optimize GitHub Actions runs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,17 +5,20 @@ on:
   # Whenever someone pushes to a branch in our repo
   push:
     branches:
-      - "**"
+      - main
+      - develop
   # Whenever a pull request is opened, reopened or gets new commits.
   pull_request:
-# This implies that for every push to a local branch in our repo for which a
-# pull request is open this runs twice. But it's important to ensure that pull
-# requests get tested even if their branch comes from a fork.
   workflow_dispatch:
     inputs:
       fail-fast:
         default: false
         description: 'Fail run on first error'
+        required: true
+        type: boolean
+      skip-docs:
+        default: false
+        description: 'Do not build documentation'
         required: true
         type: boolean
 
@@ -43,7 +46,7 @@ jobs:
   l3build:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: ${{ format('{0}', inputs.fail-fast) == '' || inputs.fail-fast }}
+      fail-fast: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.fail-fast) }}
       matrix:
         # include indicates that we want to set explicitly these combinations
         # and don't want full matrix testing.
@@ -158,7 +161,7 @@ jobs:
         run: ${{ matrix.extra_command }}
       - name: Run l3build
         working-directory: ${{ matrix.module }}
-        run: "l3build check -S -q --show-log-on-error${{ matrix.config && format(' -c {0}', matrix.config) || ''}}${{ matrix.engine && format(' -e {0}', matrix.engine) || ''}}${{ matrix.first && format(' --first {0}', matrix.first) || ''}}${{ matrix.last && format(' --last {0}', matrix.last) || ''}}"
+        run: "l3build check ${{ (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.fail-fast)) && '-H' || '-S' }} -q --show-log-on-error${{ matrix.config && format(' -c {0}', matrix.config) || ''}}${{ matrix.engine && format(' -e {0}', matrix.engine) || ''}}${{ matrix.first && format(' --first {0}', matrix.first) || ''}}${{ matrix.last && format(' --last {0}', matrix.last) || ''}}"
       # "/" is one of invalid characters in artifact names
       # see https://github.com/actions/toolkit/blob/ef77c9d60bdb03700d7758b0d04b88446e72a896/packages/artifact/src/internal/upload/path-and-artifact-name-validation.ts
       - name: Sanitize artifact name
@@ -182,7 +185,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: ${{ format('{0}', inputs.fail-fast) == '' || inputs.fail-fast }}
+      fail-fast: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.fail-fast) }}
       matrix:
         include:
           - module: base
@@ -203,6 +206,7 @@ jobs:
             component: 3
           - module: required/tools
     name: "Documentation: ${{ matrix.module }}${{ matrix.component && format(' ({0})', matrix.component) || ''}}"
+    if: ${{ !inputs.skip-docs }}
     needs: texlive-cache
     steps:
       # Boilerplate
@@ -222,7 +226,7 @@ jobs:
         run: echo "LTX_DOC_COMPONENT=${{ matrix.component }}" >> "$GITHUB_ENV"
       - name: Run l3build
         working-directory: ${{ matrix.module }}
-        run: "l3build doc -q ${{ (format('{0}', inputs.fail-fast) == '' || inputs.fail-fast) && '-H ' || '' }}--show-log-on-error"
+        run: "l3build doc -q ${{ (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.fail-fast)) && '-H ' || '' }}--show-log-on-error"
       # Now we create the artifacts for the generated documentation
       - name: Sanitize artifact name
         shell: bash
@@ -256,7 +260,7 @@ jobs:
     # We don't want information for pull requests since for pull requests from local
     # branches we already send notifications when the branch test fails and pull requests
     # from forks can't access the username and password secrets required to send mails.
-    if: ${{ failure() && github.event_name != 'pull_request' }}
+    if: ${{ failure() && github.secret_source == 'Actions' }}
     steps:
       - name: Send mail
         # The explicit commit hash ensures that this can't be used by dawidd6 as a


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

Various adaptions:

 * Do not run Actions automatically on branches. Pull Requests will still be tested as part of the Pull Request, when wanting to test other branches the tests can be started manually. The branches `main` and `develop` still get tests run for each push.
 * Tests running as part of Pull Requests always run all tests, while tests on main and develop stop at the first error.
 * When running tests manually the documentation build can be skipped.