### PR TITLE
New Tagging Socket and hook for tagging support

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -7,8 +7,8 @@ not part of the distribution.
 ================================================================================
 
 2026-04-22  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
-	* ltmeta.dtx: add a hook to \cs{MakeLinkTarget} that allows to change
-the target name also if hyperref is not used and refine \cs{NextLinkTarget} to use it.
+	* ltmeta.dtx: add a hook to \MakeLinkTarget that allows to change
+the target name also if hyperref is not used and refine \NextLinkTarget to use it.
 
 	* lttagging.dtx: add generic tagging socket for structures, rename struct-begin to struct/begin.  
 

--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,12 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
+2026-04-22  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
+	* ltmeta.dtx: add a hook to \cs{MakeLinkTarget} that allows to change
+the target name also if hyperref is not used and refine \cs{NextLinkTarget} to use it.
+
+	* lttagging.dtx: add generic tagging socket for structures, rename struct-begin to struct/begin.  
+
 2026-04-16 Joseph Wright  <Joseph.Wright@latex-project.org>
 	* ltfinal.dtx (subsection {Font loading}):
 	Streamline glyphtounicode loading

--- a/base/ltmeta.dtx
+++ b/base/ltmeta.dtx
@@ -16,7 +16,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{ltmeta.dtx}
-             [2026-01-16 v1.0d LaTeX Kernel (Document Metadata)]
+             [2026-04-22 v1.0e LaTeX Kernel (Document Metadata)]
 % \iffalse
 %
 \documentclass{l3in2edoc}
@@ -163,8 +163,16 @@
 %   To allow package and class author to support for document links
 %   we provide also the new interface commands of the hyperref package
 %   for the creation of targets.
+%   The commands are not only useful for document links: 
+%   When tagging is active the commands can also be used to reference structures.
+%   This is done in the \texttt{recordtarget} socket, which records the target name.
+%   Both for links and structure references it can be useful to change the name of the 
+%   next target. We therefore insert a hook \texttt{target/setname/after} after the name
+%   has be set. This hook is used in the \cs{NextLinkTarget} command to adapt the target name
+%   \cs{@currentHref}. 
 % \changes{v1.0b}{2022/05/17}{Default definition for targets added}
 % \changes{v1.0c}{2024/09/21}{Added tagging support}
+% \changes{v1.0e}{2026/04/22}{Add hook to change target name and use it in \cs{NextLinkTarget}}
 %  \begin{macro}{\MakeLinkTarget}
 %  \begin{macro}{\LinkTargetOn}
 %  \begin{macro}{\LinkTargetOff}
@@ -173,6 +181,7 @@
 %<latexrelease>\IncludeInRelease{2024/11/01}%
 %<latexrelease>                 {\MakeLinkTarget}{Record target name for tagging support}%
 \ExplSyntaxOn
+\hook_new:n{target/setname/after}
 \int_new:N\g__kernel_target_int
 \NewDocumentCommand\MakeLinkTarget{sO{}m}{%
   \ifvmode
@@ -190,6 +199,7 @@
      \int_gincr:N\g__kernel_target_int
      \tl_gset:Ne \@currentHref {target*.\int_use:N\g__kernel_target_int}
    }
+  \hook_use:n{target/setname/after} 
   \UseTaggingSocket{recordtarget} 
    }
 \ExplSyntaxOff   
@@ -207,7 +217,8 @@
 %<latexrelease>\EndIncludeInRelease
 \NewDocumentCommand\LinkTargetOn{}{}
 \NewDocumentCommand\LinkTargetOff{}{}
-\NewDocumentCommand\NextLinkTarget{m}{}
+\NewDocumentCommand\NextLinkTarget{m}{%
+  \AddToHookNext{target/setname/after}{\xdef\@currentHref {#1}}}
 %    \end{macrocode}
 %  \end{macro}
 %  \end{macro}

--- a/base/lttagging.dtx
+++ b/base/lttagging.dtx
@@ -628,7 +628,7 @@
                       { \__tag_para_main_store_struct: }
                    }
               }
-            \UseTaggingSocket{para/textblock/begin}{\PARALABEL}
+            \UseTaggingSocket{para/textblock/begin}{NP-}
        }
      }
   }

