### PR TITLE
add support for title block also for titlepage option

### DIFF
--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -1,3 +1,6 @@
+2026-05-07  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
+	* latex-lab-title: add support for title block structure also to the titlepage version.
+
 2026-05-02  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
 	* documentmetadata-support.dtx: add language and other-languages key
 	* latex-lab-testphase.dtx: remove stray message line

--- a/required/latex-lab/latex-lab-title.dtx
+++ b/required/latex-lab/latex-lab-title.dtx
@@ -15,8 +15,8 @@
 %
 %    https://github.com/latex3/latex2e/issues
 %
-\def\ltlabtitledate{2026-04-28}
-\def\ltlabtitleversion{0.85e}
+\def\ltlabtitledate{2026-05-07}
+\def\ltlabtitleversion{0.85f}
 
 %<*driver>
 \documentclass{l3in2edoc}
@@ -196,12 +196,16 @@
 % or only the title text (but not both).
 % As default the title text has the \texttt{Title} tag and the block is a \texttt{Part} (from
 % the symbolic name \texttt{para/semantic}), 
-% but this can be changed by reassigning the symbolic names \texttt{title/text}
-% and \texttt{title/block}, e.g.,
+% but this can be changed by reassigning the symbolic name \texttt{title/block}
+% and changing the plug of the tagging socket to the transparent plug, e.g., 
 % \begin{verbatim}
 % \AssignStructureRole{title/block}{Title}
-% \AssignStructureRole{title/text}{\UseStructureName{para/semantic}}
+% \AssignTaggingSocketPlug{title}{transparent}
 % \end{verbatim}
+% Note that in PDF 1.7 the \texttt{Title} tag is not a standard tag, it is a user defined
+% and by default rolemapped to \texttt{P}. If \texttt{Title} should be used for the 
+% title block the rolemapping must be adjusted, e.g., to \texttt{Part} or \texttt{Sect}.
+% 
 %    \begin{macrocode}
 \AssignStructureRole{title/block}{\UseStructureName{para/semantic}}
 \IfSocketExistsF{tagsupport/title}
@@ -226,8 +230,12 @@
     tag-name=\UseStructureName{title/block}]
   \let \footnote \thanks
 %    \end{macrocode}
-% use Title around the title. As in PDF 1.7 this is 
-% rolemapped to P we change the text tag there.
+% By default this socket adds \texttt{Title} around the title text. 
+% In PDF 1.7 \texttt{Title} is rolemapped to P and the socket
+% adapts the \texttt{para/textblock} to avoid 
+% that we get an \texttt{P} inside a \texttt{P}.
+% One can assign the \texttt{transparent} plug to the socket if
+% \texttt{Title} should be used for the title block instead.
 %    \begin{macrocode}
   {\LARGE\UseTaggingSocket{title}{}{\@title}\par}  
    \vskip 1.5em%
@@ -244,7 +252,8 @@
   }
  
 %    \end{macrocode}
