### PR TITLE
Tagging 1328

### DIFF
--- a/base/doc/ltnews43.tex
+++ b/base/doc/ltnews43.tex
@@ -239,7 +239,7 @@ way as if they would directly follow some horizontal text (and not add
 would result in \cs{partopsep} for the second but not for the first
 \env{center} environment resulting in uneven spacing. While this is a
 contrieved example, the problem is real and shows up in document and
-for document using \cs{DocumentMetadata} it has been corrected.
+for documents using \cs{DocumentMetadata} it has been corrected.
 %
 \taggingissue{1328}
 

--- a/base/doc/ltnews43.tex
+++ b/base/doc/ltnews43.tex
@@ -222,7 +222,7 @@ caused concerns so now the fallback is applied silently.
 \taggingissue{1115}
 
 
-\subsection{Improve handling of consequtive display blocks}
+\subsection{Improve handling of consecutive display blocks}
 
 If display block environments directly follow each other (without an
 empty line between them), then they are conceptually belonging to the
@@ -238,7 +238,7 @@ way as if they would directly follow some horizontal text (and not add
 \end{verbatim}
 would result in \cs{partopsep} for the second but not for the first
 \env{center} environment resulting in uneven spacing. While this is a
-contrieved example, the problem is real and shows up in document and
+contrieved example, the problem is real and shows up in documents and
 for documents using \cs{DocumentMetadata} it has been corrected.
 %
 \taggingissue{1328}

--- a/base/doc/ltnews43.tex
+++ b/base/doc/ltnews43.tex
@@ -167,30 +167,50 @@ be found in \texttt{latex-lab-float.pdf}.
 
 \subsection{Setting the language in \cs{DocumentMetadata}}
 
-Until now \cs{DocumentMetadata} knew only the \texttt{lang} key to set the main language.
-The key was only used to set the language in the PDF catalog and the XMP-metadata and didn't affect the language of the document as specified with \pkg{babel} or \pkg{polyglossia}. 
+Until now \cs{DocumentMetadata} knew only the \texttt{lang} key to set
+the main language.  The key was only used to set the language in the
+PDF catalog and the XMP-metadata and didn't affect the language of the
+document as specified with \pkg{babel} or \pkg{polyglossia}.
 
-With this release we are now adding two more keys: \texttt{language} and \texttt{other-languages}. The \texttt{language} key takes as argument a language in BCP~47 format, so, e.g., \texttt{de-AT} or \texttt{fr} or \texttt{gsw-u-sd-chzh} (Swiss German as used in the Canton of Zurich). The value is stored in the document properties and can be retrieved (expandably) with \verb+\GetDocumentProperty{document/language}+. 
+With this release we are now adding two more keys: \texttt{language}
+and \texttt{other-languages}. The \texttt{language} key takes as
+argument a language in BCP~47 format, so, e.g., \texttt{de-AT} or
+\texttt{fr} or \texttt{gsw-u-sd-chzh} (Swiss German as used in the
+Canton of Zurich). The value is stored in the document properties and
+can be retrieved (expandably) with
+\verb+\GetDocumentProperty{document/language}+.
 
-The value of the \texttt{language} key is also used to set the language in the PDF metadata, so it is also a replacement for the \texttt{lang} key. 
-If a different (shorter or more generic) value is wanted in the PDF metadata, an optional argument can be used: \verb+language=[de]{gsw-u-sd-chzh}+ or the \texttt{lang} key can be used after the \texttt{language} key to overwrite the value: \verb+language=gsw-u-sd-chzh,lang=de+.
+The value of the \texttt{language} key is also used to set the
+language in the PDF metadata, so it is also a replacement for the
+\texttt{lang} key.  If a different (shorter or more generic) value is
+wanted in the PDF metadata, an optional argument can be used:
+\verb+language=[de]{gsw-u-sd-chzh}+ or the \texttt{lang} key can be
+used after the \texttt{language} key to overwrite the value:
+\verb+language=gsw-u-sd-chzh,lang=de+.
 
-Just like \texttt{lang}, the \texttt{language} key does \emph{not} automatically change the language setup of a document: it doesn't change the hyphenation patterns or the fix names and doesn't set class options. It also doesn't forces the loading of a language package. 
-The expectation is that in the future packages that need to know the document language, like \pkg{babel} or 
-\pkg{polyglossia}, will read the value and react accordingly. 
+Just like \texttt{lang}, the \texttt{language} key does \emph{not}
+automatically change the language setup of a document: it doesn't
+change the hyphenation patterns or the fix names and doesn't set class
+options. It also doesn't forces the loading of a language package.
+The expectation is that in the future packages that need to know the
+document language, like \pkg{babel} or \pkg{polyglossia}, will read
+the value and react accordingly.
 
-The \texttt{other-languages} key can be used to declare further languages 
-that are used in addition to the  \enquote{main} language
-in the document. The argument is a comma list of languages in BCP~47 format:
-\verb+other-languages={fr,en-US,ar}+. The list is stored in the document properties too and can be retrieved with \verb+\GetDocumentProperty{document/other-languages}+. 
+The \texttt{other-languages} key can be used to declare further
+languages that are used in addition to the \enquote{main} language in
+the document. The argument is a comma list of languages in BCP~47
+format: \verb+other-languages={fr,en-US,ar}+. The list is stored in
+the document properties too and can be retrieved with
+\verb+\GetDocumentProperty{document/other-languages}+.
 
 
 \subsection{(Not) setting the language in \cs{DocumentMetadata}}
 
 It is good practise to always set the main document language in
-\cs{DocumentMetadata} explicitly using the \texttt{lang} or the new \texttt{language} key: It is 
-used to set the \texttt{/Lang} key in the PDF and their value can also
-be used by packages and classes to adapt locale settings.
+\cs{DocumentMetadata} explicitly using the \texttt{lang} or the new
+\texttt{language} key: It is used to set the \texttt{/Lang} key in the
+PDF and their value can also be used by packages and classes to adapt
+locale settings.
  
 However, if there is no such setting then the code will use the main
 language as set by \pkg{babel} or \pkg{polyglossia}. If they are not
@@ -200,6 +220,30 @@ to the log in such cases but feedback we received indicated that it
 caused concerns so now the fallback is applied silently.
 %
 \taggingissue{1115}
+
+
+\subsection{Improve handling of consequtive display blocks}
+
+If display block environments directly follow each other (without an
+empty line between them), then they are conceptually belonging to the
+same semantic paragraph. This means they should be handled in the same
+way as if they would directly follow some horizontal text (and not add
+\cs{partopsep}, for example). This was already incorrect in
+\LaTeXe{}, e.g.
+\begin{verbatim}
+  Start of paragraph ...
+   \begin{center} text-1 \end{center}
+   \begin{center} text-2 \end{center}
+  more text finishing the paragraph.
+\end{verbatim}
+would result in \cs{partopsep} for the second but not for the first
+\env{center} environment resulting in uneven spacing. While this is a
+contrieved example, the problem is real and shows up in document and
+for document using \cs{DocumentMetadata} it has been corrected.
+%
+\taggingissue{1328}
+
+
 
 
 \subsection{Revision of the block environments}

--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -19,7 +19,6 @@
 2026-05-02  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
 	* documentmetadata-support.dtx: add language and other-languages key
 	* latex-lab-testphase.dtx: remove stray message line
->>>>>>> develop
 
 2026-04-28  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
 	* latex-lab-sec.dtx: use \pdf_purify:nN for the title of the structure

--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -1,3 +1,11 @@
+2026-05-10  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
+
+	* latex-lab-block.dtx (subsubsection{Implementation of \insttype{block} templates}):
+	Suppress \partopsep when @endpe is true (tagging/1328)
+
+	* latex-lab-math.dtx (subsection{Regaining control after a display  has finished with \texttt{\$\$}}):
+	Backout \parskip before readding \belowdisplayskip (tagging/1328)
+
 2026-05-08  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
 	* latex-lab-block.dtx: unpack box if next-line is used, tagging/1276
 

--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -4,7 +4,7 @@
 	Suppress \partopsep when @endpe is true (tagging/1328)
 
 	* latex-lab-math.dtx (subsection{Regaining control after a display  has finished with \texttt{\$\$}}):
-	Backout \parskip before readding \belowdisplayskip (tagging/1328)
+	Backout \parskip before re-adding \belowdisplayskip (tagging/1328)
 
 2026-05-08  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
 	* latex-lab-block.dtx: unpack box if next-line is used, tagging/1276

--- a/required/latex-lab/latex-lab-block.dtx
+++ b/required/latex-lab/latex-lab-block.dtx
@@ -9,8 +9,8 @@
 %
 %    https://www.latex-project.org/lppl.txt
 %
-\def\ltlabblockdate{2026-05-08}
-\def\ltlabblockversion{0.9w}
+\def\ltlabblockdate{2026-05-10}
+\def\ltlabblockversion{0.9x}
 
 %<*driver>
 \DocumentMetadata{tagging=on,pdfstandard=ua-2,lang=en}
@@ -4221,7 +4221,8 @@
 %    The variable \cs{l_@@_effective_top_skip} is used for the
 %    vertical skip at the start. It is initialized with
 %    \key{begin-vspace} and below we add \key{begin-extra-vspace} if
-%    the block starts in vmode.
+%    the block starts in vmode and is not part of an ongoing semantic
+%    paragraph.
 %    \begin{macrocode}
     \skip_set:Nn \l_@@_effective_top_skip { \topsep }
 %    \end{macrocode}
@@ -4232,13 +4233,24 @@
     \skip_set:Nn \l_@@_effective_bot_skip { \l_@@_botsep_skip }
     \mode_if_vertical:TF
       {
-        \skip_add:Nn \l_@@_effective_top_skip { \partopsep }
+%    \end{macrocode}
+%    If \texttt{@endpe} is \texttt{true} then we are in the situation
+%    that a display environment wants to continue the current semantic
+%    paragraph, so we do not add \cs{partopsep} or
+%    \cs{l_@@_parbotsep_skip} in that case.
+% \changes{v0.9x}{2026/05/10}{Suppress \cs{partopsep} when
+%    \texttt{@endpe} is true (tagging/1328)}
+%    \begin{macrocode}
+        \legacy_if:nF { @endpe }
+         {
+           \skip_add:Nn \l_@@_effective_top_skip { \partopsep }
 %    \end{macrocode}
 %    
 % \changes{v0.9o}{2026/02/15}{Support \texttt{end-vspace} and
 %                             \texttt{end-extra-vspace} keys (tagging/738)}
 %    \begin{macrocode}
-        \skip_add:Nn \l_@@_effective_bot_skip { \l_@@_parbotsep_skip }
+           \skip_add:Nn \l_@@_effective_bot_skip { \l_@@_parbotsep_skip }
+         }
 %    \end{macrocode}
 %    At this point it is safe to add tagging structure(s) so we have
 %    a kernel-owned hook here for tagging. This is used to possibly

--- a/required/latex-lab/latex-lab-math.dtx
+++ b/required/latex-lab/latex-lab-math.dtx
@@ -2795,13 +2795,13 @@
 %    level. Therefore we have to neutralize the upcoming \cs{parskip}
 %    since we can't  prevent it from being added.
 %
-%    We have to do this before readding the saved skip, because we
+%    We have to do this before re-adding the saved skip, because we
 %    want to make this skip seen by any following
 %    \cs{addvspace}. Otherwise, we might end up with too much space in
 %    such a situation.    
 %  \changes{v0.6k}{2024/12/01}{Handle \cs{parskip} after \texttt{\$\$}
 %    display correctly (tagging/762)}
-%  \changes{v0.7d}{2026/05/10}{Backout \cs{parskip} before readding
+%  \changes{v0.7d}{2026/05/10}{Backout \cs{parskip} before re-adding
 %    \cs{belowdisplayskip} (tagging/1328)}.
 %    \begin{macrocode}
     \skip_vertical:n { -\tex_parskip:D }

--- a/required/latex-lab/latex-lab-math.dtx
+++ b/required/latex-lab/latex-lab-math.dtx
@@ -19,8 +19,8 @@
 %
 %
 
-\def\ltlabmathdate{2026-05-07}
-\def\ltlabmathversion{0.7c}
+\def\ltlabmathdate{2026-05-10}
+\def\ltlabmathversion{0.7d}
 %
 %<*driver>
 \DocumentMetadata{tagging=on,pdfstandard=ua-2}
@@ -2787,13 +2787,6 @@
 %    should be).
 %    \begin{macrocode}
     \penalty \g_@@_postdisplaypenalty_int
-    \skip_vertical:n
-%    \end{macrocode}
-%    Actually we do use the skip without flipping the sign when our records show
-%    that it wasn't flipped earlier i.e., when the negative value was due to the user
-%    specifying it inside the formula.
-%    \begin{macrocode}
-       { \g_@@_skip_sign_tl \l_@@_tmpa_skip  }
 %    \end{macrocode}
 %    As we are now in vertical mode the situation is different from
 %    the way \TeX{} would handle things after a display: \TeX{} would
@@ -2802,16 +2795,23 @@
 %    level. Therefore we have to neutralize the upcoming \cs{parskip}
 %    since we can't  prevent it from being added.
 %
-%    Actually, we could combine this correction with the previous
-%    \cs{skip_vertical:n}, which would produce marginally smaller PDFs;
-%    but that will make \cs{showoutput} tracing somewhat less easy to
-%    understand, so I haven't done that (yet).
+%    We have to do this before readding the saved skip, because we
+%    want to make this skip seen by any following
+%    \cs{addvspace}. Otherwise, we might end up with too much space in
+%    such a situation.    
 %  \changes{v0.6k}{2024/12/01}{Handle \cs{parskip} after \texttt{\$\$}
 %    display correctly (tagging/762)}
+%  \changes{v0.7d}{2026/05/10}{Backout \cs{parskip} before readding
+%    \cs{belowdisplayskip} (tagging/1328)}.
 %    \begin{macrocode}
-%    \typeout{------->~ add~ negative~ parskip~ (to~ cancel~ the~
-%                       one~ that~ TeX~ will~ add)}
     \skip_vertical:n { -\tex_parskip:D }
+    \skip_vertical:n
+%    \end{macrocode}
+%    Actually, we use the skip without flipping the sign when our records show
+%    that it wasn't flipped earlier i.e., when the negative value was due to the user
+%    specifying it inside the formula.
+%    \begin{macrocode}
+       { \g_@@_skip_sign_tl \l_@@_tmpa_skip  }
 %    \end{macrocode}
 %
 %    We also set the \texttt{@domathendpetrue} flag to signal that

--- a/required/latex-lab/testfiles-block/tagging-1279.luatex.tlg
+++ b/required/latex-lab/testfiles-block/tagging-1279.luatex.tlg
@@ -36,7 +36,7 @@ Completed box being shipped out [1]
 ...\pdflinkstate 0
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(550.0+0.0)x319.99997, glue set 507.94574fil, direction TLT
+..\vbox(550.0+0.0)x319.99997, glue set 509.94553fil, direction TLT
 ...\write-{}
 ...\glue(\topskip) 3.84921
 ...\hbox(6.15079+0.0)x294.99994, glue set 262.49988fil, shifted 25.00003, direction TLT
@@ -91,7 +91,7 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\penalty -51
-...\glue 10.0 plus 3.0 minus 5.0
+...\glue 8.0 plus 2.0 minus 4.0
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil

--- a/required/latex-lab/testfiles-block/tagging-1279.tlg
+++ b/required/latex-lab/testfiles-block/tagging-1279.tlg
@@ -35,7 +35,7 @@ Completed box being shipped out [1]
 ...\pdfrunninglinkon
 ..\glue 25.0
 ..\glue(\lineskip) 0.0
-..\vbox(550.0+0.0)x320.0061, glue set 507.94574fil
+..\vbox(550.0+0.0)x320.0061, glue set 509.94553fil
 ...\write-{}
 ...\glue(\topskip) 3.8507
 ...\hbox(6.1493+0.0)x295.0122, glue set 262.52014fil, shifted 24.9939
@@ -74,7 +74,7 @@ Completed box being shipped out [1]
 ....\glue(\parfillskip) 0.0 plus 1.0fil
 ....\glue(\rightskip) 0.0
 ...\penalty -51
-...\glue 10.0 plus 3.0 minus 5.0
+...\glue 8.0 plus 2.0 minus 4.0
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0
 ...\glue 0.0 plus 0.0001fil

--- a/required/latex-lab/testfiles-block/tagging-1328.luatex.tlg
+++ b/required/latex-lab/testfiles-block/tagging-1328.luatex.tlg
@@ -1,0 +1,244 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+\partopsep should not be added anywhere!
+\belowdisplayshortskip should prevent extra space from the following list!
+[Template] ==> Using instance 'itemize' of type 'blockenv' on line ...
+[Template] ==>   template: 'std; arguments: ||\BooleanFalse |\NoValue |\NoValue |
+[Template] ==> Using instance 'std-list-1' of type 'block' on line ...
+[Template] ==>   template: 'std'; argument: ||
+[Blocks] ==> __kernel_displayblock_beginpar_vmode:
+[Blocks] ==> __kernel_displayblock_begin:
+[Template] ==> Using instance 'itemize-1' of type 'list' on line ...
+[Template] ==>   template: 'std'; arguments: ||\BooleanFalse |\NoValue |\NoValue |
+[Blocks] ==> Set first block everypar on input line ...
+[Blocks] ==> template:list:std end
+[Template] ==> Using instance 'basic' of type 'item' on line ...
+[Template] ==>   template: 'std'; argument: ||
+[Blocks] ==> Set item block everypar on input line ...
+[Blocks] ==> blockenv common ending on input line ...
+[Blocks] ==> ... in item block everypar on input line ...
+[Blocks] ==> Set noop block everypar on input line ...
+[Blocks] ==> __kernel_displayblock_end:
+[Template] ==> Using instance 'center' of type 'blockenv' on line ...
+[Template] ==>   template: 'std; arguments: ||\BooleanFalse |\NoValue |\NoValue |
+[Template] ==> Using instance 'std-display-1' of type 'block' on line ...
+[Template] ==>   template: 'std'; argument: ||
+[Blocks] ==> __kernel_displayblock_beginpar_hmode:w
+[Blocks] ==> __kernel_displayblock_begin:
+[Template] ==> Using instance 'center' of type 'para' on line ...
+[Template] ==>   template: 'std'; argument: ||
+[Blocks] ==> blockenv common ending on input line ...
+[Blocks] ==> __kernel_displayblock_end:
+[Template] ==> Using instance 'center' of type 'blockenv' on line ...
+[Template] ==>   template: 'std; arguments: ||\BooleanFalse |\NoValue |\NoValue |
+[Template] ==> Using instance 'std-display-1' of type 'block' on line ...
+[Template] ==>   template: 'std'; argument: ||
+[Blocks] ==> __kernel_displayblock_beginpar_vmode:
+[Blocks] ==> __kernel_displayblock_begin:
+[Template] ==> Using instance 'center' of type 'para' on line ...
+[Template] ==>   template: 'std'; argument: ||
+[Blocks] ==> blockenv common ending on input line ...
+[Blocks] ==> __kernel_displayblock_end:
+[Template] ==> Using instance 'center' of type 'blockenv' on line ...
+[Template] ==>   template: 'std; arguments: ||\BooleanFalse |\NoValue |\NoValue |
+[Template] ==> Using instance 'std-display-1' of type 'block' on line ...
+[Template] ==>   template: 'std'; argument: ||
+[Blocks] ==> __kernel_displayblock_beginpar_vmode:
+[Blocks] ==> __kernel_displayblock_begin:
+[Template] ==> Using instance 'center' of type 'para' on line ...
+[Template] ==>   template: 'std'; argument: ||
+[Blocks] ==> blockenv common ending on input line ...
+[Blocks] ==> __kernel_displayblock_end:
+Completed box being shipped out [1]
+\vbox(633.0+0.0)x407.0, direction TLT
+.\hbox(0.0+0.0)x0.0, direction TLT
+..\kern-72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil, direction TLT
+...\kern-72.26999
+...\hbox(0.0+0.0)x0.0, direction TLT
+....\latelua0{ltx.__pdf.backend_ThisPage_gpush(tex.count["g_shipout_readonly_int"])}
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue 16.0
+.\vbox(617.0+0.0)x345.0, shifted 62.0, direction TLT
+..\vbox(12.0+0.0)x345.0, glue set 12.0fil, direction TLT
+...\glue 0.0 plus 1.0fil
+...\pdflinkstate 1
+...\hbox(0.0+0.0)x345.0, direction TLT
+....\hbox(0.0+0.0)x345.0, direction TLT
+...\pdflinkstate 0
+..\glue 25.0
+..\glue(\lineskip) 0.0
+..\vbox(550.0+0.0)x345.0, glue set 375.07993fil, direction TLT
+...\write-{}
+...\glue(\topskip) 5.69446
+...\hbox(4.30554+0.0)x345.0, glue set 314.99994fil, direction TLT
+....\localpar
+.....\localinterlinepenalty=0
+.....\localbrokenpenalty=0
+.....\localleftbox=null
+.....\localrightbox=null
+....\hbox(0.0+0.0)x15.0, direction TLT
+....\OT1/cmr/m/n/10 a
+....\OT1/cmr/m/n/10 a
+....\OT1/cmr/m/n/10 a
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty 10000
+...\glue(\abovedisplayshortskip) 0.0 plus 3.0
+...\glue(\baselineskip) 5.16669
+...\hbox(6.83331+0.0)x7.54167, shifted 168.72917, direction TLT
+....\OML/cmm/m/it/10 Z
+....\kern0.71527 (italic)
+...\penalty 10000
+...\glue(\belowdisplayshortskip) -28.88
+...\penalty 10000
+...\glue 28.88
+...\penalty 0
+...\glue 0.0 plus -1.0
+...\glue 28.88
+...\glue -28.88
+...\penalty -51
+...\glue 28.88
+...\glue -28.88
+...\glue 24.88 plus -2.0 minus -1.0
+...\glue(\parskip) 4.0 plus 2.0 minus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 7.62607
+...\hbox(4.37393+0.0)x319.99997, glue set 319.99997fil, shifted 25.00003, direction TLT
+....\localpar
+.....\localinterlinepenalty=0
+.....\localbrokenpenalty=0
+.....\localleftbox=null
+.....\localrightbox=null
+....\hbox(4.37393+0.0)x0.0, direction TLT
+.....\glue -25.00003
+.....\hbox(4.37393+0.0)x20.00003, glue set 15.00125fil, direction TLT
+......\glue 0.0 plus 1.0fil minus 1.0fil
+......\hbox(4.37393+0.0)x4.99878, direction TLT
+.......\hbox(0.0+0.0)x0.0, direction TLT
+.......\penalty 10000
+.......\TS1/cmr/m/n/10 ^^88
+.....\glue 5.0
+....\penalty 0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty -51
+...\glue 8.0 plus 2.0 minus 4.0
+...\glue 0.0 plus 1.0
+...\glue 12.0 plus 4.0 minus 4.0
+...\glue 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 7.69446
+...\hbox(4.30554+0.0)x345.0, glue set 316.66669fill, direction TLT
+....\localpar
+.....\localinterlinepenalty=0
+.....\localbrokenpenalty=0
+.....\localleftbox=null
+.....\localrightbox=null
+....\hbox(0.0+0.0)x15.0, direction TLT
+....\OT1/cmr/m/n/10 c
+....\OT1/cmr/m/n/10 c
+....\OT1/cmr/m/n/10 c
+....\leaders 0.0 plus 1.0fill
+.....\rule(0.4+0.0)x*
+....\kern0.0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty -51
+...\glue 8.0 plus 3.0 minus 4.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 5.16669
+...\hbox(6.83331+0.0)x345.0, glue set 168.75fil, direction TLT
+....\glue(\leftskip) 0.0 plus 1.0fil
+....\localpar
+.....\localinterlinepenalty=0
+.....\localbrokenpenalty=0
+.....\localleftbox=null
+.....\localrightbox=null
+....\hbox(0.0+0.0)x0.0, direction TLT
+....\OT1/cmr/m/n/10 Y
+....\penalty 10000
+....\glue(\parfillskip) 0.0
+....\glue(\rightskip) 0.0 plus 1.0fil
+...\penalty -51
+...\glue 8.0 plus 2.0 minus 4.0
+...\glue -8.0 plus -2.0 minus -4.0
+...\penalty -51
+...\glue 8.0 plus 2.0 minus 4.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 5.16669
+...\hbox(6.83331+0.0)x345.0, glue set 168.75fil, direction TLT
+....\glue(\leftskip) 0.0 plus 1.0fil
+....\localpar
+.....\localinterlinepenalty=0
+.....\localbrokenpenalty=0
+.....\localleftbox=null
+.....\localrightbox=null
+....\hbox(0.0+0.0)x0.0, direction TLT
+....\OT1/cmr/m/n/10 Y
+....\penalty 10000
+....\glue(\parfillskip) 0.0
+....\glue(\rightskip) 0.0 plus 1.0fil
+...\penalty -51
+...\glue 8.0 plus 2.0 minus 4.0
+...\glue -8.0 plus -2.0 minus -4.0
+...\penalty -51
+...\glue 8.0 plus 2.0 minus 4.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 5.16669
+...\hbox(6.83331+0.0)x345.0, glue set 168.75fil, direction TLT
+....\glue(\leftskip) 0.0 plus 1.0fil
+....\localpar
+.....\localinterlinepenalty=0
+.....\localbrokenpenalty=0
+.....\localleftbox=null
+.....\localrightbox=null
+....\hbox(0.0+0.0)x0.0, direction TLT
+....\OT1/cmr/m/n/10 Y
+....\penalty 10000
+....\glue(\parfillskip) 0.0
+....\glue(\rightskip) 0.0 plus 1.0fil
+...\penalty -51
+...\glue 8.0 plus 2.0 minus 4.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 7.69446
+...\hbox(4.30554+0.0)x345.0, glue set 331.66669fill, direction TLT
+....\localpar
+.....\localinterlinepenalty=0
+.....\localbrokenpenalty=0
+.....\localleftbox=null
+.....\localrightbox=null
+....\OT1/cmr/m/n/10 z
+....\OT1/cmr/m/n/10 z
+....\OT1/cmr/m/n/10 z
+....\leaders 0.0 plus 1.0fill
+.....\rule(0.4+0.0)x*
+....\kern0.0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue 0.0 plus 1.0fil
+...\glue 0.0
+...\glue 0.0 plus 0.0001fil
+..\pdflinkstate 1
+..\glue(\baselineskip) 23.55556
+..\hbox(6.44444+0.0)x345.0, direction TLT
+...\hbox(6.44444+0.0)x345.0, glue set 170.0fil, direction TLT
+....\glue 0.0 plus 1.0fil
+....\OT1/cmr/m/n/10 1
+....\glue 0.0 plus 1.0fil
+..\pdflinkstate 0
+.\kern0.0
+.\kern-633.0
+.\hbox(0.0+0.0)x0.0, direction TLT
+.\kern633.0
+(tagging-1328.aux)

--- a/required/latex-lab/testfiles-block/tagging-1328.lvt
+++ b/required/latex-lab/testfiles-block/tagging-1328.lvt
@@ -1,0 +1,43 @@
+
+\DocumentMetadata{}
+
+
+
+\documentclass{article}
+
+\input{regression-test}
+
+
+\DebugBlocksOn
+
+\showoutput
+
+\begin{document}
+
+\START
+
+\typeout{\partopsep should not be added anywhere!}
+
+\setlength\partopsep{27.77pt}
+
+\typeout{\belowdisplayshortskip should prevent extra space from the following list!}
+
+\setlength\belowdisplayshortskip{28.88pt} % this is larger than \topsep
+
+aaa
+\[Z\] 
+%
+\begin{itemize}
+\item 
+\end{itemize}
+
+\bigskip
+
+
+ccc\hrulefill
+\begin{center} Y\end{center}
+\begin{center} Y\end{center}
+\begin{center} Y\end{center}
+zzz\hrulefill
+
+\end{document}

--- a/required/latex-lab/testfiles-block/tagging-1328.tlg
+++ b/required/latex-lab/testfiles-block/tagging-1328.tlg
@@ -1,0 +1,208 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+\partopsep should not be added anywhere!
+\belowdisplayshortskip should prevent extra space from the following list!
+[Template] ==> Using instance 'itemize' of type 'blockenv' on line ...
+[Template] ==>   template: 'std; arguments: ||\BooleanFalse |\NoValue |\NoValue |
+[Template] ==> Using instance 'std-list-1' of type 'block' on line ...
+[Template] ==>   template: 'std'; argument: ||
+[Blocks] ==> __kernel_displayblock_beginpar_vmode:
+[Blocks] ==> __kernel_displayblock_begin:
+[Template] ==> Using instance 'itemize-1' of type 'list' on line ...
+[Template] ==>   template: 'std'; arguments: ||\BooleanFalse |\NoValue |\NoValue |
+[Blocks] ==> Set first block everypar on input line ...
+[Blocks] ==> template:list:std end
+[Template] ==> Using instance 'basic' of type 'item' on line ...
+[Template] ==>   template: 'std'; argument: ||
+[Blocks] ==> Set item block everypar on input line ...
+[Blocks] ==> blockenv common ending on input line ...
+[Blocks] ==> ... in item block everypar on input line ...
+[Blocks] ==> Set noop block everypar on input line ...
+[Blocks] ==> __kernel_displayblock_end:
+[Template] ==> Using instance 'center' of type 'blockenv' on line ...
+[Template] ==>   template: 'std; arguments: ||\BooleanFalse |\NoValue |\NoValue |
+[Template] ==> Using instance 'std-display-1' of type 'block' on line ...
+[Template] ==>   template: 'std'; argument: ||
+[Blocks] ==> __kernel_displayblock_beginpar_hmode:w
+[Blocks] ==> __kernel_displayblock_begin:
+[Template] ==> Using instance 'center' of type 'para' on line ...
+[Template] ==>   template: 'std'; argument: ||
+[Blocks] ==> blockenv common ending on input line ...
+[Blocks] ==> __kernel_displayblock_end:
+[Template] ==> Using instance 'center' of type 'blockenv' on line ...
+[Template] ==>   template: 'std; arguments: ||\BooleanFalse |\NoValue |\NoValue |
+[Template] ==> Using instance 'std-display-1' of type 'block' on line ...
+[Template] ==>   template: 'std'; argument: ||
+[Blocks] ==> __kernel_displayblock_beginpar_vmode:
+[Blocks] ==> __kernel_displayblock_begin:
+[Template] ==> Using instance 'center' of type 'para' on line ...
+[Template] ==>   template: 'std'; argument: ||
+[Blocks] ==> blockenv common ending on input line ...
+[Blocks] ==> __kernel_displayblock_end:
+[Template] ==> Using instance 'center' of type 'blockenv' on line ...
+[Template] ==>   template: 'std; arguments: ||\BooleanFalse |\NoValue |\NoValue |
+[Template] ==> Using instance 'std-display-1' of type 'block' on line ...
+[Template] ==>   template: 'std'; argument: ||
+[Blocks] ==> __kernel_displayblock_beginpar_vmode:
+[Blocks] ==> __kernel_displayblock_begin:
+[Template] ==> Using instance 'center' of type 'para' on line ...
+[Template] ==>   template: 'std'; argument: ||
+[Blocks] ==> blockenv common ending on input line ...
+[Blocks] ==> __kernel_displayblock_end:
+Completed box being shipped out [1]
+\vbox(633.0+0.0)x407.0
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue 16.0
+.\vbox(617.0+0.0)x345.0, shifted 62.0
+..\vbox(12.0+0.0)x345.0, glue set 12.0fil
+...\glue 0.0 plus 1.0fil
+...\pdfrunninglinkoff
+...\hbox(0.0+0.0)x345.0
+....\hbox(0.0+0.0)x345.0
+...\pdfrunninglinkon
+..\glue 25.0
+..\glue(\lineskip) 0.0
+..\vbox(550.0+0.0)x345.0, glue set 375.07993fil
+...\write-{}
+...\glue(\topskip) 5.6955
+...\hbox(4.3045+0.0)x345.0, glue set 315.00366fil
+....\hbox(0.0+0.0)x15.0
+....\T1/cmr/m/n/10 a
+....\T1/cmr/m/n/10 a
+....\T1/cmr/m/n/10 a
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty 10000
+...\glue(\abovedisplayshortskip) 0.0 plus 3.0
+...\glue(\baselineskip) 5.16669
+...\hbox(6.83331+0.0)x7.54167, shifted 168.72917, display
+....\OML/cmm/m/it/10 Z
+....\kern0.71527
+...\penalty 10000
+...\glue(\belowdisplayshortskip) -28.88
+...\penalty 10000
+...\glue 28.88
+...\penalty 0
+...\glue 0.0 plus -1.0
+...\glue 28.88
+...\glue -28.88
+...\penalty -51
+...\glue 28.88
+...\glue -28.88
+...\glue 24.88 plus -2.0 minus -1.0
+...\glue(\parskip) 4.0 plus 2.0 minus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 7.62607
+...\hbox(4.37393+0.0)x320.0061, glue set 320.0061fil, shifted 24.9939
+....\hbox(4.37393+0.0)x0.0
+.....\glue -24.9939
+.....\hbox(4.37393+0.0)x19.99512, glue set 14.99634fil
+......\glue 0.0 plus 1.0fil minus 1.0fil
+......\hbox(4.37393+0.0)x4.99878
+.......\hbox(0.0+0.0)x0.0
+.......\penalty 10000
+.......\TS1/cmr/m/n/10 ^^88
+.....\glue 4.99878
+....\penalty 0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty -51
+...\glue 8.0 plus 2.0 minus 4.0
+...\glue 0.0 plus 1.0
+...\glue 12.0 plus 4.0 minus 4.0
+...\glue 0.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 7.6955
+...\hbox(4.3045+0.0)x345.0, glue set 316.66992fill
+....\hbox(0.0+0.0)x15.0
+....\T1/cmr/m/n/10 c
+....\T1/cmr/m/n/10 c
+....\T1/cmr/m/n/10 c
+....\leaders 0.0 plus 1.0fill
+.....\rule(0.4+0.0)x*
+....\kern 0.0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\penalty -51
+...\glue 8.0 plus 3.0 minus 4.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 5.1128
+...\hbox(6.8872+0.0)x345.0, glue set 168.75092fil
+....\glue(\leftskip) 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x0.0
+....\T1/cmr/m/n/10 Y
+....\penalty 10000
+....\glue(\parfillskip) 0.0
+....\glue(\rightskip) 0.0 plus 1.0fil
+...\penalty -51
+...\glue 8.0 plus 2.0 minus 4.0
+...\glue -8.0 plus -2.0 minus -4.0
+...\penalty -51
+...\glue 8.0 plus 2.0 minus 4.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 5.1128
+...\hbox(6.8872+0.0)x345.0, glue set 168.75092fil
+....\glue(\leftskip) 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x0.0
+....\T1/cmr/m/n/10 Y
+....\penalty 10000
+....\glue(\parfillskip) 0.0
+....\glue(\rightskip) 0.0 plus 1.0fil
+...\penalty -51
+...\glue 8.0 plus 2.0 minus 4.0
+...\glue -8.0 plus -2.0 minus -4.0
+...\penalty -51
+...\glue 8.0 plus 2.0 minus 4.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 5.1128
+...\hbox(6.8872+0.0)x345.0, glue set 168.75092fil
+....\glue(\leftskip) 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x0.0
+....\T1/cmr/m/n/10 Y
+....\penalty 10000
+....\glue(\parfillskip) 0.0
+....\glue(\rightskip) 0.0 plus 1.0fil
+...\penalty -51
+...\glue 8.0 plus 2.0 minus 4.0
+...\glue(\parskip) 0.0 plus 1.0
+...\glue(\parskip) 0.0
+...\glue(\baselineskip) 7.6955
+...\hbox(4.3045+0.0)x345.0, glue set 331.66992fill
+....\T1/cmr/m/n/10 z
+....\T1/cmr/m/n/10 z
+....\T1/cmr/m/n/10 z
+....\leaders 0.0 plus 1.0fill
+.....\rule(0.4+0.0)x*
+....\kern 0.0
+....\penalty 10000
+....\glue(\parfillskip) 0.0 plus 1.0fil
+....\glue(\rightskip) 0.0
+...\glue 0.0 plus 1.0fil
+...\glue 0.0
+...\glue 0.0 plus 0.0001fil
+..\pdfrunninglinkoff
+..\glue(\baselineskip) 23.5849
+..\hbox(6.4151+0.0)x345.0
+...\hbox(6.4151+0.0)x345.0, glue set 170.00061fil
+....\glue 0.0 plus 1.0fil
+....\T1/cmr/m/n/10 1
+....\glue 0.0 plus 1.0fil
+..\pdfrunninglinkon
+.\kern 0.0
+.\kern -633.0
+.\hbox(0.0+0.0)x0.0
+.\kern 633.0
+(tagging-1328.aux)

--- a/required/latex-lab/testfiles-math-luatex/labelled-align-pdf-2.tlg
+++ b/required/latex-lab/testfiles-math-luatex/labelled-align-pdf-2.tlg
@@ -233,8 +233,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus 1.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
@@ -667,8 +667,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus 1.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
@@ -860,8 +860,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus 1.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
@@ -1235,8 +1235,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus 1.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
@@ -1652,8 +1652,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus 1.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
@@ -1941,8 +1941,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus 1.0
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0

--- a/required/latex-lab/testfiles-math-luatex/math-suspended-gh661.tlg
+++ b/required/latex-lab/testfiles-math-luatex/math-suspended-gh661.tlg
@@ -138,8 +138,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 6.0 plus 3.0 minus 3.0
 ...\penalty 0
-...\glue 6.0 plus 3.0 minus 3.0
 ...\glue 0.0 plus -1.0
+...\glue 6.0 plus 3.0 minus 3.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 7.69446

--- a/required/latex-lab/testfiles-math-luatex/mathml-luamml-2a.tlg
+++ b/required/latex-lab/testfiles-math-luatex/mathml-luamml-2a.tlg
@@ -82,8 +82,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 6.0 plus 3.0 minus 3.0
 ...\penalty 0
-...\glue 6.0 plus 3.0 minus 3.0
 ...\glue 0.0 plus -1.0
+...\glue 6.0 plus 3.0 minus 3.0
 ...\glue 0.0 plus 1.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
@@ -126,8 +126,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 6.0 plus 3.0 minus 3.0
 ...\penalty 0
-...\glue 6.0 plus 3.0 minus 3.0
 ...\glue 0.0 plus -1.0
+...\glue 6.0 plus 3.0 minus 3.0
 ...\glue 0.0 plus 1.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0

--- a/required/latex-lab/testfiles-math-luatex/tagging-1119.tlg
+++ b/required/latex-lab/testfiles-math-luatex/tagging-1119.tlg
@@ -99,8 +99,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 6.0 plus 3.0 minus 3.0
 ...\penalty 0
-...\glue 6.0 plus 3.0 minus 3.0
 ...\glue 0.0 plus -1.0
+...\glue 6.0 plus 3.0 minus 3.0
 ...\glue 0.0 plus 1.0
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0

--- a/required/latex-lab/testfiles-math-luatex/tagging-957.tlg
+++ b/required/latex-lab/testfiles-math-luatex/tagging-957.tlg
@@ -310,8 +310,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 11.0 plus 3.0 minus 6.0
 ...\penalty 0
-...\glue 11.0 plus 3.0 minus 6.0
 ...\glue 0.0 plus -1.0
+...\glue 11.0 plus 3.0 minus 6.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\lineskip) 1.0

--- a/required/latex-lab/testfiles-math-luatex/test-math-split-leqno-centertags.tlg
+++ b/required/latex-lab/testfiles-math-luatex/test-math-split-leqno-centertags.tlg
@@ -394,8 +394,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\penalty 10000
@@ -521,8 +521,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 6.0 plus 3.0 minus 3.0
 ...\penalty 0
-...\glue 6.0 plus 3.0 minus 3.0
 ...\glue 0.0 plus -1.0
+...\glue 6.0 plus 3.0 minus 3.0
 ...\glue 0.0 plus 1.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
@@ -652,8 +652,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\penalty 10000
@@ -827,8 +827,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus 1.0
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0

--- a/required/latex-lab/testfiles-math-luatex/test-math-split-leqno-tbtags.tlg
+++ b/required/latex-lab/testfiles-math-luatex/test-math-split-leqno-tbtags.tlg
@@ -393,8 +393,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\penalty 10000
@@ -519,8 +519,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 6.0 plus 3.0 minus 3.0
 ...\penalty 0
-...\glue 6.0 plus 3.0 minus 3.0
 ...\glue 0.0 plus -1.0
+...\glue 6.0 plus 3.0 minus 3.0
 ...\glue 0.0 plus 1.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
@@ -649,8 +649,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\penalty 10000
@@ -823,8 +823,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus 1.0
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0

--- a/required/latex-lab/testfiles-math-luatex/test-math-split-reqno-centertags.tlg
+++ b/required/latex-lab/testfiles-math-luatex/test-math-split-reqno-centertags.tlg
@@ -392,8 +392,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\penalty 10000
@@ -518,8 +518,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 6.0 plus 3.0 minus 3.0
 ...\penalty 0
-...\glue 6.0 plus 3.0 minus 3.0
 ...\glue 0.0 plus -1.0
+...\glue 6.0 plus 3.0 minus 3.0
 ...\glue 0.0 plus 1.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
@@ -648,8 +648,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\penalty 10000
@@ -821,8 +821,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus 1.0
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0

--- a/required/latex-lab/testfiles-math-luatex/test-math-split-reqno-tbtags.tlg
+++ b/required/latex-lab/testfiles-math-luatex/test-math-split-reqno-tbtags.tlg
@@ -426,8 +426,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\penalty 10000
@@ -551,8 +551,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 6.0 plus 3.0 minus 3.0
 ...\penalty 0
-...\glue 6.0 plus 3.0 minus 3.0
 ...\glue 0.0 plus -1.0
+...\glue 6.0 plus 3.0 minus 3.0
 ...\glue 0.0 plus 1.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
@@ -680,8 +680,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\penalty 10000
@@ -852,8 +852,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus 1.0
 ...\glue 0.0 plus 1.0fil
 ...\glue 0.0

--- a/required/latex-lab/testfiles-math/math-suspended-gh661.tlg
+++ b/required/latex-lab/testfiles-math/math-suspended-gh661.tlg
@@ -150,8 +150,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 6.0 plus 3.0 minus 3.0
 ...\penalty 0
-...\glue 6.0 plus 3.0 minus 3.0
 ...\glue 0.0 plus -1.0
+...\glue 6.0 plus 3.0 minus 3.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 7.6955

--- a/required/latex-lab/testfiles-math/mathcapture-016.tlg
+++ b/required/latex-lab/testfiles-math/mathcapture-016.tlg
@@ -101,8 +101,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue(\parskip) 0.0 plus 1.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 4.27946

--- a/required/latex-lab/testfiles-math/mtag-005-intertext.tlg
+++ b/required/latex-lab/testfiles-math/mtag-005-intertext.tlg
@@ -205,8 +205,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus -1.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 0.0 plus 1.0
 ...\kern 0.0
 ...\hbox(0.0+0.0)x0.0

--- a/required/latex-lab/testfiles-math/tagging-762.tlg
+++ b/required/latex-lab/testfiles-math/tagging-762.tlg
@@ -74,8 +74,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 6.0 plus 3.0 minus 3.0
 ...\penalty 0
-...\glue 6.0 plus 3.0 minus 3.0
 ...\glue -77.0
+...\glue 6.0 plus 3.0 minus 3.0
 ...\glue(\parskip) 77.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.1128
@@ -130,8 +130,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 6.0 plus 3.0 minus 3.0
 ...\penalty 0
-...\glue 6.0 plus 3.0 minus 3.0
 ...\glue -77.0
+...\glue 6.0 plus 3.0 minus 3.0
 ...\glue 77.0
 ...\glue(\parskip) 77.0
 ...\glue(\parskip) 0.0
@@ -247,8 +247,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue -77.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue(\parskip) 77.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 1.51276
@@ -345,8 +345,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 10.0 plus 2.0 minus 5.0
 ...\penalty 0
-...\glue 10.0 plus 2.0 minus 5.0
 ...\glue -77.0
+...\glue 10.0 plus 2.0 minus 5.0
 ...\glue 77.0
 ...\glue(\parskip) 77.0
 ...\glue(\parskip) 0.0

--- a/required/latex-lab/testfiles-math/tagging-809.tlg
+++ b/required/latex-lab/testfiles-math/tagging-809.tlg
@@ -96,8 +96,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 100.0
 ...\penalty 99
-...\glue 100.0
 ...\glue 0.0
+...\glue 100.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.1128
@@ -264,8 +264,8 @@ Completed box being shipped out [2]
 ...\penalty 10000
 ...\glue 100.0
 ...\penalty 99
-...\glue 100.0
 ...\glue 0.0
+...\glue 100.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.1128
@@ -428,8 +428,8 @@ Completed box being shipped out [3]
 ...\penalty 10000
 ...\glue 100.0
 ...\penalty 99
-...\glue 100.0
 ...\glue 0.0
+...\glue 100.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.1128
@@ -597,8 +597,8 @@ Completed box being shipped out [4]
 ...\penalty 10000
 ...\glue 100.0
 ...\penalty 99
-...\glue 100.0
 ...\glue 0.0
+...\glue 100.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.1128
@@ -764,8 +764,8 @@ Completed box being shipped out [5]
 ...\penalty 10000
 ...\glue 5.0
 ...\penalty 99
-...\glue -5.0
 ...\glue 0.0
+...\glue -5.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.1128
@@ -934,8 +934,8 @@ Completed box being shipped out [6]
 ...\penalty 10000
 ...\glue 20.0
 ...\penalty 99
-...\glue 20.0
 ...\glue 0.0
+...\glue 20.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.1128
@@ -1104,8 +1104,8 @@ Completed box being shipped out [7]
 ...\penalty 10000
 ...\glue 5.0
 ...\penalty 99
-...\glue -5.0
 ...\glue 0.0
+...\glue -5.0
 ...\glue(\parskip) 0.0
 ...\glue(\parskip) 0.0
 ...\glue(\baselineskip) 5.1128

--- a/required/latex-lab/testfiles-table-pdftex/table-016-math.tlg
+++ b/required/latex-lab/testfiles-table-pdftex/table-016-math.tlg
@@ -300,8 +300,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 6.5 plus 3.5 minus 3.0
 ...\penalty 0
-...\glue 6.5 plus 3.5 minus 3.0
 ...\glue 0.0 plus -1.0
+...\glue 6.5 plus 3.5 minus 3.0
 ...\glue 0.0 plus 1.0
 ...\write1{\new@label@record{mcid-10}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{10}{tagmcid}{\__property_code_tagmcid: }}}
 ...\pdfliteral shipout page{/Formula <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -425,8 +425,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 6.5 plus 3.5 minus 3.0
 ...\penalty 0
-...\glue 6.5 plus 3.5 minus 3.0
 ...\glue 0.0 plus -1.0
+...\glue 6.5 plus 3.5 minus 3.0
 ...\glue 0.0 plus 1.0
 ...\write1{\new@label@record{mcid-13}{{tagabspage}{\__property_code_tagabspage: }{tagmcabs}{13}{tagmcid}{\__property_code_tagmcid: }}}
 ...\pdfliteral shipout page{/Formula <</MCID \flag_height:n {__tag/mcid}\flag_raise:n {__tag/mcid} >> BDC}
@@ -550,8 +550,8 @@ Completed box being shipped out [1]
 ...\penalty 10000
 ...\glue 6.5 plus 3.5 minus 3.0
 ...\penalty 0
-...\glue 6.5 plus 3.5 minus 3.0
 ...\glue 0.0 plus -1.0
+...\glue 6.5 plus 3.5 minus 3.0
 ...\glue 0.0 plus 1.0
 ...\kern 0.0
 ...\hbox(0.0+0.0)x0.0


### PR DESCRIPTION
# Internal housekeeping

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [x] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [n/a] Rollback provided (if necessary)?
- [x] `ltnewsX.tex` (and/or `latexchanges.tex`) updated

We might want to consider fixing that also in 2e with rollback, but perhaps that only after June (or not at all)?