--- a/base/lttagging.dtx
+++ b/base/lttagging.dtx
@@ -173,8 +173,8 @@
 % The tagging of math has to collect/grab the math first. This is not wanted
 % for all uses of \verb+$+. These command allow to control the behavior of the
 % math shift token. Without the  math tagging code they do nothing. Their behavior
-% with the math tagging code is documented in latex-lab-math.pdf 
-%  
+% with the math tagging code is documented in latex-lab-math.pdf
+%
 %
 % \DescribeMacro\MathMLintent
 % \DescribeMacro\MathMLarg
@@ -190,34 +190,34 @@
 %  \DescribeMacro\NewStructureName
 %  \DescribeMacro\UseStructureName
 %  \DescribeMacro\AssignStructureRole
-%  Structure elements in a document can use as tag a name from the standard PDF namespaces 
-%  like \verb|Sect|, \verb|H1| or \verb|Figure| but they can also use new names 
+%  Structure elements in a document can use as tag a name from the standard PDF namespaces
+%  like \verb|Sect|, \verb|H1| or \verb|Figure| but they can also use new names
 %  (which then must be rolemapped to a standard name). The second option is useful for three reasons:
 %  \begin{itemize}
-%  \item It looks nicer, if, e.g., a bible uses tag names like \texttt{Testament} or 
+%  \item It looks nicer, if, e.g., a bible uses tag names like \texttt{Testament} or
 %  \texttt{Chapter} or \texttt{Book} instead of \texttt{Sect}.
 %  \item It is possible to formulate additional constraint on such structures in a Schema
 %  and thus ensure that there is no \texttt{Testament} inside a \texttt{Book},
 %  something that can not be done if \texttt{Sect} is used everywhere.
 %  \item We can provide a uniform LaTeX set of names for tags.
 %  \end{itemize}
-%  
+%
 %  To make it possible to adapt the tag names of a structure in document, the tag name
 %  should be stored in a command. These three commands offer an interface to declare,
 %  use and reassign such symbolic structure names. \verb+\NewStructureName+
-%  takes one argument and 
-%  declares the internal command, initially its value is \texttt{NonStruct}. 
+%  takes one argument and
+%  declares the internal command, initially its value is \texttt{NonStruct}.
 %  The expandable command \verb+\UseStructureName+ takes one argument and allows to use
 %  the stored value. \verb+\AssignStructureRole+ takes two
-%  arguments. The first is a symbolic structure names, the second a role which 
-%  should be a simply string allowed as a tag name. 
+%  arguments. The first is a symbolic structure names, the second a role which
+%  should be a simply string allowed as a tag name.
 %  When the tagging code is loaded \verb+\AssignStructureRole+ is redefined
-%  to setup the rolemapping, see the description in \texttt{latex-lab-namespace.dtx}. 
+%  to setup the rolemapping, see the description in \texttt{latex-lab-namespace.dtx}.
 %  There is also a description of
 %  the naming scheme and a list of the already predeclared names.
-%  
-%   
-%  
+%
+%
+%
 % \MaybeStop{}
 % \section{Implementation}
 %
@@ -270,7 +270,7 @@
 %
 %
 %  \begin{macro}{\NewTaggingSocketPlug,\AssignTaggingSocketPlug}
-%    
+%
 % \changes{v1.0o}{2025/02/26}{Macro added}
 %    \begin{macrocode}
 \cs_new_protected:Npn \NewTaggingSocketPlug #1 {
@@ -342,23 +342,23 @@
 %
 % \subsection{Math collection}
 % The documentation is in latex-lab-math.
-% 
+%
 % \begin{macro}{\MathCollectTrue,\MathCollectFalse}
 %    \begin{macrocode}
 \cs_new_protected:Npn\MathCollectTrue{}
 \cs_new_protected:Npn\MathCollectFalse{}
 %    \end{macrocode}
 % \end{macro}
