### PR TITLE
Use new helpers defined in tagpdf to reduce reliance on internals in latex-lab

### DIFF
--- a/required/latex-lab/changes.txt
+++ b/required/latex-lab/changes.txt
@@ -1,3 +1,12 @@
+2026-08-02  Marcel Krüger  <Marcel.Krueger@latex-project.org>
+
+	* latex-lab-namespace.dtx:
+	Detect existing structure elements through tagpdf helper
+	instead of accessing internal data structures.
+	* latex-lab-sec.dtx:
+	Detect currently active structure tag through tagpdf helper
+	instead of accessing internal data structures.
+
 2026-08-04  Frank Mittelbach  <Frank.Mittelbach@latex-project.org>
 
 	* latex-lab-sec-template.dtx:

--- a/required/latex-lab/latex-lab-namespace.dtx
+++ b/required/latex-lab/latex-lab-namespace.dtx
@@ -226,7 +226,7 @@ tables,       Sect,     pdf2,
 }    
 \cs_set_protected:Npn\@@_AssignStructureRole#1#2
  {
-   \@@_if_tag_known:nF{#2}
+   \tag_if_tag_known:nF{#2}
     {\exp_args:Ne\tagpdfsetup{role/new-tag=#2/\UseStructureName{#1}}}
    \tl_set:cn { l_@@_name_#1_tl }{#2}
  }

--- a/required/latex-lab/latex-lab-namespace.dtx
+++ b/required/latex-lab/latex-lab-namespace.dtx
@@ -12,8 +12,8 @@
 %    https://www.latex-project.org/lppl.txt
 %
 %<*package>
-\def\ltlabnamesdate{2026-07-29}
-\def\ltlabnamesversion{0.8l}
+\def\ltlabnamesdate{2026-08-02}
+\def\ltlabnamesversion{0.8m}
 %</package>
 %<*driver>
 \DocumentMetadata{tagging=on,pdfstandard=ua-2}
@@ -219,13 +219,14 @@ tables,       Sect,     pdf2,
 %    \verb=\UseStructureName{block/verbatim/codeline}}= but its final
 %    value. Otherwise \ldots\fmi{fix implementation and docu}
 % \changes{v0.8h}{2025/12/23}{Expand second argument before storing}
+% \changes{v0.8m}{2026-08-02}{Use tagpdf macro to check for known structure element}
 %    \begin{macrocode}
 \cs_set_protected:Npn\AssignStructureRole#1#2 {
   \exp_args:Nne \@@_AssignStructureRole {#1}{#2}
 }    
 \cs_set_protected:Npn\@@_AssignStructureRole#1#2
  {
-   \prop_get:NnNF\g_@@_role_tags_NS_prop{#2}\l_@@_tmp_unused_tl
+   \@@_if_tag_known:nF{#2}
     {\exp_args:Ne\tagpdfsetup{role/new-tag=#2/\UseStructureName{#1}}}
    \tl_set:cn { l_@@_name_#1_tl }{#2}
  }

--- a/required/latex-lab/latex-lab-sec.dtx
+++ b/required/latex-lab/latex-lab-sec.dtx
@@ -15,8 +15,8 @@
 %
 %    https://github.com/latex3/latex2e/issues
 %
-\def\ltlabsecdate{2026-06-26}
-\def\ltlabsecversion{0.84o}
+\def\ltlabsecdate{2026-08-02}
+\def\ltlabsecversion{0.84p}
 
 %<*driver>
 \DocumentMetadata{tagging=on,pdfstandard=ua-2}
@@ -234,6 +234,7 @@
 % \end{macro}
 %
 % \begin{macro}{\@@_sec_end:n}
+% \changes{0.84p}{2026-08-02}{use tagpdf macro to access current structure tag}
 %    \begin{macrocode}
 \msg_new:nnn { tag } {wrong-sect-nesting}
   {
@@ -246,7 +247,7 @@
     \seq_get:NN \g_@@_sec_stack_seq \l_@@_tmpa_tl
     \int_compare:nNnT {#1}<{\exp_last_unbraced:NV\use_ii:nnn\l_@@_tmpa_tl+1}
       {
-        \seq_get:NN\g_@@_struct_tag_stack_seq \l_@@_tmpb_tl
+        \@@_struct_get_current_tag:N \l_@@_tmpb_tl
         \exp_args:Nee
           \tl_if_eq:nnTF
             {\exp_last_unbraced:NV\use_i:nnn\l_@@_tmpa_tl}

--- a/required/latex-lab/latex-lab-sec.dtx
+++ b/required/latex-lab/latex-lab-sec.dtx
@@ -247,7 +247,7 @@
     \seq_get:NN \g_@@_sec_stack_seq \l_@@_tmpa_tl
     \int_compare:nNnT {#1}<{\exp_last_unbraced:NV\use_ii:nnn\l_@@_tmpa_tl+1}
       {
-        \@@_struct_get_current_tag:N \l_@@_tmpb_tl
+        \tag_struct_get_current_tag:N \l_@@_tmpb_tl
         \exp_args:Nee
           \tl_if_eq:nnTF
             {\exp_last_unbraced:NV\use_i:nnn\l_@@_tmpa_tl}

--- a/required/latex-lab/latex-lab-sec.dtx
+++ b/required/latex-lab/latex-lab-sec.dtx
@@ -247,7 +247,7 @@
     \seq_get:NN \g_@@_sec_stack_seq \l_@@_tmpa_tl
     \int_compare:nNnT {#1}<{\exp_last_unbraced:NV\use_ii:nnn\l_@@_tmpa_tl+1}
       {
-        \tag_struct_get_current_tag:N \l_@@_tmpb_tl
+        \tag_struct_get_current_name:N \l_@@_tmpb_tl
         \exp_args:Nee
           \tl_if_eq:nnTF
             {\exp_last_unbraced:NV\use_i:nnn\l_@@_tmpa_tl}

--- a/texmf/tex/latex/tagpdf/tagpdf.sty
+++ b/texmf/tex/latex/tagpdf/tagpdf.sty
@@ -2256,6 +2256,10 @@
    , mathml-tags .bool_gset:N = \g__tag_role_add_mathml_bool
    , add-new-tag .meta:n = {role/new-tag={#1}}
   }
+\prg_new_protected_conditional:Nnn \tag_if_tag_known:n { T, F, TF }
+  {
+    \prop_get:NnNTF\g__tag_role_tags_NS_prop{#1}\l__tag_tmp_unused_tl { \prg_return_true: } { \prg_return_false: }
+  }
 %% File: tagpdf-struct.dtx
 \__tag_seq_new:N  \g__tag_struct_objR_seq
 \tl_const:Nn\c__tag_struct_null_tl {null}
@@ -3716,6 +3720,10 @@ firstkid .code:n = { \tl_set:Nn \l__tag_struct_addkid_tl {left} },
               { \l__tag_attr_value_tl }
          }
     },
+  }
+\cs_new_protected:Npn \tag_struct_get_current_name:N
+  {
+    \seq_get:NN \g__tag_struct_tag_stack_seq
   }
 %% File: tagpdf-space.dtx
 \bool_new:N\l__tag_showspaces_bool


### PR DESCRIPTION
**READ ME FIRST**: Please understand that in most cases we will not be able to merge a pull request because there are a lot of internal activities needed when updating the LaTeX2e sources. If you have a code suggestion please discuss it with the team first.

Adapt latex-lab to use the new helpers from https://github.com/latex3/tagpdf/pull/142. This should not be merged before the tagpdf change is fully deployed.

# Internal housekeeping

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

<!-- - Feedback wanted -->
<!-- - Under development -->
- Ready to merge except for awaiting tagpdf change

## Checklist of required changes before merge will be approved
- n/a Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- n/a Rollback provided (if necessary)?
- n/a `ltnewsX.tex` (and/or `latexchanges.tex`) updated
