### PR TITLE
Streamline glyphtounicode loading

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,7 +6,7 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
-2026-03-13 Joseph Wright  <Joseph.Wright@latex-project.org>
+2026-03-16 Joseph Wright  <Joseph.Wright@latex-project.org>
 	* ltfinal.dtx (subsection {Font loading}):
 	Streamline glyphtounicode loading
 

--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,10 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
+2026-03-13 Joseph Wright  <Joseph.Wright@latex-project.org>
+	* ltfinal.dtx (subsection {Font loading}):
+	Streamline glyphtounicode loading
+
 2026-04-13  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 
 	* ltsockets.dtx (subsection{Debugging the socket structures}):

--- a/base/format.ins
+++ b/base/format.ins
@@ -231,11 +231,16 @@ the system are in the document `cfgguide.tex'.
    \file{textcomp-2018-08-11.sty}{%
           \from{lttextcomp.dtx}{TS1oldsty}}
    \file{checkencodingsubset.tex}{%
-          \from{lttextcomp.dtx}{TS1check}}
+          \from{lttextcomp.dtx}{TS1check}}         
+  }
+
+\begingroup\nopostamble
+\generate{
 %%% generate glyphtounicode-cmex.tex
    \file{glyphtounicode-cmex.tex}{%
-          \from{ltfinal.dtx}{glyphtounicode}}          
-  }
+          \from{ltfinal.dtx}{glyphtounicode}} 
+}
+\endgroup
 
 \generateFile{oldlfont.sty}{t}{%
   \from{oldlfont.dtx}{package}

--- a/base/format.ins
+++ b/base/format.ins
@@ -231,7 +231,7 @@ the system are in the document `cfgguide.tex'.
    \file{textcomp-2018-08-11.sty}{%
           \from{lttextcomp.dtx}{TS1oldsty}}
    \file{checkencodingsubset.tex}{%
-          \from{lttextcomp.dtx}{TS1check}}         
+          \from{lttextcomp.dtx}{TS1check}}
   }
 
 \begingroup\nopostamble

