### PR TITLE
hitex support in tuenc

### DIFF
--- a/base/changes.txt
+++ b/base/changes.txt
@@ -6,6 +6,10 @@ to completeness or accuracy and it contains some references to files that are
 not part of the distribution.
 ================================================================================
 
+2026-07-31  David Carlisle  <David.Carlisle@latex-project.org>
+
+	* ltoutenc.dtx: HiTeX support
+
 2026-07-30 Joseph Wright  <Joseph.Wright@latex-project.org>
 	* lttemplates.dtx:
 	Extend documentation of "name" keyword

--- a/base/ltoutenc.dtx
+++ b/base/ltoutenc.dtx
@@ -3045,7 +3045,6 @@
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-  \fi
 \fi
 %    \end{macrocode}
 %

--- a/base/ltoutenc.dtx
+++ b/base/ltoutenc.dtx
@@ -37,7 +37,7 @@
 %<TS1>\ProvidesFile{ts1enc.def}[2001/06/05 v3.0e (jk/car/fm)
 %<TU>\ProvidesFile{tuenc.def}
 %<package>\ProvidesPackage{fontenc}
-%<OT1|T1|OMS|OML|OT4|TU|package> [2026-07-32 v2.2d
+%<OT1|T1|OMS|OML|OT4|TU|package> [2026-07-31 v2.2a
 %<OT1|T1|OMS|OML|OT4|TS1|TU>      Standard LaTeX file]
 %<package>                        Standard LaTeX package]
 %

--- a/base/ltoutenc.dtx
+++ b/base/ltoutenc.dtx
@@ -2964,14 +2964,16 @@
 % then abort this file, switching back to T1 encoding.
 % Use \verb+\Umathcode+ as the marker for TU support (as in \texttt{fonttext.ltx})
 %    \begin{macrocode}
-\ifx\Umathcode\@undefined
+\expandafter\ifx\csname tex_Umathcode:D\endcsname\relax
+    \expandafter\let\csname tex_Umathcode:D\endcsname\@undefined
 %    \end{macrocode}
 %
 % Not HiTeX, LuaTeX or XeTeX, abort with a warning.
 %    \begin{macrocode}
     \PackageWarningNoLine{fontenc}
       {\UnicodeEncodingName\space
-       encoding is only available with HiTeX, XeTeX and LuaTeX.\MessageBreak
+        encoding is only available with\MessageBreak
+        HiTeX, XeTeX and LuaTeX.\MessageBreak
        Defaulting to T1 encoding}
       \def\encodingdefault{T1}
     \expandafter\endinput

--- a/base/ltoutenc.dtx
+++ b/base/ltoutenc.dtx
@@ -2958,11 +2958,12 @@
 %    \begin{macrocode}
 \providecommand\UnicodeEncodingName{TU}
 %    \end{macrocode}
-%  TU, is only currently available with XeTeX, HiTeX
+% TU is only currently available with XeTeX, HiTeX
 % or LuaTeX, we detect these engines first, and make adjustments for the
 % differing font loading syntax. For other engines, we issue a warning
 % then abort this file, switching back to T1 encoding.
-% Use \verb+\Umathcode+ as the marker for TU support (as in \texttt{fonttext.ltx})
+% Use \verb+\Umathcode+ as the marker for TU support (as in \texttt{fonttext.ltx}).
+% Here we actually test for \verb+\tex_Umathcode:D+ as \verb+\Umathcode+ is redefined locally in the \LaTeX\ test suite.
 %    \begin{macrocode}
 \expandafter\ifx\csname tex_Umathcode:D\endcsname\relax
     \expandafter\let\csname tex_Umathcode:D\endcsname\@undefined

--- a/base/ltoutenc.dtx
+++ b/base/ltoutenc.dtx
@@ -37,14 +37,14 @@
 %<TS1>\ProvidesFile{ts1enc.def}[2001/06/05 v3.0e (jk/car/fm)
 %<TU>\ProvidesFile{tuenc.def}
 %<package>\ProvidesPackage{fontenc}
-%<OT1|T1|OMS|OML|OT4|TU|package> [2025/07/18 v2.1d
+%<OT1|T1|OMS|OML|OT4|TU|package> [2026-07-32 v2.2d
 %<OT1|T1|OMS|OML|OT4|TS1|TU>      Standard LaTeX file]
 %<package>                        Standard LaTeX package]
 %
 %<*driver>
 % \fi
 \ProvidesFile{ltoutenc.dtx}
-             [2026-06-01 v2.1d LaTeX Kernel (font encodings)]
+             [2026-07-31 v2.2a LaTeX Kernel (font encodings)]
 % \iffalse
 \documentclass{ltxdoc}
 \GetFileInfo{ltoutenc.dtx}
@@ -190,7 +190,7 @@
 %         {Removed autoload code}
 % \changes{v2.0p}{2020/04/22}
 %         {corrected \=y unicode value in tuenc.def}
-%
+% \changes{v2.2a}{2026/07/31}{HiTeX support}%
 %
 % \section{Font encodings}
 %
@@ -2958,35 +2958,33 @@
 %    \begin{macrocode}
 \providecommand\UnicodeEncodingName{TU}
 %    \end{macrocode}
-% As the Unicode encoding, TU, is only currently available with XeTeX
+%  TU, is only currently available with XeTeX, HiTeX
 % or LuaTeX, we detect these engines first, and make adjustments for the
 % differing font loading syntax. For other engines, we issue a warning
 % then abort this file, switching back to T1 encoding.
+% Use \verb+\Umathcode+ as the marker for TU support (as in \texttt{fonttext.ltx})
 %    \begin{macrocode}
-\begingroup\expandafter\expandafter\expandafter\endgroup
-\expandafter\ifx\csname XeTeXrevision\endcsname\relax
+\ifx\Umathcode\@undefined
 %    \end{macrocode}
 %
-%    \begin{macrocode}
-  \begingroup\expandafter\expandafter\expandafter\endgroup
-  \expandafter\ifx\csname directlua\endcsname\relax
-%    \end{macrocode}
-%
-% Not LuaTeX or XeTeX, abort with a warning.
+% Not HiTeX, LuaTeX or XeTeX, abort with a warning.
 %    \begin{macrocode}
     \PackageWarningNoLine{fontenc}
       {\UnicodeEncodingName\space
-       encoding is only available with XeTeX and LuaTeX.\MessageBreak
+       encoding is only available with HiTeX, XeTeX and LuaTeX.\MessageBreak
        Defaulting to T1 encoding}
       \def\encodingdefault{T1}
-    \expandafter\expandafter\expandafter\endinput
+    \expandafter\endinput
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-  \else
+\fi
 %    \end{macrocode}
 %
 % LuaTeX.
+%    \begin{macrocode}
+\ifx\directlua\@undefined\else
+%    \end{macrocode}
 % For Lua\TeX~1.10+, define a Lua function to disable any handing by the font code.
 % Otherwise we reload the font without TeX ligatures.
 % \changes{v2.0q}{2020/07/04}{%
@@ -3048,10 +3046,13 @@
 %
 %    \begin{macrocode}
   \fi
-\else
+\fi
 %    \end{macrocode}
 %
 % XeTeX
+%    \begin{macrocode}
+\ifx\XeTeXversion\@undefined\else
+%    \end{macrocode}
 %    \begin{macrocode}
   \def\UnicodeFontTeXLigatures{mapping=tex-text;}
 %    \end{macrocode}
@@ -3064,6 +3065,14 @@
 \fi
 %    \end{macrocode}
 %
+%    HiTeX
+%    \begin{macrocode}
+\ifx\HiTeXversion\@undefined\else
+  \def\UnicodeFontTeXLigatures{+tlig;}
+  \def\remove@tlig#1{\mbox{\Uchar#1}}
+\fi
+%    \end{macrocode}
+
 %    \begin{macrocode}
 \def\UnicodeFontFile#1#2{"[#1]:#2"}
 \def\UnicodeFontName#1#2{"#1:#2"}


### PR DESCRIPTION


# Internal housekeeping

## Status of pull request


- Ready to merge

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [X] Version and date string updated in changed source files
- [X] Relevant `\changes` entries in source included
- [X] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated

HiTeX will need a news entry at some point once it works, but this is just a preliminary addition to get basic TU loading to allow internal testing.