-% 
+%
 % \subsection{Tagging sockets}
 % This collects tagging sockets that should be generally available
 % so that they can also be used even if the tagging code is not loaded.
 %
 % \subsection{Generic sockets}
 % These sockets are used in various places and should not be reassigned globally.
-% 
+%
 % \begin{taggingsocketdecl}{mc}
-% At first a generic socket to surround content with the mc-commands. The first 
+% At first a generic socket to surround content with the mc-commands. The first
 % argument can be used to pass options like \texttt{artifact}
 %    \begin{macrocode}
 \NewTaggingSocket{mc}{2}
@@ -385,27 +385,51 @@
       \tag_mc_end:
     \tag_struct_end:
   }
-\AssignTaggingSocketPlug{struct-mc}{kernel}  
+\AssignTaggingSocketPlug{struct-mc}{kernel}
 %    \end{macrocode}
 % \end{taggingsocketdecl}
-% 
-% \begin{taggingsocketdecl}{struct-begin,struct-end}
+%
+% \begin{taggingsocketdecl}{struct/begin,struct/end}
 % Sockets to start and end a structure. With the first
 % argument the tag and other options can be set.
 % \changes{v1.0w}{2026/04/08}{Added generic sockets for structure}
 %    \begin{macrocode}
-\NewTaggingSocket{struct-begin}{1}
-\NewTaggingSocket{struct-end}{0}
-\NewTaggingSocketPlug{struct-begin}{kernel}
+\NewTaggingSocket{struct/begin}{1}
+\NewTaggingSocket{struct/end}{0}
+\NewTaggingSocketPlug{struct/begin}{kernel}
   {
     \tag_struct_begin:n{#1}
   }
-\NewTaggingSocketPlug{struct-end}{kernel}
+\NewTaggingSocketPlug{struct/end}{kernel}
   {
     \tag_struct_end:
-  }  
-\AssignTaggingSocketPlug{struct-begin}{kernel}  
-\AssignTaggingSocketPlug{struct-end}{kernel}  
+  }
+\AssignTaggingSocketPlug{struct/begin}{kernel}
+\AssignTaggingSocketPlug{struct/end}{kernel}
+%    \end{macrocode}
+% \end{taggingsocketdecl}
+%
+% \begin{taggingsocketdecl}{inline/begin,inline/end}
+% These sockets can be used to insert small structures (often a Span with some
+% attributes) inside a paragraph: They close and reopen MC's.
+% With the argument structure name and attributes can be passed on
+%    \begin{macrocode}
+\NewTaggingSocket{inline/begin}{1}
+\NewTaggingSocketPlug{inline/begin}{kernel}
+  {
+    \tag_mc_end_push:
+    \tag_struct_begin:n{#1}
+    \tag_mc_begin:n{}
+  }
+\AssignTaggingSocketPlug{inline/begin}{kernel}
+\NewTaggingSocket{inline/end}{0}
+\NewTaggingSocketPlug{inline/end}{kernel}
+  {
+    \tag_mc_end:
+    \tag_struct_end:
+    \tag_mc_begin_pop:n{}
+  }
+\AssignTaggingSocketPlug{inline/end}{kernel}
 %    \end{macrocode}
 % \end{taggingsocketdecl}
 % 
@@ -464,8 +488,8 @@
 % \end{taggingplugdecl}
 %
 % \begin{taggingsocketdecl}{para/begin,para/end}
-% These sockets were previously defined in tagpdf. 
-% There are the main sockets to handle the paragraph tagging when it is active 
+% These sockets were previously defined in tagpdf.
+% There are the main sockets to handle the paragraph tagging when it is active
 % (i.e., when para/on or para/restore was executed earlier).
 %    \begin{macrocode}
 \NewTaggingSocket{para/begin}{0}
@@ -481,18 +505,18 @@
 %    \end{macrocode}
 
 % \end{taggingsocketdecl}
-% 
+%
 % \begin{taggingsocketdecl}{para/semantic/begin,para/semantic/end}
 % These sockets handle the \UseStructureName{para/semantic} begin and end structure.
 % These are stored in sockets of their own to be able to disable
 % them globally.
-% 
+%
 %    \begin{macrocode}
 \NewTaggingSocket{para/semantic/begin}{1}
 \NewTaggingSocket{para/semantic/end}{1}
 %    \end{macrocode}
 % \end{taggingsocketdecl}
-% 
+%
 % \begin{taggingplugdecl}{kernel (para/semantic/begin)}
 % This tagging socket adds a \UseStructureName{para/semantic} structure.
 % The argument allows to add additional commands like
@@ -512,7 +536,7 @@
  }
 %    \end{macrocode}
 % \end{taggingplugdecl}
