### PR TITLE
Fix language default

### DIFF
--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -1,3 +1,6 @@
+2026-06-15  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
+	* documentmetadata-support.dtx Correct language default.
+
 2026-06-10  Ulrike Fischer  <Ulrike.Fischer@latex-project.org>
 	* latex-lab-firstaid.dtx: fix firstaid for apacite, tagging/677.
   * latex-lab-block.dtx: fix @@-expansion, tagging/1370

--- a/required/latex-lab/documentmetadata-support.dtx
+++ b/required/latex-lab/documentmetadata-support.dtx
@@ -18,8 +18,8 @@
 % for those people who are interested or want to report an issue.
 %
 %    \begin{macrocode}
-\def\documentmetadatasupportversion{1.1c}
-\def\documentmetadatasupportdate{2026-05-27}
+\def\documentmetadatasupportversion{1.1d}
+\def\documentmetadatasupportdate{2026-06-15}
 %    \end{macrocode}
 %
 %
@@ -488,14 +488,14 @@
         \keys_set_exclude_groups:nnn  { document / metadata } { init,pdf } { #1 }
 %    \end{macrocode}
 % Finally we set up the language default.
-% If the \texttt{language} key hasn't be set yet, we set it directly
-% either to the value of the \texttt{lang} key or to en-US.
+% If the \texttt{language} key hasn't be set yet, we set it 
+% either to the value of the \texttt{lang} key or leave it empty.
+% % \changes{v1.1d}{2026-06-15}{Leave language default empty if not set}
 %    \begin{macrocode}
         \tl_if_empty:eTF{\GetDocumentProperty{document/language}}
          {
            \tl_set:Ne\l_@@_tmpa_tl{\GetDocumentProperty{document/lang}}
-           \tl_if_empty:NTF\l_@@_tmpa_tl
-            {\AddToDocumentProperties[document]{language}{en-Latn-US}} 
+           \tl_if_empty:NF\l_@@_tmpa_tl
             {
              \keys_set:ne{document/metadata}{language=\l_@@_tmpa_tl}
              \@@_update_BCPdata:

--- a/required/latex-lab/documentmetadata-support.dtx
+++ b/required/latex-lab/documentmetadata-support.dtx
@@ -202,11 +202,18 @@
 %    To extract, for example, the main language in the first group this code could be used:
 %    \begin{verbatim}
 %    \cs_generate_variant:Nn\text_bcp_parse:n{e}
-%    \tl_set:Ne\mainlanguage
-%     {\exp_last_unbraced:Ne\use_i:nnnnnnn
-%      {\text_bcp_parse:e{\GetDocumentProperty{document/language}}}}
+%    \tl_if_empty:eTF { \GetDocumentProperty{document/language} }
+%     {
+%       % other code to set the main language
+%     }
+%     {
+%       \tl_set:Ne\mainlanguage
+%        {\exp_last_unbraced:Ne\use_i:nnnnnnn
+%        {\text_bcp_parse:e{\GetDocumentProperty{document/language}}}}
+%     }   
 %    \end{verbatim}
-%    
+%    Note that \cs{text_bcp_parse:e} will error if the argument is empty 
+%    so it is necessary to test this case.
 %   
 %    The key updates the default \cs{BCPdata} command to use with the give language value.
 %    Note that this can lead to empty fields for region or script, if, e.g., only 
@@ -488,8 +495,10 @@
         \keys_set_exclude_groups:nnn  { document / metadata } { init,pdf } { #1 }
 %    \end{macrocode}
 % Finally we set up the language default.
-% If the \texttt{language} key hasn't be set yet, we set it 
-% either to the value of the \texttt{lang} key or leave it empty.
+% If the \texttt{language} key hasn't been set yet, we set it 
+% to the value of the \texttt{lang} key and so to empty if this key hasn't be set either. 
+% This way a language package like \pkg{babel} can correctly react to the situation 
+% that neither language nor lang has been explicitly set.
 % % \changes{v1.1d}{2026-06-15}{Leave language default empty if not set}
 %    \begin{macrocode}
         \tl_if_empty:eTF{\GetDocumentProperty{document/language}}

--- a/required/latex-lab/documentmetadata-support.dtx
+++ b/required/latex-lab/documentmetadata-support.dtx
@@ -183,22 +183,22 @@
 %    The key definition is in the pdfmanagement in l3pdfmeta.
 %
 %    \item[\texttt{uncompress}] (no value) Forces an uncompressed pdf
-%      --- mainly for debugging purposes. Do not unnecessarily set it in normal production 
+%      --- mainly for debugging purposes. Do not unnecessarily set it in normal production
 %      because it increases the size of the final PDF considerably.
-%    
+%
 %    \item[\texttt{language}]
-%    The language key should be used to set the main language of the 
-%    document. The value is given in BCP~47 format, 
-%    so, e.g, \texttt{languade=de-DE} or \texttt{language=fr}. 
+%    The language key should be used to set the main language of the
+%    document. The value is given in BCP~47 format,
+%    so, e.g, \texttt{languade=de-DE} or \texttt{language=fr}.
 %    The value is stored in the document properties and can be retrieved (expandably) with
-%    \verb+\GetDocumentProperty{document/language}+. 
-%  
+%    \verb+\GetDocumentProperty{document/language}+.
+%
 %    The key does \emph{not} change the language setup of a document: it doesn't change the
-%    hyphenation patterns or the fix names or forces the loading of a language package. 
-%    The expectation is that packages that need to know the document language, like \pkg{babel} or 
-%    \pkg{polyglossia}, read the value and react accordingly. 
-%    The BCP~47 value,e.g., can be parsed with \cs{text_bcp_parse:n} which produces 
-%    7 brace groups, see interface3. 
+%    hyphenation patterns or the fix names or forces the loading of a language package.
+%    The expectation is that packages that need to know the document language, like \pkg{babel} or
+%    \pkg{polyglossia}, read the value and react accordingly.
+%    The BCP~47 value,e.g., can be parsed with \cs{text_bcp_parse:n} which produces
+%    7 brace groups, see interface3.
 %    To extract, for example, the main language in the first group this code could be used:
 %    \begin{verbatim}
 %    \cs_generate_variant:Nn\text_bcp_parse:n{e}
@@ -210,31 +210,31 @@
 %       \tl_set:Ne\mainlanguage
 %        {\exp_last_unbraced:Ne\use_i:nnnnnnn
 %        {\text_bcp_parse:e{\GetDocumentProperty{document/language}}}}
-%     }   
+%     }
 %    \end{verbatim}
-%    Note that \cs{text_bcp_parse:e} will error if the argument is empty 
+%    Note that \cs{text_bcp_parse:e} will error if the argument is empty
 %    so it is necessary to test this case.
-%   
+%
 %    The key updates the default \cs{BCPdata} command to use with the give language value.
-%    Note that this can lead to empty fields for region or script, if, e.g., only 
-%    \texttt{language=de} instead of \texttt{language=de-Latn-AT} is used. 
+%    Note that this can lead to empty fields for region or script, if, e.g., only
+%    \texttt{language=de} instead of \texttt{language=de-Latn-AT} is used.
 %    This is only relevant if neither \pkg{babel} nor \pkg{polyglossia}
 %    are used as both packages overwrite the \cs{BCPdata} command with their own version.
 %
-%    The value of the \texttt{language} key is also used to set the \texttt{/Lang} key in the PDF. 
+%    The value of the \texttt{language} key is also used to set the \texttt{/Lang} key in the PDF.
 %    If a different (shorter) value is wanted there, an optional argument can be used:
-%    \verb+language=[de]{de-DE}+, or the \texttt{lang} key can be 
+%    \verb+language=[de]{de-DE}+, or the \texttt{lang} key can be
 %     used to overwrite the value: \verb+language=de-DE,lang=de+.
 %
-%     \item[\texttt{otherlanguage}] 
-%     The \texttt{other-languages} key can be used to declare more languages that are used 
+%     \item[\texttt{otherlanguage}]
+%     The \texttt{other-languages} key can be used to declare more languages that are used
 %     in the document. The argument is a comma list of languages in BCP~47 format:
-%     \verb+other-languages={fr,en-US,ar}+. 
-%     The comma list is stored in the document properties and can be retrieved 
-%     (expandably) with \verb+\GetDocumentProperty{document/other-languages}+. 
+%     \verb+other-languages={fr,en-US,ar}+.
+%     The comma list is stored in the document properties and can be retrieved
+%     (expandably) with \verb+\GetDocumentProperty{document/other-languages}+.
 %     As with the \texttt{language} key the expectation is, that language packages
 %     read the value and react accordingly.
-% 
+%
 %    \item[\texttt{lang}] Explicitly sets the Lang entry in the Catalog,
 %     e.g., \texttt{lang=de-DE}. If not given, the value of \verb+\BCPdata{language}+
 %     or \verb+ \BCPdata{main.language}+ at the beginning of the document is used (these
@@ -495,9 +495,9 @@
         \keys_set_exclude_groups:nnn  { document / metadata } { init,pdf } { #1 }
 %    \end{macrocode}
 % Finally we set up the language default.
-% If the \texttt{language} key hasn't been set yet, we set it 
-% to the value of the \texttt{lang} key and so to empty if this key hasn't be set either. 
-% This way a language package like \pkg{babel} can correctly react to the situation 
+% If the \texttt{language} key hasn't been set yet, we set it
+% to the value of the \texttt{lang} key and so to empty if this key hasn't be set either.
+% This way a language package like \pkg{babel} can correctly react to the situation
 % that neither language nor lang has been explicitly set.
 % % \changes{v1.1d}{2026-06-15}{Leave language default empty if not set}
 %    \begin{macrocode}
@@ -508,7 +508,7 @@
             {
              \keys_set:ne{document/metadata}{language=\l_@@_tmpa_tl}
              \@@_update_BCPdata:
-            }           
+            }
          }
          {
            \@@_update_BCPdata:
@@ -706,13 +706,13 @@
 %\changes{1.0u}{2025/10/09}{Added check-tagging-status}
 %\changes{1.0v}{2025/10/12}{Extend check-tagging-status to libraries}
 %\changes{1.0z}{2026-04-22}{Removed duplicated key definitions that are already done in pdfmanagement-init}
-% 
+%
 % \begin{macro}{\@@_update_BCPdata:n}
 % A helper command for the language key.
 % This command updates the \cs{BCPdata} command.
 %    \begin{macrocode}
 \cs_generate_variant:Nn \text_bcp_parse:n {e}
-\cs_new_protected:Npn\@@_update_BCPdata: 
+\cs_new_protected:Npn\@@_update_BCPdata:
  {
    \tl_set:Ne\l_@@_tmpa_tl { \text_bcp_parse:e{\GetDocumentProperty{document/language}} }
    \use:e
@@ -723,12 +723,12 @@
         {
          { language } %was en
            { \exp_last_unbraced:No\use_i:nnnnnnn { \l_@@_tmpa_tl} }
-         { region }   %was US 
+         { region }   %was US
            { \exp_last_unbraced:No\use_iv:nnnnnnn { \l_@@_tmpa_tl} }
          { script }   %was Latn
            { \exp_last_unbraced:No\use_iii:nnnnnnn { \l_@@_tmpa_tl} }
-         { tag }      %was en-US 
-           { \exp_last_unbraced:No\use_i:nnnnnnn { \l_@@_tmpa_tl}- 
+         { tag }      %was en-US
+           { \exp_last_unbraced:No\use_i:nnnnnnn { \l_@@_tmpa_tl}-
              \exp_last_unbraced:No\use_iv:nnnnnnn { \l_@@_tmpa_tl}
            }
         }
@@ -765,7 +765,7 @@
 %    \begin{macrocode}
 \keys_define:nn { document / metadata }
  {
-   language      .code:n = 
+   language      .code:n =
     {
       \@@_language_set:n {#1}
     },
@@ -811,7 +811,7 @@
        \keys_set:nn
         {document / metadata}
         {tagging=on}
-     } 
+     }
 %    \end{macrocode}
 % The following modules are all always loaded, therefore they can be ignored when used in a testphase key:
 % \changes{v1.1a}{2026-04-23}{Make testphase values for loaded modules noop}
@@ -819,7 +819,7 @@
     ,testphase .multichoices:nn =
      {math,new-or,sec,sec-template,toc,graphic,block,minipage,float,
       bib,context,text,firstaid,table,title,marginpar,tikz}
-     {}          
+     {}
     ,testphase / unknown .code:n =
       {
         \tl_gput_right:Nn\g_@@_testphase_tl

--- a/required/latex-lab/testfiles/documentmetadata-support-001.lvt
+++ b/required/latex-lab/testfiles/documentmetadata-support-001.lvt
@@ -9,7 +9,7 @@
 
 \TEST{language}
  {
-   \ASSERT{\GetDocumentProperty{document/language}}{en-Latn-US}
+   \ASSERT{\GetDocumentProperty{document/language}}{}
  } 
  
 \show\ShowTagging


### PR DESCRIPTION
This corrects the language default.

## Status of pull request

- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
