### PR TITLE
fix order key in \newtheoremstyle

### DIFF
--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -1,3 +1,6 @@
+2026-05-20  Matthew Bertucci <mbertucci@willamette.edu>
+	* latex-lab-block.dtx: Fix order key in \newtheoremstyle (issue #2092)
+
 2026-05-12  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 
 	* latex-lab-sec-template.dtx (subsubsection{Instances (sample/default definitions)}):

--- a/required/latex-lab/latex-lab-block.dtx
+++ b/required/latex-lab/latex-lab-block.dtx
@@ -6978,7 +6978,7 @@
     ,before-hspace:e = \tl_if_empty:nTF{#5}{0pt}{#5}
     ,body-decls      = {#4}
     ,punct           = {#7}
-    ,order           = {title, space, number, space, note, punct}
+    ,order           = {title, separator, number, separator, note, punct}
     ,number-decls    = \upshape
     ,note-decls      = \upshape\mdseries
 %    \end{macrocode}

--- a/required/latex-lab/latex-lab-block.dtx
+++ b/required/latex-lab/latex-lab-block.dtx
@@ -9,8 +9,8 @@
 %
 %    https://www.latex-project.org/lppl.txt
 %
-\def\ltlabblockdate{2026-05-10}
-\def\ltlabblockversion{0.9x}
+\def\ltlabblockdate{2026-05-20}
+\def\ltlabblockversion{0.9y}
 
 %<*driver>
 \DocumentMetadata{tagging=on,pdfstandard=ua-2,lang=en}


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

# Internal housekeeping

Fixes #2092.

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [ ] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