-% 
+%
 % \begin{taggingplugdecl}{kernel (para/semantic/end)}
 % This socket should be used if a \UseStructureName{para/semantic}-structure  is closed.
 % The argument allows e.g. to add debug info.
@@ -535,13 +559,13 @@
 % These sockets handle the \UseStructureName{para/textblock} begin and end structure.
 % These are stored in sockets of their own to be able to reuse them in places where only
 % a textblock is needed.
-% 
+%
 %    \begin{macrocode}
 \NewTaggingSocket{para/textblock/begin}{1}
 \NewTaggingSocket{para/textblock/end}{0}
 %    \end{macrocode}
 % \end{taggingsocketdecl}
-% 
+%
 % \begin{taggingplugdecl}{kernel (para/textblock/begin)}
 % This tagging socket opens a \UseStructureName{para/textblock} structure and
 % mc. It is used below in the \texttt{para/begin} tagging socket.
@@ -561,7 +585,7 @@
  }
 %    \end{macrocode}
 % \end{taggingplugdecl}
-% 
+%
 % \begin{taggingplugdecl}{kernel (para/textblock/end)}
 % This socket closes a \UseStructureName{para/textblock}-mc and structure.
 % It is used below in the \texttt{para/end} tagging socket.
@@ -581,10 +605,10 @@
 \AssignTaggingSocketPlug{para/textblock/begin}{kernel}
 \AssignTaggingSocketPlug{para/textblock/end}{kernel}
 %    \end{macrocode}
-% 
+%
 % \begin{taggingplugdecl}{kernel (para/begin)}
 % This plug is similar to the block socket currently defined
-% in tagpdf and should overwrite it. 
+% in tagpdf and should overwrite it.
 %    \begin{macrocode}
 \NewTaggingSocketPlug{para/begin}{kernel}
   {
@@ -602,7 +626,7 @@
                       { \__tag_para_main_store_struct: }
                    }
               }
-            \UseTaggingSocket{para/textblock/begin}{\PARALABEL} 
+            \UseTaggingSocket{para/textblock/begin}{\PARALABEL}
        }
      }
   }
@@ -633,7 +657,7 @@
     \AssignTaggingSocketPlug{para/end}{kernel}
   }
 %    \end{macrocode}
-
+%
 % \subsubsection{Tagging socket for targets}
 
 % \begin{taggingsocketdecl}{refstepcounter}
@@ -662,7 +686,7 @@
 \ExplSyntaxOff
 %    \end{macrocode}
 % \end{taggingplugdecl}
-% 
+%
 % \subsubsection{Tagging Sockets for boxes}
 % \changes{v1.0v}{2025/11/22}{Add sockets for minipage and parbox}
 %
@@ -676,32 +700,32 @@
 % \subsubsection{Tagging Sockets for lists and blocks}
 % \changes{v1.0s}{2025/08/03}{Add sockets for block code}
 % \begin{taggingsocketdecl}{block/list/label}
