### PR TITLE
Add Chinese option for varioref

### DIFF
--- a/base/doc/ltnews43.tex
+++ b/base/doc/ltnews43.tex
@@ -513,6 +513,14 @@ results.
 %
 \githubissue{1977}
 
+\subsection{\pkg{varioref}: Chinese locale strings}
+
+A \texttt{chinese} option has been added to \pkg{varioref}, providing
+Simplified Chinese locale strings for all reference text macros and
+format macros. The parentheses in the format macros use full-width
+characters (U+FF08/U+FF09), consistent with the existing Japanese
+option.
+
 \section{Changes at the L3 programming layer}
 
 The L3 programming layer provides functions to convert between different

--- a/required/tools/changes.txt
+++ b/required/tools/changes.txt
@@ -5,6 +5,10 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 =======================================================================
 
+2026-05-04  Liam Huang  <liamhuang0205@gmail.com>
+
+	* varioref.dtx: Added option chinese (CTeX-org/ctex-kit#271)
+
 2026-02-24 Joseph Wright  <Joseph.Wright@latex-project.org>
 
 	* array.dtx: Avoid 'fake math' in tabulars

--- a/required/tools/testfiles-TU/github-2071.luatex.tlg
+++ b/required/tools/testfiles-TU/github-2071.luatex.tlg
@@ -1,0 +1,321 @@
+This is a generated file for the LaTeX2e validation system.
+Don't change this file in any respect.
+[1
+] [2] [3]
+Missing character: There is no （ (U+FF08) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 第 (U+7B2C) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no ） (U+FF09) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no （ (U+FF08) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 第 (U+7B2C) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no ） (U+FF09) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 第 (U+7B2C) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 第 (U+7B2C) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no （ (U+FF08) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 前 (U+524D) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 一 (U+4E00) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no ） (U+FF09) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no （ (U+FF08) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 前 (U+524D) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 一 (U+4E00) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no ） (U+FF09) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 至 (U+81F3) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no （ (U+FF08) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 第 (U+7B2C) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 至 (U+81F3) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no ） (U+FF09) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 至 (U+81F3) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no （ (U+FF08) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 第 (U+7B2C) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 至 (U+81F3) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no ） (U+FF09) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 至 (U+81F3) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no （ (U+FF08) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 第 (U+7B2C) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 至 (U+81F3) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no ） (U+FF09) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 至 (U+81F3) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no （ (U+FF08) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 第 (U+7B2C) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 至 (U+81F3) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no ） (U+FF09) in font [lmroman10-regular]:+tlig;!
+Completed box being shipped out [4]
+\vbox(633.0+0.0)x407.0, direction TLT
+.\glue 16.0
+.\vbox(617.0+0.0)x345.0, shifted 62.0, direction TLT
+..\vbox(12.0+0.0)x345.0, glue set 12.0fil, direction TLT
+...\glue 0.0 plus 1.0fil
+...\hbox(0.0+0.0)x345.0, direction TLT
+....\hbox(0.0+0.0)x345.0, direction TLT
+..\glue 25.0
+..\glue(\lineskip) 0.0
+..\vbox(550.0+0.0)x345.0, glue set 491.94745fil, direction TLT
+...\glue(\topskip) 2.84
+...\hbox(7.16+0.22)x345.0, glue set 264.22998fil, direction TLT
+....\localpar
+.....\localinterlinepenalty=0
+.....\localbrokenpenalty=0
+.....\localleftbox=null
+.....\localrightbox=null
+....\hbox(0.0+0.0)x15.0, direction TLT
+....\TU/lmr/m/n/10 R
+....\TU/lmr/m/n/10 e
+....\TU/lmr/m/n/10 f
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 A
+....\TU/lmr/m/n/10 :
+....\penalty 10000
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 1
+....\hbox(0.0+0.0)x0.0, direction TLT
+....\TU/lmr/m/n/10 （
+....\TU/lmr/m/n/10 󰀀
+....\write1{\newlabel{1@xvr}{{}{\thepage }}}
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 第
+....\TU/lmr/m/n/10 󰀀
+....\penalty 10000
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 1
+....\hbox(0.0+0.0)x0.0, direction TLT
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 页
+....\TU/lmr/m/n/10 󰀀
+....\write1{\newlabel{1@vr}{{}{\thepage }}}
+....\TU/lmr/m/n/10 ）
+....\TU/lmr/m/n/10 󰀀
+....\TU/lmr/m/n/10 .
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 4.73
+...\hbox(7.05+2.06)x345.0, glue set 261.04999fil, direction TLT
+....\localpar
+.....\localinterlinepenalty=0
+.....\localbrokenpenalty=0
+.....\localleftbox=null
+.....\localrightbox=null
+....\hbox(0.0+0.0)x15.0, direction TLT
+....\TU/lmr/m/n/10 P
+....\kern-0.28 (font)
+....\TU/lmr/m/n/10 a
+....\TU/lmr/m/n/10 g
+....\TU/lmr/m/n/10 e
+....\TU/lmr/m/n/10 r
+....\TU/lmr/m/n/10 e
+....\TU/lmr/m/n/10 f
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 B
+....\TU/lmr/m/n/10 :
+....\write1{\newlabel{2@xvr}{{}{\thepage }}}
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 第
+....\TU/lmr/m/n/10 󰀀
+....\penalty 10000
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 2
+....\hbox(0.0+0.0)x0.0, direction TLT
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 页
+....\TU/lmr/m/n/10 󰀀
+....\write1{\newlabel{2@vr}{{}{\thepage }}}
+....\TU/lmr/m/n/10 .
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 2.89
+...\hbox(7.05+0.22)x345.0, glue set 273.37fil, direction TLT
+....\localpar
+.....\localinterlinepenalty=0
+.....\localbrokenpenalty=0
+.....\localleftbox=null
+.....\localrightbox=null
+....\hbox(0.0+0.0)x15.0, direction TLT
+....\TU/lmr/m/n/10 R
+....\TU/lmr/m/n/10 e
+....\TU/lmr/m/n/10 f
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 C
+....\TU/lmr/m/n/10 :
+....\penalty 10000
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 3
+....\hbox(0.0+0.0)x0.0, direction TLT
+....\TU/lmr/m/n/10 （
+....\TU/lmr/m/n/10 󰀀
+....\write1{\newlabel{3@xvr}{{}{\thepage }}}
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 前
+....\TU/lmr/m/n/10 󰀀
+....\TU/lmr/m/n/10 一
+....\TU/lmr/m/n/10 󰀀
+....\TU/lmr/m/n/10 页
+....\TU/lmr/m/n/10 󰀀
+....\write1{\newlabel{3@vr}{{}{\thepage }}}
+....\TU/lmr/m/n/10 ）
+....\TU/lmr/m/n/10 󰀀
+....\TU/lmr/m/n/10 .
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 4.62
+...\hbox(7.16+2.06)x345.0, glue set 215.58997fil, direction TLT
+....\localpar
+.....\localinterlinepenalty=0
+.....\localbrokenpenalty=0
+.....\localleftbox=null
+.....\localrightbox=null
+....\hbox(0.0+0.0)x15.0, direction TLT
+....\TU/lmr/m/n/10 R
+....\TU/lmr/m/n/10 a
+....\TU/lmr/m/n/10 n
+....\TU/lmr/m/n/10 g
+....\TU/lmr/m/n/10 e
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 A
+....\discretionary (penalty 50)
+.....< \TU/lmr/m/n/10 -
+.....= \TU/lmr/m/n/10 -
+....\TU/lmr/m/n/10 C
+....\TU/lmr/m/n/10 :
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 1
+....\hbox(0.0+0.0)x0.0, direction TLT
+....\penalty 10000
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 至
+....\TU/lmr/m/n/10 󰀀
+....\penalty 10000
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 3
+....\hbox(0.0+0.0)x0.0, direction TLT
+....\TU/lmr/m/n/10 （
+....\TU/lmr/m/n/10 󰀀
+....\TU/lmr/m/n/10 第
+....\TU/lmr/m/n/10 󰀀
+....\penalty 10000
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 1
+....\hbox(0.0+0.0)x0.0, direction TLT
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 至
+....\TU/lmr/m/n/10 󰀀
+....\penalty 10000
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 3
+....\hbox(0.0+0.0)x0.0, direction TLT
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 页
+....\TU/lmr/m/n/10 󰀀
+....\TU/lmr/m/n/10 ）
+....\TU/lmr/m/n/10 󰀀
+....\TU/lmr/m/n/10 .
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 2.89
+...\hbox(7.05+2.06)x345.0, glue set 216.00996fil, direction TLT
+....\localpar
+.....\localinterlinepenalty=0
+.....\localbrokenpenalty=0
+.....\localleftbox=null
+.....\localrightbox=null
+....\hbox(0.0+0.0)x15.0, direction TLT
+....\TU/lmr/m/n/10 R
+....\TU/lmr/m/n/10 a
+....\TU/lmr/m/n/10 n
+....\TU/lmr/m/n/10 g
+....\TU/lmr/m/n/10 e
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 B
+....\discretionary (penalty 50)
+.....< \TU/lmr/m/n/10 -
+.....= \TU/lmr/m/n/10 -
+....\TU/lmr/m/n/10 C
+....\TU/lmr/m/n/10 :
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 2
+....\hbox(0.0+0.0)x0.0, direction TLT
+....\penalty 10000
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 至
+....\TU/lmr/m/n/10 󰀀
+....\penalty 10000
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 3
+....\hbox(0.0+0.0)x0.0, direction TLT
+....\TU/lmr/m/n/10 （
+....\TU/lmr/m/n/10 󰀀
+....\TU/lmr/m/n/10 第
+....\TU/lmr/m/n/10 󰀀
+....\penalty 10000
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 2
+....\hbox(0.0+0.0)x0.0, direction TLT
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 至
+....\TU/lmr/m/n/10 󰀀
+....\penalty 10000
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 3
+....\hbox(0.0+0.0)x0.0, direction TLT
+....\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 页
+....\TU/lmr/m/n/10 󰀀
+....\TU/lmr/m/n/10 ）
+....\TU/lmr/m/n/10 󰀀
+....\TU/lmr/m/n/10 .
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue -2.06
+...\glue 0.0 plus 1.0fil
+...\glue 0.0
+...\glue 0.0 plus 0.0001fil
+..\glue(\baselineskip) 23.23
+..\hbox(6.77+0.0)x345.0, direction TLT
+...\hbox(6.77+0.0)x345.0, glue set 170.0fil, direction TLT
+....\glue 0.0 plus 1.0fil
+....\TU/lmr/m/n/10 4
+....\glue 0.0 plus 1.0fil
+Missing character: There is no （ (U+FF08) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 第 (U+7B2C) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no ） (U+FF09) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 第 (U+7B2C) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no （ (U+FF08) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 前 (U+524D) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 一 (U+4E00) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no ） (U+FF09) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 至 (U+81F3) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no （ (U+FF08) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 第 (U+7B2C) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 至 (U+81F3) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no ） (U+FF09) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 至 (U+81F3) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no （ (U+FF08) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 第 (U+7B2C) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 至 (U+81F3) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:+tlig;!
+Missing character: There is no ） (U+FF09) in font [lmroman10-regular]:+tlig;!
+(github-2071.aux)

--- a/required/tools/testfiles-TU/github-2071.lvt
+++ b/required/tools/testfiles-TU/github-2071.lvt
@@ -1,0 +1,38 @@
+% Test for Chinese option in varioref (CTeX-org/ctex-kit#271)
+
+\documentclass{article}
+
+\usepackage[chinese]{varioref}
+
+\input{test2e}
+
+\begin{document}
+
+\START
+
+\section{A}\label{A}
+
+\newpage
+
+\section{B} \label{B}
+
+\newpage
+
+\section{C} \label{C}
+
+\newpage
+
+\showoutput
+
+Ref A: \vref{A}.
+
+Pageref B: \vpageref{B}.
+
+Ref C: \vref{C}.
+
+Range A-C: \vrefrange{A}{C}.
+
+
+Range B-C: \vrefrange{B}{C}.
+
+\end{document}

--- a/required/tools/testfiles-TU/github-2071.tlg
+++ b/required/tools/testfiles-TU/github-2071.tlg
@@ -1,0 +1,185 @@
+This is a generated file for the LaTeX2e validation system.
+Don't change this file in any respect.
+[1
+] [2] [3]
+Missing character: There is no （ (U+FF08) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no 第 (U+7B2C) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no ） (U+FF09) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no 第 (U+7B2C) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no （ (U+FF08) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no 前 (U+524D) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no 一 (U+4E00) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no ） (U+FF09) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no 至 (U+81F3) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no （ (U+FF08) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no 第 (U+7B2C) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no 至 (U+81F3) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no ） (U+FF09) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no 至 (U+81F3) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no （ (U+FF08) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no 第 (U+7B2C) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no 至 (U+81F3) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no 页 (U+9875) in font [lmroman10-regular]:mapping=tex-text;!
+Missing character: There is no ） (U+FF09) in font [lmroman10-regular]:mapping=tex-text;!
+Completed box being shipped out [4]
+\vbox(633.0+0.0)x407.0
+.\glue 16.0
+.\vbox(617.0+0.0)x345.0, shifted 62.0
+..\vbox(12.0+0.0)x345.0, glue set 12.0fil
+...\glue 0.0 plus 1.0fil
+...\hbox(0.0+0.0)x345.0
+....\hbox(0.0+0.0)x345.0
+..\glue 25.0
+..\glue(\lineskip) 0.0
+..\vbox(550.0+0.0)x345.0, glue set 491.94745fil
+...\glue(\topskip) 2.84
+...\hbox(7.16+0.21999)x345.0, glue set 264.22998fil
+....\hbox(0.0+0.0)x15.0
+....\TU/lmr/m/n/10 Ref
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 A:
+....\penalty 10000
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 1
+....\hbox(0.0+0.0)x0.0
+....\TU/lmr/m/n/10 （
+....\write1{\newlabel{1@xvr}{{}{\thepage }}}
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 第
+....\penalty 10000
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 1
+....\hbox(0.0+0.0)x0.0
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 页
+....\write1{\newlabel{1@vr}{{}{\thepage }}}
+....\TU/lmr/m/n/10 ）.
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 4.73001
+...\hbox(7.05+2.05998)x345.0, glue set 261.04999fil
+....\hbox(0.0+0.0)x15.0
+....\TU/lmr/m/n/10 Pageref
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 B:
+....\write1{\newlabel{2@xvr}{{}{\thepage }}}
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 第
+....\penalty 10000
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 2
+....\hbox(0.0+0.0)x0.0
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 页
+....\write1{\newlabel{2@vr}{{}{\thepage }}}
+....\TU/lmr/m/n/10 .
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 2.89001
+...\hbox(7.05+0.21999)x345.0, glue set 273.37fil
+....\hbox(0.0+0.0)x15.0
+....\TU/lmr/m/n/10 Ref
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 C:
+....\penalty 10000
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 3
+....\hbox(0.0+0.0)x0.0
+....\TU/lmr/m/n/10 （
+....\write1{\newlabel{3@xvr}{{}{\thepage }}}
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 前一页
+....\write1{\newlabel{3@vr}{{}{\thepage }}}
+....\TU/lmr/m/n/10 ）.
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 4.62001
+...\hbox(7.16+2.05998)x345.0, glue set 215.58997fil
+....\hbox(0.0+0.0)x15.0
+....\TU/lmr/m/n/10 Range
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 A-C:
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 1
+....\hbox(0.0+0.0)x0.0
+....\penalty 10000
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 至
+....\penalty 10000
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 3
+....\hbox(0.0+0.0)x0.0
+....\TU/lmr/m/n/10 （第
+....\penalty 10000
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 1
+....\hbox(0.0+0.0)x0.0
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 至
+....\penalty 10000
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 3
+....\hbox(0.0+0.0)x0.0
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 页）.
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 2.89001
+...\hbox(7.05+2.05998)x345.0, glue set 216.00996fil
+....\hbox(0.0+0.0)x15.0
+....\TU/lmr/m/n/10 Range
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 B-C:
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 2
+....\hbox(0.0+0.0)x0.0
+....\penalty 10000
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 至
+....\penalty 10000
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 3
+....\hbox(0.0+0.0)x0.0
+....\TU/lmr/m/n/10 （第
+....\penalty 10000
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 2
+....\hbox(0.0+0.0)x0.0
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 至
+....\penalty 10000
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 3
+....\hbox(0.0+0.0)x0.0
+....\glue 3.33 plus 1.665 minus 1.11
+....\TU/lmr/m/n/10 页）.
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue -2.05998
+...\glue 0.0 plus 1.0fil
+...\glue 0.0
+...\glue 0.0 plus 0.0001fil
+..\glue(\baselineskip) 23.23
+..\hbox(6.77+0.0)x345.0
+...\hbox(6.77+0.0)x345.0, glue set 170.0fil
+....\glue 0.0 plus 1.0fil
+....\TU/lmr/m/n/10 4
+....\glue 0.0 plus 1.0fil
+(github-2071.aux)

--- a/required/tools/varioref.dtx
+++ b/required/tools/varioref.dtx
@@ -1282,6 +1282,28 @@
 %    workflow uses pdf\TeX{} the Japanese letters can't be displayed
 %    easily, so you will see missing glyphs below. To see the real
 %    letters you have to look at the source or package file.
+%    Chinese (Simplified and Traditional) option.
+%    The parentheses below are full width ones U+FF08 and U+FF09.
+% \begin{allowtofu}
+%    \begin{macrocode}
+\DeclareVrefOptions{chinese}
+  {\def\reftextfaceafter {\reftextvario{对面}{下一}页}%
+    \def\reftextfacebefore{\reftextvario{对面}{上一}页}%
+    \def\reftextafter     {\reftextvario{后一}{下一}页}%
+    \def\reftextbefore    {\reftextvario{前一}{上一}页}%
+    \def\reftextcurrent   {\reftextvario{本}{当前}页}%
+    \def\reftextfaraway#1{第~\pageref{#1} 页}%
+    \def\reftextpagerange#1#2{第~\pageref{#1} 至~\pageref{#2} 页}%
+    \def\reftextlabelrange#1#2{\ref{#1}~至~\ref{#2}}%
+    \def\vrefformat#1#2{\ref{#2}（\vpageref[#1]{#2}）}%
+    \def\Vrefformat#1#2{\Ref{#2}（\vpageref[#1]{#2}）}%
+    \def\fullrefformat#1{\ref{#1}（\reftextfaraway{#1}）}%
+    \def\vrefrangeformat#1#2#3{\reftextlabelrange{#2}{#3}%
+                               （\vpagerefrange[{#1}]{#2}{#3}）}%
+  }
+%    \end{macrocode}
+% \end{allowtofu}
+%
 % \changes{v1.6d}{2020/07/20}{Option japanese added (gh/352)}
 % \changes{v1.6e}{2020/07/25}{Option japanese changed (gh/352)}
 % \begin{allowtofu}

--- a/required/tools/varioref.dtx
+++ b/required/tools/varioref.dtx
@@ -1276,15 +1276,15 @@
     \let\vrefrangeformat\vrefrangedefaultformat
   }
 %    \end{macrocode}
-%    Defaults for Japanese. It needs a special \cs{vrefformat},
-%    \cs{Vrefformat}, \cs{fullrefformat} and \cs{vrefrangeformat}
-%    for grammatical reasons. As our standard documentation
-%    workflow uses pdf\TeX{} the Japanese letters can't be displayed
-%    easily, so you will see missing glyphs below. To see the real
-%    letters you have to look at the source or package file.
 % \changes{v1.6i}{2026/05/04}{Option chinese added (CTeX-org/ctex-kit\#271)}
-%    Chinese (Simplified and Traditional) option.
-%    The parentheses below are full width ones U+FF08 and U+FF09.
+%    Defaults for Chinese.  Like Japanese below, Chinese needs custom
+%    \cs{vrefformat}, \cs{Vrefformat}, \cs{fullrefformat} and
+%    \cs{vrefrangeformat}.  As our standard documentation
+%    workflow uses pdf\TeX{} the Chinese characters can't be displayed
+%    easily, so you will see missing glyphs below. To see the real
+%    characters you have to look at the source or package file.
+%    The parentheses in the format macros are full-width ones
+%    U+FF08 and U+FF09.
 % \begin{allowtofu}
 %    \begin{macrocode}
 \DeclareVrefOptions{chinese}
@@ -1305,6 +1305,12 @@
 %    \end{macrocode}
 % \end{allowtofu}
 %
+%    Defaults for Japanese. It needs a special \cs{vrefformat},
+%    \cs{Vrefformat}, \cs{fullrefformat} and \cs{vrefrangeformat}
+%    for grammatical reasons. As our standard documentation
+%    workflow uses pdf\TeX{} the Japanese letters can't be displayed
+%    easily, so you will see missing glyphs below. To see the real
+%    letters you have to look at the source or package file.
 % \changes{v1.6d}{2020/07/20}{Option japanese added (gh/352)}
 % \changes{v1.6e}{2020/07/25}{Option japanese changed (gh/352)}
 % \begin{allowtofu}

--- a/required/tools/varioref.dtx
+++ b/required/tools/varioref.dtx
@@ -42,7 +42,7 @@
 %<package>\DeclareCurrentRelease{}{2026-06-01}
 %<package>
 %<package>\ProvidesPackage{varioref}
-%<package>    [2026/01/20 v1.6h package for extended references (FMi)]
+%<package>    [2026/05/04 v1.6i package for extended references (FMi)]
 % \fi
 %
 %%
@@ -1282,6 +1282,7 @@
 %    workflow uses pdf\TeX{} the Japanese letters can't be displayed
 %    easily, so you will see missing glyphs below. To see the real
 %    letters you have to look at the source or package file.
+% \changes{v1.6i}{2026/05/04}{Option chinese added (CTeX-org/ctex-kit\#271)}
 %    Chinese (Simplified and Traditional) option.
 %    The parentheses below are full width ones U+FF08 and U+FF09.
 % \begin{allowtofu}


### PR DESCRIPTION
# Internal housekeeping

## Status of pull request

- Feedback wanted

## Checklist of required changes before merge will be approved
- [x] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [n/a] Rollback provided (if necessary)?
- [x] `ltnewsX.tex` (and/or `latexchanges.tex`) updated

---

## Summary

Add Simplified Chinese locale strings for `varioref`, following the same pattern as the existing Japanese option (added in gh/352).

This covers:
- All eight `reftext*` macros (`\reftextfaceafter`, `\reftextfacebefore`, `\reftextafter`, `\reftextbefore`, `\reftextcurrent`, `\reftextfaraway`, `\reftextpagerange`, `\reftextlabelrange`)
- All four format macros (`\vrefformat`, `\Vrefformat`, `\fullrefformat`, `\vrefrangeformat`) using full-width parentheses (U+FF08/U+FF09), consistent with the Japanese option

Example output with the `chinese` option:
- `\vref{foo}` produces something like `2.1（第 5 页）`
- `\vpageref{foo}` produces something like `第 5 页`
- `\fullref{foo}` produces something like `2.1（第 5 页）`

The option name `chinese` aligns with the convention used in `babel` Chinese locale.

Related: CTeX-org/ctex-kit#271