--- a/base/format.ins
+++ b/base/format.ins
@@ -238,7 +238,7 @@ the system are in the document `cfgguide.tex'.
 \generate{
 %%% generate glyphtounicode-cmex.tex
    \file{glyphtounicode-cmex.tex}{%
-          \from{ltfinal.dtx}{glyphtounicode}} 
+          \from{ltfinal.dtx}{glyphtounicode}}
 }
 \endgroup
 

--- a/base/ltfinal.dtx
+++ b/base/ltfinal.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltfinal.dtx}
-             [2026-03-12 v2.3k LaTeX Kernel (Final Settings)]
+             [2026-03-15 v2.3l LaTeX Kernel (Final Settings)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltfinal.dtx}
@@ -665,23 +665,43 @@
 %    \end{macrocode}
 %
 %   For pdf\TeX\ preload and enable automatic glyph to Unicode mapping
-%   for more reliable copy and paste support.
+%   for more reliable copy and paste support. Since v1.40.22, this data is
+%   dumped into the format so is simply loaded directly. For older engines,
+%   the same method as Lua\TeX{} is used (see below).
 %   \changes{v2.2l}{2021/01/21}{Load glyphtounicode.tex for pdf\TeX}
 %   \changes{v2.2m}{2021/02/25}{Improve speed of ToUnicode everyjob loading code}
 %   
-%  For lua\TeX{} |\pdfextension glyphtounicode| would error in dvi-mode. As the outputmode
-%  can be changed in the preamble we have to test in the definition.
+%  For lua\TeX{} |\pdfextension glyphtounicode| would error in dvi-mode. As the
+%  outputmode can be changed in the preamble we have to test in the definition.
+%  Lua\TeX{} does not dump this information into the format, so we need to load
+%  it in the \cs{everyjob} hook. We can't use \cs{input} there, as it would
+%  set the \cs{jobname} in the event of the run being started without loading
+%  a file. We also don't want to put all of the tokens from the files
+%  \emph{directly} in the hook, so we save to a file.
 %  
 %  For other engines we provide the two commands with noop definitions
 %  \changes{v2.3j}{2026-02-25}{Define \cs{pdfglyphtounicode} for lua\TeX}
 %  \changes{v2.3j}{2026-02-25}{Load and enable glyphtounicode.tex for lua\TeX in PDF mode}
-%  \changes{v2.3j}{2026-02-25}{Provide noop definitions for the other engines} 
+%  \changes{v2.3j}{2026-02-25}{Provide noop definitions for the other engines}
+%  \changes{v2.3l}{2026-04-15}{Revise glyphtounicode loading to reduce tokens
+%    in \cs{everyjob}}
 %    \begin{macrocode}
 %</2ekernel>
 %<*2ekernel|latexrelease>
 %<latexrelease>\IncludeInRelease{2026/06/01}%
 %<latexrelease>                 {\pdfgentounicode}{Preload glyphtounicode}%
-\ifx \pdfgentounicode \@undefined \else
+\ifdefined\directlua
+  \protected\def\pdfglyphtounicode{%
+    \ifnum\outputmode=1 %
+     \expandafter\@firstofone 
+    \else 
+     \expandafter\@gobblethree 
+    \fi
+     {\pdfextension glyphtounicode}%
+  }
+  \protected\edef\pdfgentounicode{\pdfvariable gentounicode}
+\fi
+\ifdefined\pdfgentounicode
 %<*2ekernel>
   \ifnum 0=0%
     \ifdefined\pdftexversion
@@ -690,36 +710,28 @@
     \fi
     \relax
 %</2ekernel>
-    \input glyphtounicode
-    \input glyphtounicode-cmex
+    \input glyphtounicode %
+    \input glyphtounicode-cmex %
 %<*2ekernel>
   \else
-    \begingroup
-      \everyeof{\noexpand}\endlinechar-1
-      \edef\x{\endgroup
-        \everyjob{\the\everyjob\@@input glyphtounicode \@@input glyphtounicode-cmex }%
-    }\x
+    \ExplSyntaxOn
+      \file_get:nnN { glyphtounicode } { \ExplSyntaxOff }
+        \@@data@glyphtounicode
+      \file_get:nnN { glyphtounicode-cmex } { \ExplSyntaxOff }
+        \@@data@glyphtounicode@cmex
+    \ExplSyntaxOff
+    \everyjob\expandafter{%
+       \the\everyjob
+       \@@data@glyphtounicode
+       \@@data@glyphtounicode@cmex
+     }
   \fi
 %</2ekernel>
-  \pdfgentounicode=1
-\fi
-\ifx\directlua\undefined \else
-  \protected\def\pdfglyphtounicode 
-   {\ifnum\outputmode=1 
-     \expandafter \@firstofone 
-    \else 
-     \expandafter\@gobblethree 
-    \fi
-   {\pdfextension glyphtounicode}}
-  \protected\edef\pdfgentounicode {\pdfvariable gentounicode} 
-   \ifnum\outputmode=1   
-    \begingroup
-     \everyeof{\noexpand}\endlinechar-1
-      \edef\x{\endgroup
-        \everyjob{\the\everyjob\@@input glyphtounicode \@@input glyphtounicode-cmex }%
-       }\x
-      \pdfvariable gentounicode=1
-   \fi    
+  \ifdefined\directlua
+    \pdfvariable gentounicode=1 %
+  \else
+    \pdfgentounicode=1 %
+  \fi
 \fi
 %    \end{macrocode}
 % For other engines we provide the two commands with noop definitions

--- a/base/ltfinal.dtx
+++ b/base/ltfinal.dtx
@@ -716,9 +716,9 @@
 %<*2ekernel>
   \else
     \ExplSyntaxOn
-      \file_get:nnN { glyphtounicode } { \ExplSyntaxOff }
+      \file_get:nnN { glyphtounicode } { }
         \@@data@glyphtounicode
-      \file_get:nnN { glyphtounicode-cmex } { \ExplSyntaxOff }
+      \file_get:nnN { glyphtounicode-cmex } { }
         \@@data@glyphtounicode@cmex
     \ExplSyntaxOff
     \everyjob\expandafter{%

--- a/base/ltfinal.dtx
+++ b/base/ltfinal.dtx
@@ -677,8 +677,9 @@
 %  it in the \cs{everyjob} hook. We can't use \cs{input} there, as it would
 %  set the \cs{jobname} in the event of the run being started without loading
 %  a file. We also don't want to put all of the tokens from the files
-%  \emph{directly} in the hook, so we save to a file. We need to read with
-%  spaces \enquote{present} as this is part of the syntax of the primitive.
+%  \emph{directly} in the hook, so we save to a macro. We need to read with
+%  spaces \enquote{present} as this is part of the syntax of the primitive,
+%  so need \cs{ExplSyntaxOff} in the setup for \cs{file_get:nnN}.
 %  
 %  For other engines we provide the two commands with noop definitions
 %  \changes{v2.3j}{2026-02-25}{Define \cs{pdfglyphtounicode} for lua\TeX}

--- a/base/ltfinal.dtx
+++ b/base/ltfinal.dtx
@@ -716,9 +716,9 @@
 %<*2ekernel>
   \else
     \ExplSyntaxOn
-      \file_get:nnN { glyphtounicode } { }
+      \file_get:nnN { glyphtounicode } { \ExplSyntaxOff }
         \@@data@glyphtounicode
-      \file_get:nnN { glyphtounicode-cmex } { }
+      \file_get:nnN { glyphtounicode-cmex } { \ExplSyntaxOff }
         \@@data@glyphtounicode@cmex
     \ExplSyntaxOff
     \everyjob\expandafter{%

--- a/base/ltfinal.dtx
+++ b/base/ltfinal.dtx
@@ -707,6 +707,7 @@
     \ifdefined\pdftexversion
 % \pdftexversion<140 does not have \pdfgentounicode, so we only check higher values
       \ifnum \pdftexversion=140 \ifnum\pdftexrevision<22 1\fi\fi
+    \else 1%
     \fi
     \relax
 %</2ekernel>

--- a/base/ltfinal.dtx
+++ b/base/ltfinal.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltfinal.dtx}
-             [2026-03-16 v2.3l LaTeX Kernel (Final Settings)]
+             [2026-04-16 v2.3l LaTeX Kernel (Final Settings)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltfinal.dtx}

--- a/base/ltfinal.dtx
+++ b/base/ltfinal.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltfinal.dtx}
-             [2026-03-15 v2.3l LaTeX Kernel (Final Settings)]
+             [2026-03-16 v2.3l LaTeX Kernel (Final Settings)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltfinal.dtx}
@@ -677,13 +677,14 @@
 %  it in the \cs{everyjob} hook. We can't use \cs{input} there, as it would
 %  set the \cs{jobname} in the event of the run being started without loading
 %  a file. We also don't want to put all of the tokens from the files
-%  \emph{directly} in the hook, so we save to a file.
+%  \emph{directly} in the hook, so we save to a file. We need to read with
+%  spaces \enquote{present} as this is part of the syntax of the primitive.
 %  
 %  For other engines we provide the two commands with noop definitions
 %  \changes{v2.3j}{2026-02-25}{Define \cs{pdfglyphtounicode} for lua\TeX}
 %  \changes{v2.3j}{2026-02-25}{Load and enable glyphtounicode.tex for lua\TeX in PDF mode}
 %  \changes{v2.3j}{2026-02-25}{Provide noop definitions for the other engines}
-%  \changes{v2.3l}{2026-04-15}{Revise glyphtounicode loading to reduce tokens
+%  \changes{v2.3l}{2026-04-16}{Revise glyphtounicode loading to reduce tokens
 %    in \cs{everyjob}}
 %    \begin{macrocode}
 %</2ekernel>


### PR DESCRIPTION
This avoids an issue with \jobname in LuaTeX

**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
- Under development
- [x] Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