-%  A tagging socket around the label in a list. 
+%  A tagging socket around the label in a list.
 %    \begin{macrocode}
 \NewTaggingSocket{block/list/label}{2}
 %    \end{macrocode}
 % \end{taggingsocketdecl}
 %
 % \begin{taggingsocketdecl}{block/recipe}
-%  A tagging socket to set the tagging recipe. 
+%  A tagging socket to set the tagging recipe.
 %    \begin{macrocode}
 \NewTaggingSocket{block/recipe}{1}
 %    \end{macrocode}
 % \end{taggingsocketdecl}
-% 
+%
 % \subsubsection{Tagging sockets for headings}
 % \changes{v1.0u}{2025/10/20}{Tagging sockets for headings added}
-% Tagging headings is quite tricky. The sockets (and plugs) 
+% Tagging headings is quite tricky. The sockets (and plugs)
 % used by the kernel definitions often expect specially formatted arguments.
-% For this reason some of them may not be suitable in other classes or packages. 
-% In that case additional sockets (or plugs) might be required. 
-%  
+% For this reason some of them may not be suitable in other classes or packages.
+% In that case additional sockets (or plugs) might be required.
+%
 % \begin{taggingsocketdecl}{sec/begin, sec/end}
 % These two sockets should surround the whole section by a \texttt{Sect} structure.
-% They should be suited also for classes and packages. 
+% They should be suited also for classes and packages.
 % The begin socket takes two brace groups are argument: the level and key for the structure
 % (typically \verb|tag=somename|), the end socket takes as argument a level.
-% 
+%
 %    \begin{macrocode}
 \NewTaggingSocket{sec/begin}{1}
 \NewTaggingSocket{sec/end}{1}
@@ -710,7 +734,7 @@
 %
 % \begin{taggingsocketdecl}{sec/title/begin, sec/title/end}
 % These two sockets are used around display heading where the number
-% is on a line of its own. 
+% is on a line of its own.
 % The argument of the begin socket consists of two brace groups containing the level and
 % the title.
 %    \begin{macrocode}
@@ -718,14 +742,14 @@
 \NewTaggingSocket{sec/title/end}{0}
 %    \end{macrocode}
 % \end{taggingsocketdecl}
-% 
+%
 % \begin{taggingsocketdecl}{sec/title/hang}
-% This socket is used in headings with hanging number. 
+% This socket is used in headings with hanging number.
 %    \begin{macrocode}
 \NewTaggingSocket{sec/title/hang}{2}
 %    \end{macrocode}
 % \end{taggingsocketdecl}
-% 
+%
 % \begin{taggingsocketdecl}{sec/title/init,sec/title/split,sec/title/runin/number}
 % These sockets are used by run-in heading to initialize tagging and to split
 % heading and following text and tag the title.
@@ -743,7 +767,7 @@
 \NewTaggingSocket{sec/title/number}{2}
 %    \end{macrocode}
 % \end{taggingsocketdecl}