-% The titlepage variant
+% The titlepage variant:
+% \changes{0.85f}{2026-05-07}{Added support for title/block tag}
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_patch_maketitle_page:
   {\begin{titlepage}%
@@ -258,10 +267,19 @@
   \null\vfil
   \vskip 60\p@
 %    \end{macrocode}
-% use Title around the title. As in PDF 1.7 this is 
-% rolemapped to P we change the text tag there.
 %    \begin{macrocode}
   \begin{center}%
+   [tagging-suppress-paras=true,
+    tagging-recipe=standalone,
+    tag-name=\UseStructureName{title/block}]
+%    \end{macrocode}
+% By default this socket adds \texttt{Title} around the title text. 
+% In PDF 1.7 \texttt{Title} is rolemapped to P and the socket
+% adapts the \texttt{para/textblock} to avoid 
+% that we get an \texttt{P} inside a \texttt{P}.
+% One can assign the \texttt{transparent} plug to the socket if
+% \texttt{Title} should be used for the title block instead.
+%    \begin{macrocode}
    {\LARGE\UseTaggingSocket{title}{}{\@title}\par}
    \vskip 3em%
     {\large

--- a/required/latex-lab/testfiles-title/title-010-block.luatex.tlg
+++ b/required/latex-lab/testfiles-title/title-010-block.luatex.tlg
@@ -1,0 +1,103 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: Show PDF Tags
+============================================================
+-------- title-010-block.xml (start) ---------
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <Title xmlns="http://iso.org/pdf2/ssn"
+      id="ID.006"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>A title
+     <footnotemark xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.008"
+        rolemaps-to="Lbl"
+        referenced-as="2"
+       >
+       <?References objects="1" ?>
+      <Span xmlns="http://iso.org/pdf2/ssn"
+         id="ID.009"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextPosition="Sup"
+        >
+       <?MarkedContent page="1" ?>∗
+      </Span>
+     </footnotemark>
+    </text>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?> author A author B
+    </text>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.011"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>May 20, 2016
+    </text>
+   </Title>
+   <footnote xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.012"
+      rolemaps-to="FENote"
+      referenced-as="1"
+     >
+     <?References objects="2" ?>
+    <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.015"
+       rolemaps-to="Lbl"
+      >
+     <Span xmlns="http://iso.org/pdf2/ssn"
+        id="ID.016"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextPosition="Sup"
+       >
+      <?MarkedContent page="1" ?>∗
+     </Span>
+    </footnotelabel>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.014"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>Note
+     </text>
+    </text-unit>
+   </footnote>
+  </Document>
+ </StructTreeRoot>
+</PDF>
+-------- title-010-block.xml (end) ---------
+============================================================
+[1
+]<<latex-list-css.html>><<latex-align-css.html>> (title-010-block.aux)
+Package tagpdf Info: Finalizing the tagging structure:
+(tagpdf)             Writing out ~16 structure objects
+(tagpdf)             with ~16 'MC' leaf nodes.
+(tagpdf)             Be patient if there are lots of objects!
+Package tagpdf Info: writing ParentTree
+Package tagpdf Info: writing IDTree
+Package tagpdf Info: writing RoleMap
+Package tagpdf Info: writing ClassMap
+Package tagpdf Info: writing NameSpaces
+Package tagpdf Info: writing StructElems
+Package tagpdf Info: writing Root

--- a/required/latex-lab/testfiles-title/title-010-block.lvt
+++ b/required/latex-lab/testfiles-title/title-010-block.lvt
@@ -1,0 +1,17 @@
+\ExplSyntaxOn
+\debug_on:n { check-declarations , deprecation }
+\ExplSyntaxOff
+\DocumentMetadata{tagging=on}
+\input{regression-test}
+\documentclass[]{article}
+
+\author{author A \and author B}
+\title{A title\thanks{Note}}
+\AssignStructureRole{title/block}{Title}
+\AssignTaggingSocketPlug{title}{transparent}
+\begin{document}
+\START
+\maketitle 
+
+\SHOWPDFTAGS
+\end{document}

--- a/required/latex-lab/testfiles-title/title-010-block.tlg
+++ b/required/latex-lab/testfiles-title/title-010-block.tlg
@@ -1,0 +1,111 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: Show PDF Tags
+============================================================
+-------- title-010-block.xml (start) ---------
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <Title xmlns="http://iso.org/pdf2/ssn"
+      id="ID.005"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>A title
+     <footnotemark xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.007"
+        rolemaps-to="Lbl"
+        referenced-as="2"
+       >
+       <?References objects="1" ?>
+      <?MarkedContent page="1" ?>
+      <Span xmlns="http://iso.org/pdf2/ssn"
+         id="ID.008"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextPosition="Sup"
+        >
+       <?MarkedContent page="1" ?>∗
+      </Span>
+      <?MarkedContent page="1" ?>
+     </footnotemark>
+     <?MarkedContent page="1" ?>
+    </text>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>author A author B
+    </text>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>May 20, 2016
+    </text>
+   </Title>
+   <footnote xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="FENote"
+      referenced-as="1"
+     >
+     <?References objects="2" ?>
+    <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.014"
+       rolemaps-to="Lbl"
+      >
+     <?MarkedContent page="1" ?>
+     <Span xmlns="http://iso.org/pdf2/ssn"
+        id="ID.015"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextPosition="Sup"
+       >
+      <?MarkedContent page="1" ?>∗
+     </Span>
+     <?MarkedContent page="1" ?>
+    </footnotelabel>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.013"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>Note
+      <?MarkedContent page="1" ?>
+     </text>
+    </text-unit>
+   </footnote>
+  </Document>
+ </StructTreeRoot>
+</PDF>
+-------- title-010-block.xml (end) ---------
+============================================================
+[1
+]<<latex-list-css.html>><<latex-align-css.html>> (title-010-block.aux)
+Package tagpdf Info: Finalizing the tagging structure:
+(tagpdf)             Writing out ~15 structure objects
+(tagpdf)             with ~16 'MC' leaf nodes.
+(tagpdf)             Be patient if there are lots of objects!
+Package tagpdf Info: writing ParentTree
+Package tagpdf Info: writing IDTree
+Package tagpdf Info: writing RoleMap
+Package tagpdf Info: writing ClassMap
+Package tagpdf Info: writing NameSpaces
+Package tagpdf Info: writing StructElems
+Package tagpdf Info: writing Root

--- a/required/latex-lab/testfiles-title/title-011-block.luatex.tlg
+++ b/required/latex-lab/testfiles-title/title-011-block.luatex.tlg
@@ -1,0 +1,104 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+[1
+]
+============================================================
+TEST 1: Show PDF Tags
+============================================================
+-------- title-011-block.xml (start) ---------
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <Title xmlns="http://iso.org/pdf2/ssn"
+      id="ID.006"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>A title
+     <footnotemark xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.008"
+        rolemaps-to="Lbl"
+        referenced-as="2"
+       >
+       <?References objects="1" ?>
+      <Span xmlns="http://iso.org/pdf2/ssn"
+         id="ID.009"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextPosition="Sup"
+        >
+       <?MarkedContent page="1" ?>1
+      </Span>
+     </footnotemark>
+    </text>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?> author A author B
+    </text>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.011"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>May 20, 2016
+    </text>
+   </Title>
+   <footnote xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.012"
+      rolemaps-to="FENote"
+      referenced-as="1"
+     >
+     <?References objects="2" ?>
+    <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.015"
+       rolemaps-to="Lbl"
+      >
+     <Span xmlns="http://iso.org/pdf2/ssn"
+        id="ID.016"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextPosition="Sup"
+       >
+      <?MarkedContent page="1" ?>1
+     </Span>
+    </footnotelabel>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.014"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>Note
+     </text>
+    </text-unit>
+   </footnote>
+  </Document>
+ </StructTreeRoot>
+</PDF>
+-------- title-011-block.xml (end) ---------
+============================================================
+<<latex-list-css.html>><<latex-align-css.html>> (title-011-block.aux)
+Package tagpdf Info: Finalizing the tagging structure:
+(tagpdf)             Writing out ~16 structure objects
+(tagpdf)             with ~16 'MC' leaf nodes.
+(tagpdf)             Be patient if there are lots of objects!
+Package tagpdf Info: writing ParentTree
+Package tagpdf Info: writing IDTree
+Package tagpdf Info: writing RoleMap
+Package tagpdf Info: writing ClassMap
+Package tagpdf Info: writing NameSpaces
+Package tagpdf Info: writing StructElems
+Package tagpdf Info: writing Root

--- a/required/latex-lab/testfiles-title/title-011-block.lvt
+++ b/required/latex-lab/testfiles-title/title-011-block.lvt
@@ -1,0 +1,17 @@
+\ExplSyntaxOn
+\debug_on:n { check-declarations , deprecation }
+\ExplSyntaxOff
+\DocumentMetadata{tagging=on}
+\input{regression-test}
+\documentclass[titlepage]{article}
+
+\author{author A \and author B}
+\title{A title\thanks{Note}}
+\AssignStructureRole{title/block}{Title}
+\AssignTaggingSocketPlug{title}{transparent}
+\begin{document}
+\START
+\maketitle 
+
+\SHOWPDFTAGS
+\end{document}

--- a/required/latex-lab/testfiles-title/title-011-block.tlg
+++ b/required/latex-lab/testfiles-title/title-011-block.tlg
@@ -1,0 +1,112 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+[1
+]
+============================================================
+TEST 1: Show PDF Tags
+============================================================
+-------- title-011-block.xml (start) ---------
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <Title xmlns="http://iso.org/pdf2/ssn"
+      id="ID.005"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>A title
+     <footnotemark xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.007"
+        rolemaps-to="Lbl"
+        referenced-as="2"
+       >
+       <?References objects="1" ?>
+      <?MarkedContent page="1" ?>
+      <Span xmlns="http://iso.org/pdf2/ssn"
+         id="ID.008"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextPosition="Sup"
+        >
+       <?MarkedContent page="1" ?>1
+      </Span>
+      <?MarkedContent page="1" ?>
+     </footnotemark>
+     <?MarkedContent page="1" ?>
+    </text>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>author A author B
+    </text>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>May 20, 2016
+    </text>
+   </Title>
+   <footnote xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="FENote"
+      referenced-as="1"
+     >
+     <?References objects="2" ?>
+    <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.014"
+       rolemaps-to="Lbl"
+      >
+     <?MarkedContent page="1" ?>
+     <Span xmlns="http://iso.org/pdf2/ssn"
+        id="ID.015"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextPosition="Sup"
+       >
+      <?MarkedContent page="1" ?>1
+     </Span>
+     <?MarkedContent page="1" ?>
+    </footnotelabel>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.013"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>Note
+      <?MarkedContent page="1" ?>
+     </text>
+    </text-unit>
+   </footnote>
+  </Document>
+ </StructTreeRoot>
+</PDF>
+-------- title-011-block.xml (end) ---------
+============================================================
+<<latex-list-css.html>><<latex-align-css.html>> (title-011-block.aux)
+Package tagpdf Info: Finalizing the tagging structure:
+(tagpdf)             Writing out ~15 structure objects
+(tagpdf)             with ~16 'MC' leaf nodes.
+(tagpdf)             Be patient if there are lots of objects!
+Package tagpdf Info: writing ParentTree
+Package tagpdf Info: writing IDTree
+Package tagpdf Info: writing RoleMap
+Package tagpdf Info: writing ClassMap
+Package tagpdf Info: writing NameSpaces
+Package tagpdf Info: writing StructElems
+Package tagpdf Info: writing Root


### PR DESCRIPTION
The titlepage-\maketitle was missing the title/block code 


# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [x] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
