### PR TITLE
add alt text to `\layout` command

### DIFF
--- a/required/tools/changes.txt
+++ b/required/tools/changes.txt
@@ -5,6 +5,9 @@ completeness or accuracy and it contains some references to files that
 are not part of the distribution.
 =======================================================================
 
+2026-08-12 Matthew Bertucci  <mbertucci@willamette.edu>
+	* layout.dtx: Add alt text to \layout for tagging compatibility
+
 2026-06-01 Joseph Wright  <Joseph.Wright@latex-project.org>
 	Switch generally to US spelling
 

--- a/required/tools/layout.dtx
+++ b/required/tools/layout.dtx
@@ -114,6 +114,7 @@
 % \changes{v1.2}{1998/04/13}{Redesign of the output by Hideo Umeki}
 % \changes{v1.2c}{2000/09/21}{Added option german}
 % \changes{v1.2c}{2000/09/25}{Added option for italian by Claudio Beccari}
+% \changes{v1.2f}{2026/08/12}{Make alt text configurable by language}
 %    \begin{macrocode}
 %<*package>
 \DeclareOption{dutch}{%
@@ -123,6 +124,7 @@
   \def\MarginNotestext{Marge\\Notities}
   \def\oneinchtext{een inch}
   \def\notshown{niet getoond}
+  \def\DiagramAlttext{Schema dat de pagina-indeling weergeeft}
   }
 \DeclareOption{german}{%
   \def\Headertext{Kopfzeile}
@@ -131,6 +133,7 @@
   \def\MarginNotestext{Rand-\\ notizen}
   \def\oneinchtext{ein Zoll}
   \def\notshown{ohne Abbildung}
+  \def\DiagramAlttext{Diagramm zur Darstellung des Seitenlayouts}
   }
 \DeclareOption{ngerman}{\ExecuteOptions{german}}
 \DeclareOption{english}{%
@@ -140,6 +143,7 @@
   \def\MarginNotestext{Margin\\Notes}
   \def\oneinchtext{one inch}
   \def\notshown{not shown}
+  \def\DiagramAlttext{Diagram displaying the page layout}
   }
 \DeclareOption{french}{%
   \def\Headertext{Ent\^{e}te}
@@ -148,6 +152,7 @@
   \def\MarginNotestext{Marge\\Notes}
   \def\oneinchtext{un pouce}
   \def\notshown{non affich\'{e}}
+  \def\DiagramAlttext{Schéma illustrant la mise en page}
   }
 \DeclareOption{francais}{\ExecuteOptions{french}}
 \DeclareOption{spanish}{%
@@ -157,6 +162,7 @@
   \def\MarginNotestext{Notas\\ Marginales}
   \def\oneinchtext{una pulgada}
   \def\notshown{no mostradas}
+  \def\DiagramAlttext{Diagrama que muestra la maquetación de la página}
   }
 \DeclareOption{portuguese}{%
   \def\Headertext{Cabe\c{c}alho}
@@ -165,6 +171,7 @@
   \def\MarginNotestext{Notas\\ Marginais}
   \def\oneinchtext{uma polegada}
   \def\notshown{n\~ao mostradas}
+  \def\DiagramAlttext{Diagrama que mostra o layout da página}
   }
 \DeclareOption{brazilian}{%
   \def\Headertext{Cabe\c{c}alho}
@@ -173,6 +180,7 @@
   \def\MarginNotestext{Notas\\ Marginais}
   \def\oneinchtext{uma polegada}
   \def\notshown{n\~ao mostradas}
+  \def\DiagramAlttext{Diagrama que mostra o layout da página}
   }
 \DeclareOption{italian}{%
   \def\Headertext{Testatina}
@@ -181,6 +189,7 @@
   \def\MarginNotestext{Note\\ Marginali}
   \def\oneinchtext{un pollice}
   \def\notshown{non mostrato}
+  \def\DiagramAlttext{Schema che illustra l'impaginazione}
   }
 %    \end{macrocode}
 %    
@@ -193,6 +202,7 @@
   \def\MarginNotestext{Note\\ Marginale}
   \def\oneinchtext{un inch}
   \def\notshown{neafi\textcommabelow sat}
+  \def\DiagramAlttext{Diagrama care prezintă structura paginii}
   }
 %    \end{macrocode}
 %    
@@ -206,6 +216,7 @@
   \def\MarginNotestext{傍\\注}
   \def\oneinchtext{1インチ}
   \def\notshown{非表示}
+  \def\DiagramAlttext{ページレイアウトを示す図}
   }
 %    \end{macrocode}
 % \end{allowtofu}