-% 
+%
 % \subsubsection{Tagging sockets for toc}
 %
 % \begin{taggingsocketdecl}{toc/contentsline/before,
@@ -776,9 +800,9 @@
 \NewTaggingSocket{toc/leaders/after}{0}
 %    \end{macrocode}
 % \end{taggingsocketdecl}
-% 
+%
 % \subsubsection{Tagging support for marginpar}
-% 
+%
 % \begin{taggingsocketdecl}{marginpar/begin,marginpar/end}
 % \changes{v1.0n}{2025/02/21}{move marginpar sockets}
 %    \begin{macrocode}
@@ -1073,7 +1097,7 @@
 % \end{taggingsocketdecl}
 %
 % \paragraph{Socket to annotate}
-% 
+%
 % \begin{taggingsocketdecl}{math/luamml/annotate/false}
 %  These socket can be used for content that should be annotated
 %  with \texttt{core=false}
@@ -1081,7 +1105,7 @@
 \NewTaggingSocket{math/luamml/annotate/false}{2}
 %    \end{macrocode}
 % \end{taggingsocketdecl}
-% 
+%
 % \paragraph{Array sockets} These sockets will be used in \pkg{array} to
 % add luamml support to the array environment.
 %
@@ -1128,8 +1152,8 @@
 \NewTaggingSocket{math/luamml/mtable/finalizecol}{1}
 %    \end{macrocode}
 % \end{taggingsocketdecl}
-% 
-% 
+%
+%
 % \begin{taggingsocketdecl}{math/luamml/mtable/finalize}
 % This sockets is used at the end of alignment environment to finalize the
 % mtable code. It should be used normally with \cs{UseExpandableTaggingSocket}.
@@ -1147,7 +1171,7 @@
 %    \end{macrocode}
 % \end{taggingsocketdecl}
 
-% 
+%
 % \begin{taggingsocketdecl}{math/luamml/mtable/innertable/save}
 % This socket is used in \cs{endaligned} to save the table. It takes no argument.
 %    \begin{macrocode}
@@ -1163,15 +1187,15 @@
 \NewTaggingSocket{math/luamml/mtable/smallmatrix/save}{0}
 %    \end{macrocode}
 % \end{taggingsocketdecl}
-% 
+%
 % \begin{taggingsocketdecl}{math/luamml/mtable/innertable/finalize}
-% This socket is used e.g. in \cs{endsmallmatrix} and \cs{gathered} to finalize the table. 
+% This socket is used e.g. in \cs{endsmallmatrix} and \cs{gathered} to finalize the table.
 % It takes no argument.
 %    \begin{macrocode}
 \NewTaggingSocket{math/luamml/mtable/innertable/finalize}{0}
 %    \end{macrocode}
 % \end{taggingsocketdecl}
-% 
+%
 % \begin{taggingsocketdecl}{math/luamml/mtable/tag/save}
 % This socket is used to save a tag for later use.
 % has been save before.
@@ -1187,7 +1211,7 @@
 \NewTaggingSocket{math/luamml/mtable/tag/set}{0}
 %    \end{macrocode}
 % \end{taggingsocketdecl}
-% 
+%
 % \paragraph{mbox socket}
 %
 % \begin{taggingsocketdecl}{math/luamml/hbox}
@@ -1251,7 +1275,7 @@
 \cs_new_protected:Npn\NewStructureName#1
  {
    \tl_new:c  {l_@@_name_#1_tl}
-   \tl_set:cn {l_@@_name_#1_tl}{NonStruct}           
+   \tl_set:cn {l_@@_name_#1_tl}{NonStruct}
  }
 \cs_new:Npn\UseStructureName#1
  {
@@ -1265,7 +1289,7 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% 
+%
 % \section{For lttab.dtx parked here for now}
 %
 %

--- a/base/lttagging.dtx
+++ b/base/lttagging.dtx
@@ -33,7 +33,7 @@
 %<*driver>
 % \fi
 \ProvidesFile{lttagging.dtx}
-             [2026-04-08 v1.0w LaTeX Kernel (tagging support)]
+             [2026-04-22 v1.0x LaTeX Kernel (tagging support)]
 % \iffalse
 \documentclass{l3in2edoc}
 \GetFileInfo{lttagging.dtx}
@@ -393,6 +393,7 @@
 % Sockets to start and end a structure. With the first
 % argument the tag and other options can be set.
 % \changes{v1.0w}{2026/04/08}{Added generic sockets for structure}
+% \changes{v1.0x}{2026/04/22}{renamed struct-begin socket}
 %    \begin{macrocode}
 \NewTaggingSocket{struct/begin}{1}
 \NewTaggingSocket{struct/end}{0}
@@ -412,7 +413,8 @@
 % \begin{taggingsocketdecl}{inline/begin,inline/end}
 % These sockets can be used to insert small structures (often a Span with some
 % attributes) inside a paragraph: They close and reopen MC's.
-% With the argument structure name and attributes can be passed on
+% With the argument structure name and attributes can be passed on.
+% \changes{v1.0x}{2026/04/22}{added inline/begin, inline/end socket}
 %    \begin{macrocode}
 \NewTaggingSocket{inline/begin}{1}
 \NewTaggingSocketPlug{inline/begin}{kernel}

--- a/base/testfiles-lthooks/ltcmdhooks-001.tlg
+++ b/base/testfiles-lthooks/ltcmdhooks-001.tlg
@@ -68,6 +68,7 @@ l. ...\show\@kernel@after@begindocument
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop

--- a/base/testfiles-lthooks/lthooks-000.tlg
+++ b/base/testfiles-lthooks/lthooks-000.tlg
@@ -4,6 +4,7 @@ Don't change this file in any respect.
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop

--- a/base/testfiles-lthooks/lthooks-001.tlg
+++ b/base/testfiles-lthooks/lthooks-001.tlg
@@ -11,6 +11,7 @@ The property list \g__hook_xxx_code_prop contains the pairs (without outer brace
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop
@@ -273,6 +274,7 @@ The sequence \g__hook_all_seq contains the items (without outer braces):
 >  {para/after}
 >  {para/begin}
 >  {para/end}
+>  {target/setname/after}
 >  {begindocument}
 >  {begindocument/before}
 >  {begindocument/end}
@@ -355,6 +357,7 @@ The sequence \g__hook_all_seq contains the items (without outer braces):
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop

--- a/base/testfiles-lthooks/lthooks-002.tlg
+++ b/base/testfiles-lthooks/lthooks-002.tlg
@@ -11,6 +11,7 @@ The property list \g__hook_xxx_code_prop contains the pairs (without outer brace
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop
@@ -276,6 +277,7 @@ The sequence \g__hook_all_seq contains the items (without outer braces):
 >  {para/after}
 >  {para/begin}
 >  {para/end}
+>  {target/setname/after}
 >  {begindocument}
 >  {begindocument/before}
 >  {begindocument/end}
@@ -358,6 +360,7 @@ The sequence \g__hook_all_seq contains the items (without outer braces):
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop

--- a/base/testfiles-lthooks/lthooks-003.tlg
+++ b/base/testfiles-lthooks/lthooks-003.tlg
@@ -33,6 +33,7 @@ The sequence \g__hook_all_seq contains the items (without outer braces):
 >  {para/after}
 >  {para/begin}
 >  {para/end}
+>  {target/setname/after}
 >  {begindocument}
 >  {begindocument/before}
 >  {begindocument/end}
@@ -126,6 +127,7 @@ The hook xxx contains the rules:
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop

--- a/base/testfiles-lthooks/lthooks-004.tlg
+++ b/base/testfiles-lthooks/lthooks-004.tlg
@@ -18,6 +18,7 @@ The sequence \g__hook_all_seq contains the items (without outer braces):
 >  {para/after}
 >  {para/begin}
 >  {para/end}
+>  {target/setname/after}
 >  {begindocument}
 >  {begindocument/before}
 >  {begindocument/end}
@@ -105,6 +106,7 @@ The hook xxx contains the rules:
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop

--- a/base/testfiles-lthooks/lthooks-005.tlg
+++ b/base/testfiles-lthooks/lthooks-005.tlg
@@ -40,6 +40,7 @@ The sequence \g__hook_all_seq contains the items (without outer braces):
 >  {para/after}
 >  {para/begin}
 >  {para/end}
+>  {target/setname/after}
 >  {begindocument}
 >  {begindocument/before}
 >  {begindocument/end}
@@ -133,6 +134,7 @@ The hook xxx contains the rules:
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop

--- a/base/testfiles-lthooks/lthooks-006.tlg
+++ b/base/testfiles-lthooks/lthooks-006.tlg
@@ -15,6 +15,7 @@ The sequence \g__hook_all_seq contains the items (without outer braces):
 >  {para/after}
 >  {para/begin}
 >  {para/end}
+>  {target/setname/after}
 >  {begindocument}
 >  {begindocument/before}
 >  {begindocument/end}
@@ -100,6 +101,7 @@ The hook xxx contains the rules:
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop

--- a/base/testfiles-lthooks/lthooks-007.tlg
+++ b/base/testfiles-lthooks/lthooks-007.tlg
@@ -15,6 +15,7 @@ The sequence \g__hook_all_seq contains the items (without outer braces):
 >  {para/after}
 >  {para/begin}
 >  {para/end}
+>  {target/setname/after}
 >  {begindocument}
 >  {begindocument/before}
 >  {begindocument/end}
@@ -101,6 +102,7 @@ The hook xxx contains the rules:
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop
@@ -364,6 +366,7 @@ Data structure for label rules:
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop

--- a/base/testfiles-lthooks/lthooks-008.tlg
+++ b/base/testfiles-lthooks/lthooks-008.tlg
@@ -19,6 +19,7 @@ The sequence \g__hook_all_seq contains the items (without outer braces):
 >  {para/after}
 >  {para/begin}
 >  {para/end}
+>  {target/setname/after}
 >  {begindocument}
 >  {begindocument/before}
 >  {begindocument/end}
@@ -101,6 +102,7 @@ The hook enddocument contains the rules:
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop

--- a/base/testfiles-lthooks/lthooks-009.tlg
+++ b/base/testfiles-lthooks/lthooks-009.tlg
@@ -8,6 +8,7 @@ Don't change this file in any respect.
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop

--- a/base/testfiles-lthooks/lthooks-011.tlg
+++ b/base/testfiles-lthooks/lthooks-011.tlg
@@ -6,6 +6,7 @@ Don't change this file in any respect.
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop
@@ -268,6 +269,7 @@ Data structure for label rules:
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop
@@ -532,6 +534,7 @@ Data structure for label rules:
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop
@@ -798,6 +801,7 @@ Data structure for label rules:
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop

--- a/base/testfiles-lthooks/lthooks-013.tlg
+++ b/base/testfiles-lthooks/lthooks-013.tlg
@@ -63,6 +63,7 @@ Data structure for label rules:
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop

--- a/base/testfiles-lthooks/lthooks-021.tlg
+++ b/base/testfiles-lthooks/lthooks-021.tlg
@@ -4,6 +4,7 @@ Don't change this file in any respect.
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop

--- a/base/testfiles-lthooks/lthooks-legacy.tlg
+++ b/base/testfiles-lthooks/lthooks-legacy.tlg
@@ -6,6 +6,7 @@ Don't change this file in any respect.
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 [lthooks] Add to hook 'begindocument' (legacy) on input line ...
 [lthooks]    <- \typeout {legacy begindocument\on@line }

--- a/base/testfiles-lthooks2/lthooks2-002.tlg
+++ b/base/testfiles-lthooks2/lthooks2-002.tlg
@@ -31,6 +31,7 @@ Data structure for label rules:
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop

--- a/base/testfiles-lthooks2/lthooks2-005.tlg
+++ b/base/testfiles-lthooks2/lthooks2-005.tlg
@@ -6,6 +6,7 @@ Don't change this file in any respect.
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop
@@ -256,6 +257,7 @@ Data structure for label rules:
 [lthooks] Update code for hook 'para/after' on input line ...:
 [lthooks] Update code for hook 'para/begin' on input line ...:
 [lthooks] Update code for hook 'para/end' on input line ...:
+[lthooks] Update code for hook 'target/setname/after' on input line ...:
 [lthooks] Update code for hook 'begindocument' on input line ...:
 Code labels for sorting:
  calc-noop


### PR DESCRIPTION
* Adds a hook to MakeLinkTarget to allow to adjust the target name also when hyperref is not used. This will be needed for better/easier tagging of the bibliography. 
* Corrects a socket name (unused currently but will be used)
* lots of spaces trimmed, sorry ;-)


# Internal housekeeping

## Status of pull request
- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added (updated)
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [no] Rollback provided (if necessary)?  no, I don't think it is need to remove the hook again.
- [n/a] `ltnewsX.tex` (and/or `latexchanges.tex`) updated 
