### PR TITLE
GHA: Timeout after 15 minutes in CI tests to avoid blocking runners

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -171,6 +171,7 @@ jobs:
           ${{ matrix.engine && format('-e {0}', matrix.engine) || ''}}
           ${{ matrix.first && format('--first {0}', matrix.first) || ''}}
           ${{ matrix.last && format('--last {0}', matrix.last) || ''}}"
+        timeout-minutes: 15
       # "/" is one of invalid characters in artifact names
       # see https://github.com/actions/toolkit/blob/ef77c9d60bdb03700d7758b0d04b88446e72a896/packages/artifact/src/internal/upload/path-and-artifact-name-validation.ts
       - name: Sanitize artifact name


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

Currently our GitHub Actions tasks can run for up to 6 hours before they timeout. If they take a lot of time they occupy GitHub Runners which are then not available to execute other CI pipelines. Since our tests usually don't take too long, this reduces the timeout for one l3build run to 15 minutes to fail faster and free resources if things are broken.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 
<!-- - Under development -->
- Ready to merge

## Checklist of required changes before merge will be approved
- n/a Test file(s) added
- n/a Version and date string updated in changed source files
- n/a Relevant `\changes` entries in source included
- n/a Relevant `changes.txt` updated
- n/a Rollback provided (if necessary)?
- n/a `ltnewsX.tex` (and/or `latexchanges.tex`) updated