@@ -722,8 +733,7 @@
 %  \changes{v1.2f}{2026/08/12}{Add alt text for tagging compatibility}
 %    \begin{macrocode}
   \setlength{\unitlength}{.5pt}
-  \begin{picture}%
-    [alt=Diagram displaying the page layout](\cnt@paperwidth,\cnt@paperheight)
+  \begin{picture}[alt=\DiagramAlttext](\cnt@paperwidth,\cnt@paperheight)
     \centering
     \thicklines
 %    \end{macrocode}

--- a/required/tools/layout.dtx
+++ b/required/tools/layout.dtx
@@ -30,7 +30,7 @@
 %<+package>\ProvidesPackage{layout}
 %<+driver>\ProvidesFile{layout.drv}
 %\ProvidesFile{layout.dtx}
-                [2026-06-26 v1.2e Show layout parameters]
+                [2026-08-12 v1.2f Show layout parameters]
 %
 %    A short driver is provided that can be extracted if necessary by
 %    the \textsf{DocStrip} program provided with \LaTeXe.
@@ -719,9 +719,11 @@
 %
 %  Now we begin the picture environment; dividing all the lengths by
 %  two is done by setting |\unitlength| to \texttt{0.5pt}.
+%  \changes{v1.2f}{2026/08/12}{Add alt text for tagging compatibility}
 %    \begin{macrocode}
   \setlength{\unitlength}{.5pt}
-  \begin{picture}(\cnt@paperwidth,\cnt@paperheight)
+  \begin{picture}%
+    [alt=Diagram displaying the page layout](\cnt@paperwidth,\cnt@paperheight)
     \centering
     \thicklines
 %    \end{macrocode}

--- a/required/tools/layout.dtx
+++ b/required/tools/layout.dtx
@@ -133,7 +133,7 @@
   \def\MarginNotestext{Rand-\\ notizen}
   \def\oneinchtext{ein Zoll}
   \def\notshown{ohne Abbildung}
-  \def\DiagramAlttext{Diagramm zur Darstellung des Seitenlayouts}
+  \def\DiagramAlttext{Schematische Darstellung des Seitenlayouts}
   }
 \DeclareOption{ngerman}{\ExecuteOptions{german}}
 \DeclareOption{english}{%


### PR DESCRIPTION
# Internal housekeeping

Adds alt text to the `picture` environment in the `\layout` command. It currently just says "Diagram displaying the page layout" because I don't know how useful a description of all the parameters are in the alt text, but if desired the code could be adjusted and those read out too. I've also made it configurable by the language option. I just used DeepL to do the translations so please feel free to correct.

Closes https://github.com/latex3/tagging-project/issues/111.

## Status of pull request

<!--- You might be creating this pull request hoping for feedback or intentionally half-way though the development process. Delete lines as needed. -->

- Feedback wanted 

## Checklist of required changes before merge will be approved
- [ ] Test file(s) added
- [x] Version and date string updated in changed source files
- [x] Relevant `\changes` entries in source included
- [x] Relevant `changes.txt` updated
- [ ] Rollback provided (if necessary)?
- [ ] `ltnewsX.tex` (and/or `latexchanges.tex`) updated
